### PR TITLE
fix:[BUG][#IOPAE-455]Generator doesn't generate correctly required parameter inside allOf in openApi

### DIFF
--- a/.changeset/dull-parrots-draw.md
+++ b/.changeset/dull-parrots-draw.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Generator doesn't generate correctly required parameter inside allOf in openApi

--- a/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
@@ -36,9 +36,11 @@ export const itemToResponse = ({
   fsm,
   data,
   id,
+  last_update,
 }: ServiceLifecycle.ItemType): ServiceResponsePayload => ({
   id,
   status: toServiceStatus(fsm),
+  last_update: last_update ?? new Date().getTime().toString(),
   name: data.name,
   description: data.description,
   organization: data.organization,

--- a/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
@@ -11,9 +11,11 @@ export const itemToResponse = ({
   fsm: { state },
   data,
   id,
+  last_update,
 }: ServicePublication.ItemType): ServiceResponsePayload => ({
   id,
   status: toServiceStatusType(state),
+  last_update: last_update ?? new Date().getTime().toString(),
   name: data.name,
   description: data.description,
   organization: data.organization,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-lifecycle.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-lifecycle.test.ts
@@ -113,6 +113,7 @@ describe("getServiceLifecycle", () => {
 
   const aServiceLifecycle = {
     id: "aServiceId",
+    last_update: "aServiceLastUpdate",
     data: {
       name: "aServiceName",
       description: "aServiceDescription",

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-publication.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__test__/get-service-publication.test.ts
@@ -97,6 +97,7 @@ const subscriptionCIDRsModel = new SubscriptionCIDRsModel(containerMock);
 
 const aServicePub = {
   id: "aServiceId",
+  last_update: "aServiceLastUpdate",
   data: {
     name: "aServiceName",
     description: "aServiceDescription",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -572,11 +572,11 @@ components:
               type: integer
             last_update:
               $ref: '#/components/schemas/Timestamp'
+          required:
+            - id
+            - status
+            - last_update
         - $ref: '#/components/schemas/ServiceData'
-      required:
-        - id
-        - status
-        - last_update
     ServicePublication:
       description: Service Publication model data
       allOf:
@@ -590,11 +590,11 @@ components:
               type: integer
             last_update:
               $ref: '#/components/schemas/Timestamp'
+          required:
+            - id
+            - status
+            - last_update
         - $ref: '#/components/schemas/ServiceData'
-      required:
-        - id
-        - status
-        - last_update
     ServicePayload:
       description: A payload used to create or update a service.
       allOf:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
With the way we wrote the openApi using an **allOf** object and the required parameter outside of it , the generator does not generate the : `id` , `status` and `last_update` for the serviceLifecycle/Publication model to be mandatory , but sets them as optional
#### List of Changes

<!--- Describe your changes in detail -->

- Moved required parameter inside the allOf object in the openApi
- update converters
- update tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
First the Old one , Second the New one

<!--- Attach screenshots in case changes impact UI. -->
<img width="551" alt="old openApi" src="https://github.com/pagopa/io-services-cms/assets/109847793/632528d8-1b26-4d63-a620-1f5e19e1c442">
<img width="548" alt="new openApi" src="https://github.com/pagopa/io-services-cms/assets/109847793/1c7c1b60-5399-4447-b6cc-789a9fabbcd7">

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
