### PR TITLE
chore: Add retry capabilities to Jira Legacy Client on Throttled response

### DIFF
--- a/.changeset/odd-jeans-agree.md
+++ b/.changeset/odd-jeans-agree.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Add retry capabilities to Jira Legacy Client on Throttled response

--- a/apps/io-services-cms-webapp/src/lib/clients/__tests__/jira-legacy-client.test.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/__tests__/jira-legacy-client.test.ts
@@ -15,13 +15,6 @@ const JIRA_CONFIG = {
   LEGACY_JIRA_PROJECT_NAME: "LEGACYBOARD",
 } as config.IConfig;
 
-const mockFetchJson = vitest.fn();
-const getMockFetchWithStatus = (status: number) =>
-  vitest.fn().mockImplementation(async () => ({
-    json: mockFetchJson,
-    status,
-  }));
-
 const aServiceId = "sid" as ServiceId;
 const aSearchJiraIssuesByServiceIdResponse: SearchJiraLegacyIssuesResponse = {
   startAt: 0,
@@ -46,12 +39,20 @@ const aSearchJiraIssuesByServiceIdResponse: SearchJiraLegacyIssuesResponse = {
 
 describe("[JiraLegacyClient] searchJiraIssueByServiceId", () => {
   it("should return an error containing the details if searchJiraIssueByServiceId returns an error on body", async () => {
+    const mockHeaders = new Map();
+    mockHeaders.set("anHeader", "anHeaderValue");
+
     const resultObj = {
       errorMessages: "Error on Jira response",
     };
+
     const mockFetch = vitest.fn().mockImplementation(async () => ({
       json: vitest.fn(() => Promise.resolve(resultObj)),
-      status: 429,
+      headers: {
+        forEach: (callback) => mockHeaders.forEach(callback),
+        get: (key) => mockHeaders.get(key),
+      },
+      status: 500,
     }));
 
     const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
@@ -68,19 +69,24 @@ describe("[JiraLegacyClient] searchJiraIssueByServiceId", () => {
     if (E.isLeft(issues)) {
       expect(issues.left).toHaveProperty(
         "message",
-        `Unknown status code 429 received, responseBody: ${JSON.stringify(
-          resultObj
-        )}`
+        `Jira API returns an error, responseBody: ${JSON.stringify(resultObj)}`
       );
     }
   });
 
-  it("should return the deserializzation error if searchJiraIssueByServiceId body extractions both json and text end up in failure", async () => {
+  it("should return the deserializzation error if searchJiraIssueByServiceId body extractions json end up in failure", async () => {
+    const mockHeaders = new Map();
+    mockHeaders.set("anHeader", "anHeaderValue");
+
     const mockFetch = vitest.fn().mockImplementation(async () => ({
       json: vitest.fn(() =>
         Promise.reject(new Error("Bad Error on JSON deserialize"))
       ),
-      status: 429,
+      headers: {
+        forEach: (callback) => mockHeaders.forEach(callback),
+        get: (key) => mockHeaders.get(key),
+      },
+      status: 500,
     }));
 
     const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
@@ -97,16 +103,155 @@ describe("[JiraLegacyClient] searchJiraIssueByServiceId", () => {
     if (E.isLeft(issues)) {
       expect(issues.left).toHaveProperty(
         "message",
-        "Error parsing Jira response, statusCode: 429 error: Bad Error on JSON deserialize"
+        'Error parsing Jira response, statusCode: 500, headers: {"anHeader":"anHeaderValue"}, error: Bad Error on JSON deserialize'
       );
     }
   });
 
+  it(
+    "should fail after execute retries",
+    async () => {
+      const mockHeaders = new Map();
+      mockHeaders.set("Retry-After", "2");
+
+      const mockFetch = vitest.fn().mockImplementation(async () => ({
+        json: vitest.fn(() =>
+          Promise.reject(new Error("Bad Error on JSON deserialize"))
+        ),
+        headers: {
+          forEach: (callback) => mockHeaders.forEach(callback),
+          get: (key) => mockHeaders.get(key),
+        },
+        status: 429,
+      }));
+
+      const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
+      const maxRetry = 2;
+
+      const issues = await client.searchJiraIssueByServiceId(aServiceId, {
+        maxRetry,
+      })();
+
+      expect(mockFetch).toBeCalledWith(expect.any(String), {
+        body: expect.any(String),
+        headers: expect.any(Object),
+        method: "POST",
+      });
+
+      expect(mockFetch).toBeCalledTimes(maxRetry + 1);
+
+      expect(E.isLeft(issues)).toBeTruthy();
+      if (E.isLeft(issues)) {
+        expect(issues.left).toHaveProperty(
+          "message",
+          'Cannot Contact jira after retries, statusCode: 429, headers: {"Retry-After":"2"}'
+        );
+      }
+    },
+    { timeout: 15000 }
+  );
+
+  it(
+    "should retry with the default delay on 429 response with no Retry header",
+    async () => {
+      const mockHeaders = new Map();
+      mockHeaders.set("anotherHeader", "anotherHeaderValue");
+
+      const mockFetch = vitest.fn().mockImplementation(async () => ({
+        json: vitest.fn(() =>
+          Promise.reject(new Error("Bad Error on JSON deserialize"))
+        ),
+        headers: {
+          forEach: (callback) => mockHeaders.forEach(callback),
+          get: (key) => mockHeaders.get(key),
+        },
+        status: 429,
+      }));
+
+      const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
+
+      const maxRetry = 2;
+      const defaultRetryAfter = 1000;
+
+      const issues = await client.searchJiraIssueByServiceId(aServiceId, {
+        maxRetry,
+        defaultRetryAfter,
+      })();
+
+      expect(mockFetch).toBeCalledWith(expect.any(String), {
+        body: expect.any(String),
+        headers: expect.any(Object),
+        method: "POST",
+      });
+
+      expect(mockFetch).toBeCalledTimes(maxRetry + 1);
+
+      expect(E.isLeft(issues)).toBeTruthy();
+      if (E.isLeft(issues)) {
+        expect(issues.left).toHaveProperty(
+          "message",
+          'Cannot Contact jira after retries, statusCode: 429, headers: {"anotherHeader":"anotherHeaderValue"}'
+        );
+      }
+    },
+    { timeout: 7000 }
+  );
+
+  it(
+    "should retry with the default delay on 429 response with Retry header containing not a number",
+    async () => {
+      const mockHeaders = new Map();
+      mockHeaders.set("Retry-After", "anotherHeaderValue");
+
+      const mockFetch = vitest.fn().mockImplementation(async () => ({
+        json: vitest.fn(() =>
+          Promise.reject(new Error("Bad Error on JSON deserialize"))
+        ),
+        headers: {
+          forEach: (callback) => mockHeaders.forEach(callback),
+          get: (key) => mockHeaders.get(key),
+        },
+        status: 429,
+      }));
+
+      const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
+
+      const issues = await client.searchJiraIssueByServiceId(aServiceId)();
+
+      expect(mockFetch).toBeCalledWith(expect.any(String), {
+        body: expect.any(String),
+        headers: expect.any(Object),
+        method: "POST",
+      });
+
+      expect(mockFetch).toBeCalledTimes(6);
+
+      expect(E.isLeft(issues)).toBeTruthy();
+      if (E.isLeft(issues)) {
+        expect(issues.left).toHaveProperty(
+          "message",
+          'Cannot Contact jira after retries, statusCode: 429, headers: {"Retry-After":"anotherHeaderValue"}'
+        );
+      }
+    },
+    { timeout: 30000 }
+  );
+
   it("should correctly retrieve an issue", async () => {
-    mockFetchJson.mockImplementationOnce(() =>
-      Promise.resolve(aSearchJiraIssuesByServiceIdResponse)
-    );
-    const mockFetch = getMockFetchWithStatus(200);
+    const mockHeaders = new Map();
+    mockHeaders.set("anHeader", "anHeaderValue");
+
+    const mockFetch = vitest.fn().mockImplementation(async () => ({
+      json: vitest.fn(() =>
+        Promise.resolve(aSearchJiraIssuesByServiceIdResponse)
+      ),
+      headers: {
+        forEach: (callback) => mockHeaders.forEach(callback),
+        get: (key) => mockHeaders.get(key),
+      },
+      status: 200,
+    }));
+
     const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
 
     const issue = await client.searchJiraIssueByServiceId(aServiceId)();
@@ -118,4 +263,52 @@ describe("[JiraLegacyClient] searchJiraIssueByServiceId", () => {
     });
     expect(E.isRight(issue)).toBeTruthy();
   });
+
+  it(
+    "should correctly retrieve an issue after 1 retry",
+    async () => {
+      const mockHeaders1 = new Map();
+      mockHeaders1.set("Retry-After", "2");
+
+      const mockHeaders2 = new Map();
+      mockHeaders2.set("anHeader", "anHeaderValue");
+
+      const mockFetch = vitest
+        .fn()
+        .mockImplementationOnce(async () => ({
+          json: vitest.fn(() =>
+            Promise.reject(new Error("Bad Error on JSON deserialize"))
+          ),
+          headers: {
+            forEach: (callback) => mockHeaders1.forEach(callback),
+            get: (key) => mockHeaders1.get(key),
+          },
+          status: 429,
+        }))
+        .mockImplementationOnce(async () => ({
+          json: vitest.fn(() =>
+            Promise.resolve(aSearchJiraIssuesByServiceIdResponse)
+          ),
+          headers: {
+            forEach: (callback) => mockHeaders2.forEach(callback),
+            get: (key) => mockHeaders2.get(key),
+          },
+          status: 200,
+        }));
+
+      const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
+
+      const issue = await client.searchJiraIssueByServiceId(aServiceId)();
+
+      expect(mockFetch).toBeCalledWith(expect.any(String), {
+        body: expect.any(String),
+        headers: expect.any(Object),
+        method: "POST",
+      });
+
+      expect(mockFetch).toBeCalledTimes(2);
+      expect(E.isRight(issue)).toBeTruthy();
+    },
+    { timeout: 5000 }
+  );
 });

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
@@ -6,7 +6,7 @@ import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { isNumber } from "fp-ts/lib/number";
-import * as T from "fp-ts/task";
+import * as T from "fp-ts/Task";
 import * as t from "io-ts";
 import nodeFetch from "node-fetch-commonjs";
 import { IConfig } from "../../config";

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
@@ -164,12 +164,10 @@ export const jiraLegacyClient = (
                 O.chain((delay) =>
                   isNumber(Number(delay)) ? O.some(delay) : O.none
                 ),
-                (x) => x,
                 O.fold(
                   () => defaultRetryAfter,
                   (retryAfter) => Number(retryAfter) * 1000
                 ),
-                (x) => x,
                 (retryAfter) =>
                   retryCount < maxRetryCount
                     ? pipe(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Add retry capabilities to Jira Legacy Client on Throttled response

#### List of Changes
- Handle `Retry-After` header on Jira response, this header contains the number of seconds which needs to be Re-Done the REST API call to the Jira API.
- Add related unit tests.
<!--- Describe your changes in detail -->

#### Motivation and Context
Manage throttled responses received from jira accordin to this [documentation page](https://developer.atlassian.com/cloud/jira/platform/rate-limiting/#rate-limit-responses).
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
