### PR TITLE
fix: bulk fetch on store cosmos which prevent from fetching any data

### DIFF
--- a/packages/io-services-cms-models/src/lib/fsm/store.cosmos.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/store.cosmos.ts
@@ -82,7 +82,7 @@ export const createCosmosStore = <
       TE.map((operationResponses) =>
         operationResponses.map(
           flow(
-            O.fromPredicate((res) => res.statusCode === 404),
+            O.fromPredicate((res) => res.statusCode === 200),
             // if present, try to decode in the expected shape
             O.chain((res) =>
               pipe(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix CosmosDb bulkFetch operation which was preventing fetch of anything

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local application run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
