### PR TITLE
[#IOPAE-303] Service Review Proxy - Add getJiraIssueByServiceId

### DIFF
--- a/apps/io-services-cms-webapp/src/utils/__tests__/service_review_proxy.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/service_review_proxy.test.ts
@@ -167,7 +167,7 @@ describe("Service Review Proxy", () => {
       body:
         expect.any(String) &&
         expect.stringContaining(
-          `"jql":"project = ${aJiraClient.config.JIRA_PROJECT_NAME} AND summary ~ Review #aServiceId`
+          `"jql":"project = ${aJiraClient.config.JIRA_PROJECT_NAME} AND summary ~ 'Review #aServiceId'`
         ),
       headers: expect.any(Object),
       method: "POST",

--- a/apps/io-services-cms-webapp/src/utils/__tests__/service_review_proxy.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/service_review_proxy.test.ts
@@ -4,8 +4,10 @@ import { Delegate, ServiceReviewProxy } from "../service_review_proxy";
 import { Service } from "io-services-cms-models/service-lifecycle/types";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
 import {
   JiraAPIClient,
+  JiraIssue,
   SearchJiraIssuesResponse,
   jiraAPIClient,
 } from "../../jira_client";
@@ -67,27 +69,32 @@ const aDelegate = {
   ],
 } as Delegate;
 
+const aJiraIssue: JiraIssue = {
+  id: "122796" as NonEmptyString,
+  key: "IEST-17" as NonEmptyString,
+  fields: {
+    comment: {
+      comments: [
+        { body: "Questo è un commento" },
+        { body: "Questo è un altro commento" },
+        { body: "Un *commento* formattato … {{codice}} ." },
+      ],
+    },
+    status: {
+      name: "NEW",
+    },
+  },
+};
+
 const aSearchJiraIssuesResponse: SearchJiraIssuesResponse = {
   startAt: 0,
   total: 12,
-  issues: [
-    {
-      id: "122796" as NonEmptyString,
-      key: "IEST-17" as NonEmptyString,
-      fields: {
-        comment: {
-          comments: [
-            { body: "Questo è un commento" },
-            { body: "Questo è un altro commento" },
-            { body: "Un *commento* formattato … {{codice}} ." },
-          ],
-        },
-        status: {
-          name: "NEW",
-        },
-      },
-    },
-  ],
+  issues: [aJiraIssue],
+};
+
+const anEmptySearchJiraIssuesResponse: SearchJiraIssuesResponse = {
+  ...aSearchJiraIssuesResponse,
+  issues: [],
 };
 
 describe("Service Review Proxy", () => {
@@ -142,5 +149,81 @@ describe("Service Review Proxy", () => {
       method: "POST",
     });
     expect(E.isRight(serviceReviews)).toBeTruthy();
+  });
+
+  it("should retrieve a service review by its ID", async () => {
+    mockFetchJson.mockImplementationOnce(() =>
+      Promise.resolve(aSearchJiraIssuesResponse)
+    );
+    const mockFetch = getMockFetchWithStatus(200);
+
+    const aJiraClient: jiraAPIClient = JiraAPIClient(JIRA_CONFIG, mockFetch);
+    const proxy = ServiceReviewProxy(aJiraClient);
+    const serviceReview = await proxy.getJiraIssueByServiceId(
+      "aServiceId" as NonEmptyString
+    )();
+
+    expect(mockFetch).toBeCalledWith(expect.any(String), {
+      body:
+        expect.any(String) &&
+        expect.stringContaining(
+          `"jql":"project = ${aJiraClient.config.JIRA_PROJECT_NAME} AND summary ~ Review #aServiceId`
+        ),
+      headers: expect.any(Object),
+      method: "POST",
+    });
+    expect(E.isRight(serviceReview)).toBeTruthy();
+    if (E.isRight(serviceReview)) {
+      expect(O.isSome(serviceReview.right));
+      if (O.isSome(serviceReview.right)) {
+        expect(E.isRight(JiraIssue.decode(serviceReview.right.value))).toBe(
+          true
+        );
+      }
+    }
+  });
+
+  it("should not retrieve a service review for a wrong service ID", async () => {
+    mockFetchJson.mockImplementationOnce(() =>
+      Promise.resolve(anEmptySearchJiraIssuesResponse)
+    );
+    const mockFetch = getMockFetchWithStatus(200);
+
+    const aJiraClient: jiraAPIClient = JiraAPIClient(JIRA_CONFIG, mockFetch);
+    const proxy = ServiceReviewProxy(aJiraClient);
+    const serviceReview = await proxy.getJiraIssueByServiceId(
+      "aWrongServiceId" as NonEmptyString
+    )();
+
+    expect(mockFetch).toBeCalledWith(expect.any(String), {
+      body: expect.any(String),
+      headers: expect.any(Object),
+      method: "POST",
+    });
+    expect(E.isRight(serviceReview)).toBeTruthy();
+    if (E.isRight(serviceReview)) {
+      expect(O.isNone(serviceReview.right));
+    }
+  });
+
+  it("should return a specific Jira API Error if jira client returns a 500 status code", async () => {
+    mockFetchJson.mockImplementationOnce(() =>
+      Promise.resolve({
+        errorMessages: ["A specific JIRA error message"],
+        errors: {},
+      })
+    );
+    const mockFetch = getMockFetchWithStatus(500);
+
+    const aJiraClient: jiraAPIClient = JiraAPIClient(JIRA_CONFIG, mockFetch);
+    const proxy = ServiceReviewProxy(aJiraClient);
+    const serviceReview = await proxy.getJiraIssueByServiceId(
+      "aServiceId" as NonEmptyString
+    )();
+
+    expect(E.isLeft(serviceReview)).toBeTruthy();
+    if (E.isLeft(serviceReview)) {
+      expect(serviceReview.left.message).toBe("Jira API returns an error");
+    }
   });
 });

