### PR TITLE
fix: [BUG] Placeholder metadata description on legacy cms mapping

### DIFF
--- a/.changeset/nine-readers-wave.md
+++ b/.changeset/nine-readers-wave.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Add placeholder value for metadata.description while mapping a legacy sevice who lacks of description

--- a/apps/io-services-cms-webapp/src/watchers/__tests__/on-legacy-service-change.test.ts
+++ b/apps/io-services-cms-webapp/src/watchers/__tests__/on-legacy-service-change.test.ts
@@ -184,7 +184,10 @@ describe("On Legacy Service Change Handler", () => {
         expect.objectContaining({
           requestSyncCms: expect.arrayContaining([
             expect.objectContaining({
-              data: expect.objectContaining({ description: "-" }),
+              data: expect.objectContaining({
+                description: "-",
+                metadata: expect.objectContaining({ description: "-" }),
+              }),
               kind: "LifecycleItemType",
             }),
           ]),

--- a/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
+++ b/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
@@ -99,7 +99,7 @@ const fromLegacyToCmsService = (
       category: service.serviceMetadata?.category,
       cta: service.serviceMetadata?.cta,
       custom_special_flow: service.serviceMetadata?.customSpecialFlow,
-      description: service.serviceMetadata?.description,
+      description: getDescription(service),
       email: service.serviceMetadata?.email,
       pec: service.serviceMetadata?.pec,
       phone: service.serviceMetadata?.phone,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
A freshly created service on Dev portal `lack of description`, this cause a sync problem, cause the description is required in CMS application, in order to fix this issue we set a placeholder value as `metadata.description` while mapping a legacy service who lack of it.

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
