### PR TITLE
fix: regenerate serviceKey

### DIFF
--- a/apps/io-services-cms-webapp/src/lib/clients/apim-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/apim-client.ts
@@ -351,7 +351,12 @@ export function regenerateSubscriptionKey(
     TE.chain(() =>
       // retrieve updated subscription
       TE.tryCatch(
-        () => apimClient.subscription.get(apimResourceGroup, apim, serviceId),
+        () =>
+          apimClient.subscription.listSecrets(
+            apimResourceGroup,
+            apim,
+            serviceId
+          ),
         E.toError
       )
     ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix regenerate service key API.
#### List of Changes
- Change apim api call to retrieve subscription's keys `subscription.get` -> `subscription.listSecrets` after regenerate them.
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit test and Local Application run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
