### PR TITLE
[#IOPEA-369] Fix withDefault config keys

### DIFF
--- a/apps/io-services-cms-webapp/src/config.ts
+++ b/apps/io-services-cms-webapp/src/config.ts
@@ -53,14 +53,20 @@ export type JiraConfig = t.TypeOf<typeof JiraConfig>;
 export type PostgreSqlConfig = t.TypeOf<typeof PostgreSqlConfig>;
 export const PostgreSqlConfig = t.type({
   REVIEWER_DB_HOST: NonEmptyString,
-  REVIEWER_DB_IDLE_TIMEOUT: withDefault(NumberFromString, 30000),
+  REVIEWER_DB_IDLE_TIMEOUT: withDefault(
+    NumberFromString,
+    "30000" as unknown as number
+  ),
   REVIEWER_DB_NAME: NonEmptyString,
   REVIEWER_DB_PASSWORD: NonEmptyString,
   REVIEWER_DB_PORT: NumberFromString,
   REVIEWER_DB_SCHEMA: NonEmptyString,
   REVIEWER_DB_TABLE: NonEmptyString,
   REVIEWER_DB_USER: NonEmptyString,
-  REVIEWER_DB_READ_MAX_ROW: withDefault(IntegerFromString, 50),
+  REVIEWER_DB_READ_MAX_ROW: withDefault(
+    IntegerFromString,
+    "50" as unknown as number
+  ),
   REVIEWER_DB_APP_NAME: withDefault(
     NonEmptyString,
     "reviewer" as NonEmptyString


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix webapp configuration keys in which a default value is expected.
With this fix it is possible to use correctly the default value of the "_withDefault_" keys without necessarily having to enter the value in the environment.

#### List of Changes
- apps/io-services-cms-webapp/src/config.ts
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
