### PR TITLE
Rename Azure resources

### DIFF
--- a/infra/src/common.tf
+++ b/infra/src/common.tf
@@ -34,5 +34,5 @@ variable "tags" {
 locals {
   project              = "${var.prefix}-${var.env_short}"
   is_prod              = var.env_short == "p" ? true : false
-  application_basename = "servicescms"
+  application_basename = "services-cms"
 }


### PR DESCRIPTION
fixes a typo and regenerate resources accordingly