### PR TITLE
fix: storage account public access unless private endpoint

### DIFF
--- a/infra/src/storage_account.tf
+++ b/infra/src/storage_account.tf
@@ -10,7 +10,7 @@ module "storage_account" {
   resource_group_name           = azurerm_resource_group.rg.name
   location                      = var.location
   advanced_threat_protection    = false
-  public_network_access_enabled = false
+  public_network_access_enabled = true
 
   tags = var.tags
 }


### PR DESCRIPTION
A Storage Account requires either public access or a private endpoint. Otherwise its endpoint cannot be accessed and no operation on it can be performed

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
