### PR TITLE
chore: [IOPAE-385] add legacy filter to service lifecycle watcher

### DIFF
--- a/.changeset/tiny-tigers-wink.md
+++ b/.changeset/tiny-tigers-wink.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+add legacy filter on service lifecycle watcher to avoid sync loop

--- a/apps/io-services-cms-webapp/src/watchers/__tests__/on-service-lifecycle-change.test.ts
+++ b/apps/io-services-cms-webapp/src/watchers/__tests__/on-service-lifecycle-change.test.ts
@@ -32,13 +32,14 @@ const aPublicationService = {
 
 describe("On Service Lifecycle Change Handler", () => {
   it.each`
-    scenario                                     | item                                                                 | expected
-    ${"request-review"}                          | ${{ ...aService, version: "aVersion", fsm: { state: "submitted" } }} | ${{ requestReview: { ...aService, version: "aVersion" }, requestHistoricization: { ...aService, fsm: { state: "submitted" } } }}
-    ${"no-op (empty object)"}                    | ${{ ...aService, fsm: { state: "draft" } }}                          | ${{ requestHistoricization: { ...aService, fsm: { state: "draft" } } }}
-    ${"request-publication"}                     | ${{ ...aService, fsm: { state: "approved", autoPublish: true } }}    | ${{ requestPublication: { ...aPublicationService, autoPublish: true }, requestHistoricization: { ...aService, fsm: { state: "approved", autoPublish: true } } }}
-    ${"request-publication-with-no-autopublish"} | ${{ ...aService, fsm: { state: "approved" } }}                       | ${{ requestPublication: { ...aPublicationService, autoPublish: false }, requestHistoricization: { ...aService, fsm: { state: "approved" } } }}
-    ${"no-op (empty object)"}                    | ${{ ...aService, fsm: { state: "rejected" } }}                       | ${{ requestHistoricization: { ...aService, fsm: { state: "rejected" } } }}
-    ${"no-op (empty object)"}                    | ${{ ...aService, fsm: { state: "deleted" } }}                        | ${{ requestHistoricization: { ...aService, fsm: { state: "deleted" } } }}
+    scenario                                     | item                                                                          | expected
+    ${"request-review"}                          | ${{ ...aService, version: "aVersion", fsm: { state: "submitted" } }}          | ${{ requestReview: { ...aService, version: "aVersion" }, requestHistoricization: { ...aService, fsm: { state: "submitted" } } }}
+    ${"no-op (empty object)"}                    | ${{ ...aService, fsm: { state: "draft" } }}                                   | ${{ requestHistoricization: { ...aService, fsm: { state: "draft" } } }}
+    ${"request-publication"}                     | ${{ ...aService, fsm: { state: "approved", autoPublish: true } }}             | ${{ requestPublication: { ...aPublicationService, autoPublish: true }, requestHistoricization: { ...aService, fsm: { state: "approved", autoPublish: true } } }}
+    ${"request-publication-with-no-autopublish"} | ${{ ...aService, fsm: { state: "approved" } }}                                | ${{ requestPublication: { ...aPublicationService, autoPublish: false }, requestHistoricization: { ...aService, fsm: { state: "approved" } } }}
+    ${"no-op (empty object)"}                    | ${{ ...aService, fsm: { state: "rejected" } }}                                | ${{ requestHistoricization: { ...aService, fsm: { state: "rejected" } } }}
+    ${"no-op (empty object)"}                    | ${{ ...aService, fsm: { state: "deleted" } }}                                 | ${{ requestHistoricization: { ...aService, fsm: { state: "deleted" } } }}
+    ${"no-op (approved from Legacy)"}            | ${{ ...aService, fsm: { state: "approved", lastTransition: "from Legacy" } }} | ${{ requestHistoricization: { ...aService, fsm: { state: "approved", lastTransition: "from Legacy" } } }}
   `("should map an item to a $scenario action", async ({ item, expected }) => {
     const res = await handler({
       MAX_ALLOWED_PAYMENT_AMOUNT: 1000000,

--- a/apps/io-services-cms-webapp/src/watchers/on-service-lifecycle-change.ts
+++ b/apps/io-services-cms-webapp/src/watchers/on-service-lifecycle-change.ts
@@ -71,24 +71,27 @@ export const handler =
     | ((OnSubmitActions | OnApproveActions) & RequestHistoricizationAction)
   > =>
   ({ item }) => {
-    // eslint-disable-next-line sonarjs/no-small-switch
-    switch (item.fsm.state) {
-      case "submitted":
-        return pipe(
-          item,
-          onSubmitHandler,
-          (actions) => ({ ...actions, ...onAnyChangesHandler(item) }),
-          TE.right
-        );
-      case "approved":
-        return pipe(
-          item,
-          onApproveHandler(config),
-          (x) => x,
-          (actions) => ({ ...actions, ...onAnyChangesHandler(item) }),
-          TE.right
-        );
-      default:
-        return TE.right(onAnyChangesHandler(item));
+    if (item.fsm.lastTransition !== "from Legacy") {
+      switch (item.fsm.state) {
+        case "submitted":
+          return pipe(
+            item,
+            onSubmitHandler,
+            (actions) => ({ ...actions, ...onAnyChangesHandler(item) }),
+            TE.right
+          );
+        case "approved":
+          return pipe(
+            item,
+            onApproveHandler(config),
+            (x) => x,
+            (actions) => ({ ...actions, ...onAnyChangesHandler(item) }),
+            TE.right
+          );
+        default:
+          return TE.right(onAnyChangesHandler(item));
+      }
+    } else {
+      return TE.right(onAnyChangesHandler(item));
     }
   };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add a filter to service lifecycle watcher to avoid opening a review or publication request for services from legacy system.

#### List of Changes
<!--- Describe your changes in detail -->
- Add a filter (`item.fsm.lastTransition`) to service lifecycle watcher

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid "side effects" on synching CMS from Legacy

#### How Has This Been Tested?
Unit Tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
