### PR TITLE
Fix `@io-services-cms` package

### DIFF
--- a/.changeset/fifty-chicken-learn.md
+++ b/.changeset/fifty-chicken-learn.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/models": patch
+---
+
+Fix package configuration and exported types

--- a/packages/io-services-cms-models/index.js
+++ b/packages/io-services-cms-models/index.js
@@ -1,0 +1,7 @@
+// This is a workaround to enhance compatibility of the package
+// Some builder (i.e. vitest) fails to interpret the main entrypoint of the package when defined in the package.json
+// As the default entrypoint is a "index.js" file in the root of the package, by creating this file we do not have to define a "main" field in package.json
+//   so that engines don't mess.
+// Remember to include such file in the "files" field of package.json aliongside with files in /dist
+// eslint-disable-next-line functional/immutable-data
+module.exports = require("./dist/index.js");

--- a/packages/io-services-cms-models/package.json
+++ b/packages/io-services-cms-models/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@io-services-cms/models",
   "version": "1.0.0",
-  "exports": {
-    "./": "./dist/"
-  },
   "typesVersions": {
     "*": {
       "*": [
@@ -12,7 +9,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.js"
   ],
   "packageManager": "yarn@3.3.0",
   "scripts": {

--- a/packages/io-services-cms-models/src/index.ts
+++ b/packages/io-services-cms-models/src/index.ts
@@ -1,1 +1,2 @@
 export * as ServiceLifecycle from "./service-lifecycle";
+export { stores, FSMStore } from "./lib/fsm";


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* set a dummy `index.js` entrypoint
* export FSM types

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
We encountered an issue while executing tests with `vitest` on apps that uses the package `@io-services-cms`. `vitest` seems not to understand what the correct entrypoint is, giving the following error:
```
Failed to resolve entry for package "@io-services-cms". The package may have incorrect main/module/exports specified in its package.json.
```
This can be solved by defining a `main` field in package.json with `dist/index.js`. However, such value breaks the application build (which would otherwise expect just `index.js`). 

A similar issue has been reported https://github.com/vitest-dev/vitest/issues/2922

The found workaround is to have a _dummy_ `index.js` that just proxies `dist/index.js`. Being that the default value for the `main` field, it can be omitted.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