--- a/apps/io-services-cms-webapp/src/utils/service_review_proxy.ts
+++ b/apps/io-services-cms-webapp/src/utils/service_review_proxy.ts
@@ -1,8 +1,11 @@
-import { TaskEither } from "fp-ts/lib/TaskEither";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as O from "fp-ts/lib/Option";
+import * as TE from "fp-ts/lib/TaskEither";
+import { pipe } from "fp-ts/lib/function";
 import { Service } from "io-services-cms-models/service-lifecycle/types";
 import {
   CreateJiraIssueResponse,
+  JiraIssue,
   SearchJiraIssuesPayload,
   SearchJiraIssuesResponse,
   jiraAPIClient,
@@ -11,14 +14,20 @@ import {
 const formatOptionalStringValue = (value?: string) =>
   value || `{color:#FF991F}*[ DATO MANCANTE ]*{color}`;
 
+const formatIssueTitle = (serviceId: NonEmptyString) =>
+  `Review #${serviceId}` as NonEmptyString;
+
 export type ServiceReviewProxy = {
   readonly createJiraIssue: (
     service: Service,
     delegate: Delegate
-  ) => TaskEither<Error, CreateJiraIssueResponse>;
+  ) => TE.TaskEither<Error, CreateJiraIssueResponse>;
   readonly searchJiraIssuesByKey: (
     jiraIssueKeys: ReadonlyArray<NonEmptyString>
-  ) => TaskEither<Error, SearchJiraIssuesResponse>;
+  ) => TE.TaskEither<Error, SearchJiraIssuesResponse>;
+  readonly getJiraIssueByServiceId: (
+    serviceId: NonEmptyString
+  ) => TE.TaskEither<Error, O.Option<JiraIssue>>;
 };
 
 export type Delegate = {
@@ -82,33 +91,65 @@ export const ServiceReviewProxy = (
   const createJiraIssue = (
     service: Service,
     delegate: Delegate
-  ): TaskEither<Error, CreateJiraIssueResponse> =>
+  ): TE.TaskEither<Error, CreateJiraIssueResponse> =>
     jiraClient.createJiraIssue(
-      `Review #${service.id}` as NonEmptyString,
+      formatIssueTitle(service.id),
       buildIssueDescription(service, delegate),
       [`service-${service.id}` as NonEmptyString],
       buildIssueCustomFields(service, delegate)
     );
 
-  const buildSearchIssuesPayload = (
-    jiraIssueKeys: ReadonlyArray<NonEmptyString>
+  const buildSearchIssuesBasePayload = (
+    jql: string
   ): SearchJiraIssuesPayload => ({
     fields: ["status", "comment"],
     fieldsByKeys: false,
-    maxResults: jiraIssueKeys.length,
+    maxResults: 1,
     startAt: 0,
-    jql: `project = ${
-      jiraClient.config.JIRA_PROJECT_NAME
-    } AND key IN(${jiraIssueKeys.join(",")})`,
+    jql,
+  });
+
+  const buildSearchJiraIssuesByKeyPayload = (
+    jiraIssueKeys: ReadonlyArray<NonEmptyString>
+  ) => ({
+    ...buildSearchIssuesBasePayload(
+      `project = ${
+        jiraClient.config.JIRA_PROJECT_NAME
+      } AND key IN(${jiraIssueKeys.join(",")})`
+    ),
+    maxResults: jiraIssueKeys.length,
   });
 
   const searchJiraIssuesByKey = (
     jiraIssueKeys: ReadonlyArray<NonEmptyString>
-  ): TaskEither<Error, SearchJiraIssuesResponse> =>
-    jiraClient.searchJiraIssues(buildSearchIssuesPayload(jiraIssueKeys));
+  ): TE.TaskEither<Error, SearchJiraIssuesResponse> =>
+    jiraClient.searchJiraIssues(
+      buildSearchJiraIssuesByKeyPayload(jiraIssueKeys)
+    );
+
+  const buildGetJiraIssueByServiceIdPayload = (serviceId: NonEmptyString) => ({
+    ...buildSearchIssuesBasePayload(
+      `project = ${
+        jiraClient.config.JIRA_PROJECT_NAME
+      } AND summary ~ ${formatIssueTitle(serviceId)}`
+    ),
+  });
+
+  const getJiraIssueByServiceId = (
+    serviceId: NonEmptyString
+  ): TE.TaskEither<Error, O.Option<JiraIssue>> =>
+    pipe(
+      jiraClient.searchJiraIssues(
+        buildGetJiraIssueByServiceIdPayload(serviceId)
+      ),
+      TE.map((response) =>
+        response.issues.length > 0 ? O.some(response.issues[0]) : O.none
+      )
+    );
 
   return {
     createJiraIssue,
     searchJiraIssuesByKey,
+    getJiraIssueByServiceId,
   };
 };

