### PR TITLE
[#IOPAE-329] ADD Get service lifecycle API

### DIFF
--- a/apps/io-services-cms-webapp/GetServiceLifecycle/function.json
+++ b/apps/io-services-cms-webapp/GetServiceLifecycle/function.json
@@ -1,0 +1,21 @@
+{
+    "bindings": [
+        {
+            "authLevel": "anonymous",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "route": "services/{serviceId}",
+            "methods": [
+                "get"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "res"
+        }
+    ],
+    "scriptFile": "../dist/main.js",
+    "entryPoint": "httpEntryPoint"
+}

--- a/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
@@ -1,12 +1,12 @@
 import { ServiceLifecycle } from "@io-services-cms/models";
 
-import { ServiceLifecycle as ServiceResponsePayload } from "../../../generated/api/ServiceLifecycle";
-import { ServicePayload as ServiceRequestPayload } from "../../../generated/api/ServicePayload";
+import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";
+import { ServicePayload as ServiceRequestPayload } from "../../generated/api/ServicePayload";
 import {
   ServiceLifecycleStatusType,
   ServiceLifecycleStatusTypeEnum,
-} from "../../../generated/api/ServiceLifecycleStatusType";
-import { ScopeEnum } from "../../../generated/api/ServiceMetadata";
+} from "../../generated/api/ServiceLifecycleStatusType";
+import { ScopeEnum } from "../../generated/api/ServiceMetadata";
 
 export const payloadToItem = (
   id: ServiceLifecycle.definitions.Service["id"],

--- a/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
@@ -1,10 +1,10 @@
 import { ServicePublication } from "@io-services-cms/models";
-import { ServicePublication as ServiceResponsePayload } from "../../../generated/api/ServicePublication";
-import { toScopeType } from "../create-service/converters";
+import { ServicePublication as ServiceResponsePayload } from "../../generated/api/ServicePublication";
 import {
   ServicePublicationStatusType,
   ServicePublicationStatusTypeEnum,
-} from "../../../generated/api/ServicePublicationStatusType";
+} from "../../generated/api/ServicePublicationStatusType";
+import { toScopeType } from "./service-lifecycle-converters";
 
 export const itemToResponse = ({
   fsm: { state },

--- a/apps/io-services-cms-webapp/src/webservice/controllers/create-service/index.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/create-service/index.ts
@@ -37,7 +37,10 @@ import {
   getUserByEmail,
   upsertSubscription,
 } from "../../../lib/clients/apim-client";
-import { payloadToItem, itemToResponse } from "./converters";
+import {
+  payloadToItem,
+  itemToResponse,
+} from "../../../utils/converters/service-lifecycle-converters";
 
 type HandlerResponseTypes =
   | IResponseSuccessJson<ServiceResponsePayload>

--- a/apps/io-services-cms-webapp/src/webservice/index.ts
+++ b/apps/io-services-cms-webapp/src/webservice/index.ts
@@ -32,7 +32,10 @@ import {
   applyRequestMiddelwares as applyGetPublicationStatusServiceRequestMiddelwares,
   makeGetServiceHandler,
 } from "./controllers/get-service-publication";
-
+import {
+  applyRequestMiddelwares as applyGetServiceLifecycleRequestMiddelwares,
+  makeGetServiceLifecycleHandler,
+} from "./controllers/get-service-lifecycle";
 const servicePublicationPath: string = "/services/:serviceId/release";
 
 type Dependencies = {
@@ -65,6 +68,17 @@ export const createWebServer = ({
         apimConfig: config,
       }),
       applyCreateServiceRequestMiddelwares,
+      wrapRequestHandler
+    )
+  );
+
+  router.get(
+    "/services/:serviceId",
+    pipe(
+      makeGetServiceLifecycleHandler({
+        store: serviceLifecycleStore,
+      }),
+      applyGetServiceLifecycleRequestMiddelwares,
       wrapRequestHandler
     )
   );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add Get Service Lifecycle Endpoint _(**GET** /services/:serviceId)_
#### List of Changes
- ADD AZ function.json
- ADD Get Service Lifecycle Controller
- -ADD unit tests for GET /services/:serviceId-
- Moved all converters.ts from controller own folder to a more generic /utils/converters, cause now converters.ts that was under create-service controller is used also in the new get-service-lifecycle controlle
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
-Unit Tests-
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
