### PR TITLE
[#IOPAE-366] Manage APIs error response codes

### DIFF
--- a/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-publication-converters.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-publication-converters.test.ts
@@ -6,56 +6,11 @@ import {
   FsmStoreSaveError,
   FsmTooManyTransitionsError,
   FsmTransitionExecutionError,
-  ServiceLifecycle,
 } from "@io-services-cms/models";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { describe, expect, test } from "vitest";
-import { FiscalCode } from "../../../generated/api/FiscalCode";
-import { ServicePayload } from "../../../generated/api/ServicePayload";
-import {
-  fsmToApiError,
-  payloadToItem,
-  toServiceStatus,
-} from "../service-lifecycle-converters";
-
-const fsm: ServiceLifecycle.ItemType["fsm"] = {
-  state: "rejected",
-};
-
-const anAutorizedFiscalCode = "BBBBBB99C88D555I";
-const aSandboxFiscalCode = "AAAAAA00A00A000A";
+import { fsmToApiError } from "../service-publication-converters";
 
 describe("test service-lifecycle-converters", () => {
-  test("test service-lifecycle-converters", () => {
-    const result = toServiceStatus(fsm);
-    expect(result.reason).not.toBeDefined();
-  });
-
-  test("Authorized User should contains the default fiscal code and the one on request", () => {
-    const aNewService = {
-      name: "a service",
-      description: "a description",
-      organization: {
-        name: "org",
-        fiscal_code: "00000000000",
-      },
-      metadata: {
-        scope: "LOCAL",
-      },
-      authorized_recipients: [anAutorizedFiscalCode],
-    } as unknown as ServicePayload;
-
-    const result = payloadToItem(
-      "ffefefe" as NonEmptyString,
-      aNewService,
-      aSandboxFiscalCode as FiscalCode
-    );
-    expect(result.data.authorized_recipients).toBeDefined();
-    expect(result.data.authorized_recipients).toContain(aSandboxFiscalCode);
-    expect(result.data.authorized_recipients).toContain(anAutorizedFiscalCode);
-    expect(result.data.authorized_recipients).toHaveLength(2);
-  });
-
   test("fsmToApiError: should return a ResponseErrorConflict given a FsmNoApplicableTransitionError", () => {
     const err = new FsmNoApplicableTransitionError("anAppliedAction");
     const result = fsmToApiError(err);

--- a/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
@@ -1,4 +1,18 @@
-import { ServiceLifecycle } from "@io-services-cms/models";
+import {
+  FsmItemNotFoundError,
+  FsmNoApplicableTransitionError,
+  FsmNoTransitionMatchedError,
+  FsmStoreFetchError,
+  FsmStoreSaveError,
+  FsmTooManyTransitionsError,
+  FsmTransitionExecutionError,
+  ServiceLifecycle,
+} from "@io-services-cms/models";
+import {
+  ResponseErrorConflict,
+  ResponseErrorInternal,
+  ResponseErrorNotFound,
+} from "@pagopa/ts-commons/lib/responses";
 import { FiscalCode } from "../../generated/api/FiscalCode";
 import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";
 import { ServiceLifecycleStatus } from "../../generated/api/ServiceLifecycleStatus";
@@ -74,5 +88,27 @@ export const toScopeType = (
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = s;
       return ScopeEnum[s];
+  }
+};
+
+/**
+ * Convert FSM error to API error
+ * @param err FSM custom error
+ * @returns API http error
+ */
+export const fsmToApiError = (err: ServiceLifecycle.AllFsmErrors) => {
+  switch (err.constructor) {
+    case FsmNoApplicableTransitionError:
+    case FsmNoTransitionMatchedError:
+    case FsmTooManyTransitionsError:
+      return ResponseErrorConflict(err.message);
+    case FsmTransitionExecutionError:
+    case FsmStoreFetchError:
+    case FsmStoreSaveError:
+      return ResponseErrorInternal(err.message);
+    case FsmItemNotFoundError:
+      return ResponseErrorNotFound("Not Found", err.message);
+    default:
+      return ResponseErrorInternal(err.message);
   }
 };

--- a/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
@@ -1,4 +1,18 @@
-import { ServicePublication } from "@io-services-cms/models";
+import {
+  FsmItemNotFoundError,
+  FsmNoApplicableTransitionError,
+  FsmNoTransitionMatchedError,
+  FsmStoreFetchError,
+  FsmStoreSaveError,
+  FsmTooManyTransitionsError,
+  FsmTransitionExecutionError,
+  ServicePublication,
+} from "@io-services-cms/models";
+import {
+  ResponseErrorConflict,
+  ResponseErrorInternal,
+  ResponseErrorNotFound,
+} from "@pagopa/ts-commons/lib/responses";
 import { ServicePublication as ServiceResponsePayload } from "../../generated/api/ServicePublication";
 import {
   ServicePublicationStatusType,
@@ -30,5 +44,27 @@ export const toServiceStatusType = (
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = s;
       return ServicePublicationStatusTypeEnum[s];
+  }
+};
+
+/**
+ * Convert FSM error to API error
+ * @param err FSM custom error
+ * @returns API http error
+ */
+export const fsmToApiError = (err: ServicePublication.AllFsmErrors) => {
+  switch (err.constructor) {
+    case FsmNoApplicableTransitionError:
+    case FsmNoTransitionMatchedError:
+    case FsmTooManyTransitionsError:
+      return ResponseErrorConflict(err.message);
+    case FsmTransitionExecutionError:
+    case FsmStoreFetchError:
+    case FsmStoreSaveError:
+      return ResponseErrorInternal(err.message);
+    case FsmItemNotFoundError:
+      return ResponseErrorNotFound("Not Found", err.message);
+    default:
+      return ResponseErrorInternal(err.message);
   }
 };

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/delete-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/delete-service.test.ts
@@ -62,7 +62,7 @@ describe("deleteService", () => {
       .set("x-user-id", "any-user-id")
       .set("x-subscription-id", "any-subscription-id");
 
-    expect(response.statusCode).toBe(500); // FIXME: should be 404 (or 409)
+    expect(response.statusCode).toBe(404);
   });
 
   it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
@@ -79,7 +79,7 @@ describe("deleteService", () => {
       .set("x-user-id", "any-user-id")
       .set("x-subscription-id", "any-subscription-id");
 
-    expect(response.statusCode).toBe(500); // FIXME: should be 409
+    expect(response.statusCode).toBe(409);
   });
 
   it("should not allow the operation without right group", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/edit-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/edit-service.test.ts
@@ -90,7 +90,7 @@ describe("editService", () => {
       .set("x-user-id", "any-user-id")
       .set("x-subscription-id", "any-subscription-id");
 
-    expect(response.statusCode).toBe(500); // FIXME: should be 404 (or 409)
+    expect(response.statusCode).toBe(404);
   });
 
   it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
@@ -100,19 +100,19 @@ describe("editService", () => {
     })();
 
     const response = await request(app)
-      .put("/api/services/s4")
+      .put("/api/services/s1")
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", UserGroup.ApiServiceWrite)
       .set("x-user-id", "any-user-id")
       .set("x-subscription-id", "any-subscription-id");
 
-    expect(response.statusCode).toBe(500); // FIXME: should be 409
+    expect(response.statusCode).toBe(409);
   });
 
   it("should not allow the operation without right group", async () => {
     const response = await request(app)
-      .put("/api/services/s4")
+      .put("/api/services/s1")
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", "OtherGroup")

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-lifecycle.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-lifecycle.test.ts
@@ -63,7 +63,7 @@ describe("getServiceLifecycle", () => {
       .set("x-user-id", "any-user-id")
       .set("x-subscription-id", "any-subscription-id");
 
-    expect(response.statusCode).toBe(404); // FIXME: should be 404 (or 409)
+    expect(response.statusCode).toBe(404);
   });
 
   const asServiceLifecycleWithStatus = {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-publication.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-publication.test.ts
@@ -80,7 +80,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(404); // FIXME: should be 404 (or 409)
+      expect(response.statusCode).toBe(404);
     });
 
     const asServiceWithStatus = {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/publish-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/publish-service.test.ts
@@ -79,7 +79,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(500); // FIXME: should be 404 (or 409)
+      expect(response.statusCode).toBe(500); // FIXME: the publish of a non-existing service is allowed by the 'autopublish' feature, so it is not possible to receive a 404 error.
     });
 
     it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
@@ -96,7 +96,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(500); // FIXME: should be 409
+      expect(response.statusCode).toBe(409);
     });
 
     it("should not allow the operation without right group", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/review-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/review-service.test.ts
@@ -85,7 +85,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(500); // FIXME: should be 404 (or 409)
+      expect(response.statusCode).toBe(404);
     });
 
     it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
