### PR TITLE
fix: add vscode workspace configuration

### DIFF
--- a/io-services-cms.code-workspace
+++ b/io-services-cms.code-workspace
@@ -1,0 +1,18 @@
+{
+    "folders": [
+      {
+        "path": "."
+      },
+      {
+        "path": "apps/io-services-cms-webapp"
+      },
+      {
+        "path": "packages/io-services-cms-models",
+        "name": "@io-services-cms/models"
+      },
+    ],
+    "settings": {
+      "azureFunctions.funcCliPath": "../../node_modules/.bin/func"
+    }
+  }
+  


### PR DESCRIPTION
#### List of Changes

Adds VSCode workspace configuration.

#### Motivation and Context

Let VSCode Vitest extension works in a monorepo.

#### How Has This Been Tested?

Open the workspace from file then run tests using the extension sidebar.

<img width="551" alt="image" src="https://github.com/pagopa/io-services-cms/assets/148224/2ac61ecc-695d-4f4a-8518-17e74334e4f4">