--- a/apps/io-services-cms-webapp/src/utils/service_review_proxy.ts
+++ b/apps/io-services-cms-webapp/src/utils/service_review_proxy.ts
@@ -131,7 +131,7 @@ export const ServiceReviewProxy = (
     ...buildSearchIssuesBasePayload(
       `project = ${
         jiraClient.config.JIRA_PROJECT_NAME
-      } AND summary ~ ${formatIssueTitle(serviceId)}`
+      } AND summary ~ '${formatIssueTitle(serviceId)}'`
     ),
   });
 

--- a/packages/io-services-cms-models/src/service-lifecycle/types.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/types.ts
@@ -65,7 +65,7 @@ const ServiceMetadata = t.intersection([
 ]);
 
 export type ServiceId = t.TypeOf<typeof ServiceId>;
-export const ServiceId = t.string;
+export const ServiceId = NonEmptyString;
 
 export type Service = t.TypeOf<typeof Service>;
 export const Service = t.type({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This utility will be used in **Service Review Process** for:
- create a ticket on jira after a request for a service review
- search for one or more tickets on jira
  - by issue key
  - by serviceId **_(new)_**

#### List of Changes

<!--- Describe your changes in detail -->

- Added `getJiraIssueByServiceId` method for retrievieng a single Jira Issue given the related _serviceId_
- Added unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests and manual integration tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