@@ -102,7 +102,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(500); // FIXME: should be 409
+      expect(response.statusCode).toBe(409);
     });
 
     it("should not allow the operation without right group", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/unpublish-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/unpublish-service.test.ts
@@ -79,7 +79,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(500); // FIXME: should be 404 (or 409)
+      expect(response.statusCode).toBe(404);
     });
 
     it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
@@ -96,7 +96,7 @@ describe("WebService", () => {
         .set("x-user-id", "any-user-id")
         .set("x-subscription-id", "any-subscription-id");
 
-      expect(response.statusCode).toBe(500); // FIXME: should be 409
+      expect(response.statusCode).toBe(409);
     });
 
     it("should not allow the operation without right group", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/delete-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/delete-service.ts
@@ -13,12 +13,12 @@ import {
   IResponseErrorNotFound,
   IResponseErrorTooManyRequests,
   IResponseSuccessNoContent,
-  ResponseErrorInternal,
   ResponseSuccessNoContent,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
+import { fsmToApiError } from "../../utils/converters/service-lifecycle-converters";
 
 type Dependencies = {
   fsmLifecycleClient: ServiceLifecycle.FsmClient;
@@ -45,7 +45,7 @@ export const makeDeleteServiceHandler =
     pipe(
       fsmLifecycleClient.delete(serviceId),
       TE.map(ResponseSuccessNoContent),
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
+      TE.mapLeft((err) => fsmToApiError(err)),
       TE.toUnion
     )();
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/edit-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/edit-service.ts
@@ -15,7 +15,6 @@ import {
   IResponseErrorTooManyRequests,
   IResponseSuccessJson,
   IResponseSuccessNoContent,
-  ResponseErrorInternal,
   ResponseSuccessJson,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
@@ -24,6 +23,7 @@ import { pipe } from "fp-ts/lib/function";
 import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";
 import { ServicePayload as ServiceRequestPayload } from "../../generated/api/ServicePayload";
 import {
+  fsmToApiError,
   itemToResponse,
   payloadToItem,
 } from "../../utils/converters/service-lifecycle-converters";
@@ -62,7 +62,7 @@ export const makeEditServiceHandler =
       }),
       TE.map(itemToResponse),
       TE.map(ResponseSuccessJson),
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
+      TE.mapLeft((err) => fsmToApiError(err)),
       TE.toUnion
     )();
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/publish-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/publish-service.ts
@@ -13,12 +13,12 @@ import {
   IResponseErrorNotFound,
   IResponseErrorTooManyRequests,
   IResponseSuccessNoContent,
-  ResponseErrorInternal,
   ResponseSuccessNoContent,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
+import { fsmToApiError } from "../../utils/converters/service-publication-converters";
 
 type Dependencies = {
   fsmPublicationClient: ServicePublication.FsmClient;
@@ -43,7 +43,7 @@ export const makePublishServiceHandler =
     pipe(
       fsmPublicationClient.publish(serviceId),
       TE.map(ResponseSuccessNoContent),
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
+      TE.mapLeft((err) => fsmToApiError(err)),
       TE.toUnion
     )();
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/review-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/review-service.ts
@@ -14,13 +14,13 @@ import {
   IResponseErrorNotFound,
   IResponseErrorTooManyRequests,
   IResponseSuccessNoContent,
-  ResponseErrorInternal,
   ResponseSuccessNoContent,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { ReviewRequest as ReviewRequestPayload } from "../../generated/api/ReviewRequest";
+import { fsmToApiError } from "../../utils/converters/service-lifecycle-converters";
 
 type Dependencies = {
   fsmLifecycleClient: ServiceLifecycle.FsmClient;
@@ -50,7 +50,7 @@ export const makeReviewServiceHandler =
         autoPublish: body.auto_publish ?? false,
       }),
       TE.map(ResponseSuccessNoContent),
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
+      TE.mapLeft((err) => fsmToApiError(err)),
       TE.toUnion
     )();
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/unpublish-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/unpublish-service.ts
@@ -13,12 +13,12 @@ import {
   IResponseErrorNotFound,
   IResponseErrorTooManyRequests,
   IResponseSuccessNoContent,
-  ResponseErrorInternal,
   ResponseSuccessNoContent,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
+import { fsmToApiError } from "../../utils/converters/service-publication-converters";
 
 type Dependencies = {
   fsmPublicationClient: ServicePublication.FsmClient;
@@ -43,7 +43,7 @@ export const makeUnpublishServiceHandler =
     pipe(
       fsmPublicationClient.unpublish(serviceId),
       TE.map(ResponseSuccessNoContent),
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
+      TE.mapLeft((err) => fsmToApiError(err)),
       TE.toUnion
     )();
 

--- a/packages/io-services-cms-models/src/index.ts
+++ b/packages/io-services-cms-models/src/index.ts
@@ -1,13 +1,14 @@
-export * as Queue from "./queue";
-export * as ServiceLifecycle from "./service-lifecycle";
-export * as ServicePublication from "./service-publication";
 export {
-  stores,
   FSMStore,
+  FsmItemNotFoundError,
   FsmNoApplicableTransitionError,
   FsmNoTransitionMatchedError,
   FsmStoreFetchError,
   FsmStoreSaveError,
   FsmTooManyTransitionsError,
   FsmTransitionExecutionError,
+  stores,
 } from "./lib/fsm";
+export * as Queue from "./queue";
+export * as ServiceLifecycle from "./service-lifecycle";
+export * as ServicePublication from "./service-publication";

--- a/packages/io-services-cms-models/src/lib/fsm/types.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/types.ts
@@ -86,6 +86,14 @@ export type Transition<
   ) => E.Either<FsmTransitionExecutionError, WithState<ToState[0], ToState[1]>>;
 };
 
+export class FsmItemNotFoundError extends Error {
+  public kind = "FsmItemNotFoundError";
+  constructor(id: string) {
+    const formattedMessage = `no item with id ${id} found`;
+    super(formattedMessage);
+  }
+}
+
 export class FsmNoApplicableTransitionError extends Error {
   public kind = "FsmNoApplicableTransitionError";
   constructor(appliedAction: string) {

--- a/packages/io-services-cms-models/src/service-publication/index.ts
+++ b/packages/io-services-cms-models/src/service-publication/index.ts
@@ -8,6 +8,7 @@ import * as t from "io-ts";
 import {
   EmptyState,
   FSMStore,
+  FsmItemNotFoundError,
   FsmNoApplicableTransitionError,
   FsmNoTransitionMatchedError,
   FsmStoreFetchError,
@@ -31,13 +32,14 @@ type ToRecord<Q> = Q extends []
 // commodity aliases
 type AllStateNames = keyof FSM["states"];
 type AllResults = States[number];
-type AllFsmErrors =
+export type AllFsmErrors =
   | FsmNoApplicableTransitionError
   | FsmNoTransitionMatchedError
   | FsmTooManyTransitionsError
   | FsmTransitionExecutionError
   | FsmStoreFetchError
-  | FsmStoreSaveError;
+  | FsmStoreSaveError
+  | FsmItemNotFoundError;
 
 // All the states admitted by the FSM
 type States = t.TypeOf<typeof States>;
@@ -255,9 +257,24 @@ function apply(
                     tr: T
                   ): tr is T & { from: "*" } => tr.from === EmptyState
                 ),
+                // if no transactions starting from the empty state are found:
+                // return a dummy transaction with the exec() containing a NotFound Error
+                // with the aim of differentiating from a NoTransitionMatched Error
+                (fromEmptyStateTransitions) =>
+                  fromEmptyStateTransitions.length === 0
+                    ? ([
+                        {
+                          exec: () => E.left(new FsmItemNotFoundError(id)),
+                        },
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      ] as any)
+                    : fromEmptyStateTransitions,
                 // bind all data into a lazy implementation of exec
                 RA.map((tr) => ({
-                  exec: (): E.Either<FsmTransitionExecutionError, AllResults> =>
+                  exec: (): E.Either<
+                    FsmTransitionExecutionError | FsmItemNotFoundError,
+                    AllResults
+                  > =>
                     // FIXME: avoid this forcing
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
@@ -289,7 +306,7 @@ function apply(
                     //  bind all data into a lazy implementation of exec
                     E.map((current) => ({
                       exec: (): E.Either<
-                        FsmTransitionExecutionError,
+                        FsmTransitionExecutionError | FsmItemNotFoundError,
                         AllResults
                       > =>
                         tr.exec({
@@ -307,7 +324,7 @@ function apply(
                 )
               )
           ),
-          // skim unmatched transitions
+          // skip unmatched transitions
           RA.filter(E.isRight)
         )
       ),
@@ -346,4 +363,4 @@ type FsmClient = ReturnType<typeof getFsmClient>;
 
 type ItemType = t.TypeOf<typeof ItemType>;
 const ItemType = t.union(States.types);
-export { getFsmClient, FsmClient, FSM, ItemType };
+export { FSM, FsmClient, ItemType, getFsmClient };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The goal is to have some talking errors when API calls fail, to better understand the reason for the failure and be able to fix it.
Before this update, the APIs that assumed an _apply_ on _FSM_, generically returned error _**500**_ in case of failure.

With this update, the new `fsmToApiError` function used into controllers, converts an FSM error into a suitable http error, and the result is to have:
- **404** for `FsmItemNotFoundError`**\***
- **409** for `FsmNoApplicableTransitionError`, `FsmNoTransitionMatchedError`, `FsmTooManyTransitionsError`
- **500** for `FsmTransitionExecutionError`, `FsmStoreFetchError`, `FsmStoreSaveError` and unmatched errors


**\*Note:** To disambiguate between an actual `FsmNoTransitionMatchedError` rather than an unwanted _NotFound_ error, the implementation of both _FSMs_ _(Lifecycle and Publication)_ has been updated to return a `FsmItemNotFoundError` rather than a `FsmNoTransitionMatchedError` depending on the use cases .



#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
