### PR TITLE
feat: [IOPAE-320]  add force/override action on fsm

### DIFF
--- a/.changeset/gold-tigers-return.md
+++ b/.changeset/gold-tigers-return.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/models": minor
+---
+
+add override action to both Lifecycle and Publication FSM

--- a/packages/io-services-cms-models/src/lib/fsm/types.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/types.ts
@@ -128,3 +128,10 @@ export class FsmStoreSaveError extends Error {
     super(`Error while saving data in the store`);
   }
 }
+
+export class FsmItemValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FsmItemValidationError";
+  }
+}

--- a/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
@@ -260,15 +260,6 @@ describe("apply", () => {
 });
 
 describe("override", () => {
-  it("should fails when item not exists", async () => {
-    const id = "non-existent_id" as NonEmptyString;
-    const item = {} as unknown as ItemType;
-    const result = await fsmClient.override(id, item)();
-    expect(E.isLeft(result)).toBeTruthy();
-    if (E.isLeft(result)) {
-      expect(result.left.message).eq(`No item found with id = ${id}`);
-    }
-  });
   it("should fails when stored item is not valid", async () => {
     store
       .inspect()
@@ -281,6 +272,21 @@ describe("override", () => {
     expect(E.isLeft(result)).toBeTruthy();
     if (E.isLeft(result)) {
       expect(result.left.message).not.empty;
+    }
+  });
+  it("should save item when not exists", async () => {
+    const id = "non-existent_id" as NonEmptyString;
+    const item = {
+      ...aService,
+      id,
+      fsm: { state: "submitted" },
+    } as WithState<"submitted", Service>;
+    const result = await fsmClient.override(id, item)();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      console.log("result:", result.right);
+      expect(store.inspect().get(id)).eq(result.right);
+      expect(result.right.fsm.state).eq("submitted");
     }
   });
   it("should save a valid item", async () => {

--- a/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
@@ -230,7 +230,7 @@ describe("apply", () => {
         return TE.left(new Error());
       }),
       save: vi.fn(),
-    };
+    } as unknown as FSMStore<ItemType>;
     const mockFsmClient = getFsmClient(mockStore);
 
     const result = await mockFsmClient.release(aServiceId, {
@@ -252,7 +252,7 @@ describe("apply", () => {
       save: vi.fn(() => {
         return TE.left(new Error());
       }),
-    };
+    } as unknown as FSMStore<ItemType>;
     const mockFsmClient = getFsmClient(mockStore);
 
     const result = await mockFsmClient.release(aServiceId, {

--- a/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
@@ -268,15 +268,6 @@ describe("apply", () => {
 });
 
 describe("override", () => {
-  it("should fails when item not exists", async () => {
-    const id = "non-existent_id" as NonEmptyString;
-    const item = {} as unknown as ItemType;
-    const result = await fsmClient.override(id, item)();
-    expect(E.isLeft(result)).toBeTruthy();
-    if (E.isLeft(result)) {
-      expect(result.left.message).eq(`No item found with id = ${id}`);
-    }
-  });
   it("should fails when stored item is not valid", async () => {
     store
       .inspect()
@@ -289,6 +280,20 @@ describe("override", () => {
     expect(E.isLeft(result)).toBeTruthy();
     if (E.isLeft(result)) {
       expect(result.left.message).not.empty;
+    }
+  });
+  it("should save item when not exists", async () => {
+    const id = "non-existent_id" as NonEmptyString;
+    const item = {
+      ...aService,
+      id,
+      fsm: { state: "unpublished" },
+    } as WithState<"unpublished", Service>;
+    const result = await fsmClient.override(id, item)();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(store.inspect().get(id)).eq(result.right);
+      expect(result.right.fsm.state).eq("unpublished");
     }
   });
   it("should save a valid item", async () => {

--- a/packages/io-services-cms-models/src/service-publication/index.ts
+++ b/packages/io-services-cms-models/src/service-publication/index.ts
@@ -9,6 +9,7 @@ import * as t from "io-ts";
 import {
   EmptyState,
   FSMStore,
+  FsmItemValidationError,
   FsmNoApplicableTransitionError,
   FsmNoTransitionMatchedError,
   FsmStoreFetchError,
@@ -344,9 +345,15 @@ function override(
       store.fetch(id),
       TE.chain(
         flow(
-          E.fromOption(() => new Error(`No item found with id = ${id}`)), // TODO: maybe we need to define a custom error
-          E.chain(
-            flow(ItemType.decode, E.mapLeft(flow(readableReport, E.toError)))
+          O.fold(
+            () => E.right(void 0),
+            flow(
+              ItemType.decode,
+              E.bimap(
+                flow(readableReport, (msg) => new FsmItemValidationError(msg)),
+                (_) => void 0
+              )
+            )
           ),
           TE.fromEither
         )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add override action to both FSM (lifecycle and publication) to bypass FSM constraints and "force" update when sync from legacy in order to get both system in-sync

#### List of Changes
<!--- Describe your changes in detail -->
- add override action to FSM lifecycle
- add override action to FSM publication

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is required to get in-synch both legacy and new cms systems

#### How Has This Been Tested?
Unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
