### PR TITLE
fix: [IOPAE-479] unpublish service when deleting id coming from legacy sync

### DIFF
--- a/.changeset/soft-dogs-boil.md
+++ b/.changeset/soft-dogs-boil.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+unpublish service when deleting request is coming from legacy sync

--- a/apps/io-services-cms-webapp/src/watchers/__tests__/on-legacy-service-change.test.ts
+++ b/apps/io-services-cms-webapp/src/watchers/__tests__/on-legacy-service-change.test.ts
@@ -115,7 +115,7 @@ const mockApimClient = {
 } as unknown as ApiManagementClient;
 
 describe("On Legacy Service Change Handler", () => {
-  it("should map a deleted item to a requestSyncCms action containing a service lifecycle with DELETED status", async () => {
+  it("should map a deleted item to a requestSyncCms action containing a service lifecycle with DELETED status and a service publication with UNPUBLISHED status", async () => {
     const item = {
       ...aLegacyService,
       serviceName: "DELETED aServiceName",
@@ -143,6 +143,11 @@ describe("On Legacy Service Change Handler", () => {
               state: "deleted",
             },
             kind: "LifecycleItemType",
+          },
+          {
+            ...aServicePublicationItem,
+            fsm: { state: "unpublished" },
+            kind: "PublicationItemType",
           },
         ],
       });

--- a/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
+++ b/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
@@ -68,7 +68,7 @@ const getLegacyToCmsStatus = (
   issueStatus?: JiraLegacyIssueStatus
 ): Array<Queue.RequestSyncCmsItem["fsm"]["state"]> => {
   if (isDeletedService(service)) {
-    return ["deleted"];
+    return ["deleted", "unpublished"];
   } else if (
     isValidService(qualityCheckExclusionList)(service) &&
     hasOngoingReview(issueStatus)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
unpublish service when deleting id coming from legacy sync

#### List of Changes
<!--- Describe your changes in detail -->
- add an unpublish item to requestSyncCms when a legacy service is deleted

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Test

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
