### PR TITLE
fix: change apim api to retrieve subscription keys

### DIFF
--- a/.changeset/nasty-plums-raise.md
+++ b/.changeset/nasty-plums-raise.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Fix Get Service Keys API

--- a/apps/io-services-cms-webapp/src/lib/clients/apim-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/apim-client.ts
@@ -167,6 +167,21 @@ export const getSubscription = (
     chainApimMappedError
   );
 
+export const listSecrets = (
+  apimClient: ApiManagementClient,
+  apimResourceGroup: string,
+  apim: string,
+  serviceId: string
+) =>
+  pipe(
+    TE.tryCatch(
+      () =>
+        apimClient.subscription.listSecrets(apimResourceGroup, apim, serviceId),
+      identity
+    ),
+    chainApimMappedError
+  );
+
 /**
  * Create or updates a subscription for a given user
  *

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-keys.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-keys.test.ts
@@ -166,7 +166,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(listSecrets).toHaveBeenCalledTimes(1);
+    expect(listSecrets).toHaveBeenCalled();
     expect(response.statusCode).toBe(500);
   });
 
@@ -184,7 +184,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(listSecrets).toHaveBeenCalledTimes(1);
+    expect(listSecrets).toHaveBeenCalled();
     expect(response.statusCode).toBe(500);
   });
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-keys.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-keys.test.ts
@@ -19,7 +19,7 @@ import * as TE from "fp-ts/lib/TaskEither";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IConfig } from "../../../config";
-import { getSubscription } from "../../../lib/clients/apim-client";
+import { getSubscription, listSecrets } from "../../../lib/clients/apim-client";
 import { createWebServer } from "../../index";
 
 vi.mock("../../../lib/clients/apim-client", async () => {
@@ -31,6 +31,7 @@ vi.mock("../../../lib/clients/apim-client", async () => {
   return {
     ...apimClient,
     getSubscription: vi.fn((_) => TE.right(anApimResource)),
+    listSecrets: vi.fn((_) => TE.right(anApimResource)),
   };
 });
 
@@ -63,6 +64,7 @@ const fsmPublicationClient = ServicePublication.getFsmClient(
 const mockApimClient = {
   subscription: {
     get: vi.fn(() => Promise.resolve(anApimResource)),
+    listSecrets: vi.fn(() => Promise.resolve(anApimResource)),
   },
 } as unknown as ApiManagementClient;
 const mockConfig = {} as unknown as IConfig;
@@ -124,7 +126,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(getSubscription).toHaveBeenCalledTimes(2);
+    expect(listSecrets).toHaveBeenCalled();
     expect(response.statusCode).toBe(200);
     expect(JSON.stringify(response.body)).toBe(
       JSON.stringify({
@@ -135,12 +137,7 @@ describe("getServiceKeys", () => {
   });
 
   it("should fail with a not found error when cannot find requested service subscription", async () => {
-    // first getSubscription for manage key middleware
-    vi.mocked(getSubscription).mockImplementationOnce(() =>
-      TE.right(anApimResource)
-    );
-    // second getSubscription for get service subscription
-    vi.mocked(getSubscription).mockImplementationOnce(() =>
+    vi.mocked(listSecrets).mockImplementationOnce(() =>
       TE.left({ statusCode: 404 })
     );
 
@@ -152,17 +149,12 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(getSubscription).toHaveBeenCalledTimes(2);
+    expect(listSecrets).toHaveBeenCalled();
     expect(response.statusCode).toBe(404);
   });
 
   it("should fail with a generic error if service subscription returns an error", async () => {
-    // first getSubscription for manage key middleware
-    vi.mocked(getSubscription).mockImplementationOnce(() =>
-      TE.right(anApimResource)
-    );
-    // second getSubscription for get service subscription
-    vi.mocked(getSubscription).mockImplementationOnce(() =>
+    vi.mocked(listSecrets).mockImplementationOnce(() =>
       TE.left({ statusCode: 500 })
     );
 
@@ -174,13 +166,13 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(getSubscription).toHaveBeenCalledTimes(2);
+    expect(listSecrets).toHaveBeenCalledTimes(1);
     expect(response.statusCode).toBe(500);
   });
 
   it("should fail with a generic error if manage subscription returns an error", async () => {
     // first getSubscription for manage key middleware
-    vi.mocked(getSubscription).mockImplementationOnce(() =>
+    vi.mocked(listSecrets).mockImplementationOnce(() =>
       TE.left({ statusCode: 500 })
     );
 
@@ -192,7 +184,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(getSubscription).toHaveBeenCalledTimes(1);
+    expect(listSecrets).toHaveBeenCalledTimes(1);
     expect(response.statusCode).toBe(500);
   });
 
@@ -205,7 +197,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(getSubscription).not.toHaveBeenCalled();
+    expect(listSecrets).not.toHaveBeenCalled();
     expect(response.statusCode).toBe(403);
   });
 
@@ -220,7 +212,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", userId)
       .set("x-subscription-id", aNotManageSubscriptionId);
 
-    expect(getSubscription).not.toHaveBeenCalled();
+    expect(listSecrets).not.toHaveBeenCalled();
     expect(response.statusCode).toBe(403);
   });
 
@@ -236,7 +228,7 @@ describe("getServiceKeys", () => {
       .set("x-user-id", aDifferentUserId)
       .set("x-subscription-id", aDifferentManageSubscriptionId);
 
-    expect(getSubscription).toHaveBeenCalledTimes(1);
+    expect(listSecrets).not.toHaveBeenCalled();
     expect(response.statusCode).toBe(403);
   });
 });

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-keys.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-keys.ts
@@ -36,10 +36,7 @@ import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { IConfig } from "../../config";
 import { SubscriptionKeys } from "../../generated/api/SubscriptionKeys";
-import {
-  getSubscription,
-  mapApimRestError,
-} from "../../lib/clients/apim-client";
+import { listSecrets, mapApimRestError } from "../../lib/clients/apim-client";
 import { serviceOwnerCheckManageTask } from "../../utils/subscription";
 
 type HandlerResponseTypes =
@@ -74,7 +71,7 @@ export const makeGetServiceKeysHandler =
       ),
       TE.chainW(() =>
         pipe(
-          getSubscription(
+          listSecrets(
             apimClient,
             config.AZURE_APIM_RESOURCE_GROUP,
             config.AZURE_APIM,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Change apim api call to retrieve subscription's keys `subscription.get` -> `subscription.listSecrets`

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test and Local Application run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
