### PR TITLE
chore(fix): Status category optional legacy jira

### DIFF
--- a/.changeset/nine-chairs-warn.md
+++ b/.changeset/nine-chairs-warn.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+statuscategorychangedate optional in JiraLegacyIssue

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
@@ -26,15 +26,19 @@ export type JiraLegacyIssueStatus = t.TypeOf<typeof JiraLegacyIssueStatus>;
 export const JiraLegacyIssue = t.type({
   id: NonEmptyString,
   key: NonEmptyString,
-  fields: t.type({
-    comment: t.type({
-      comments: t.readonlyArray(t.type({ body: t.string })),
+  fields: t.intersection([
+    t.type({
+      comment: t.type({
+        comments: t.readonlyArray(t.type({ body: t.string })),
+      }),
+      status: t.type({
+        name: JiraLegacyIssueStatus,
+      }),
     }),
-    status: t.type({
-      name: JiraLegacyIssueStatus,
+    t.partial({
+      statuscategorychangedate: t.string,
     }),
-    statuscategorychangedate: NonEmptyString,
-  }),
+  ]),
 });
 export type JiraLegacyIssue = t.TypeOf<typeof JiraLegacyIssue>;
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The field `statuscategorychangedate` is not always valued, so we should set it as an optional value in our ` io-ts codec` for the jira legacy response.
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
Fetching data from the Jira Legacy board we received the following error:

```
LegacyServiceWatcher|Error while processing serviceId censored, the reason was => value [null] at [root.0.issues.0.fields.statuscategorychangedate] is not a valid [non empty string], the stack was => Error: value [null] at [root.0.issues.0.fields.statuscategorychangedate] is not a valid [non empty string]
    at Object.toError (/home/site/wwwroot/node_modules/fp-ts/lib/Either.js:1229:37)
    at /home/site/wwwroot/dist/lib/clients/jira-legacy-client.js:97:543
    at /home/site/wwwroot/node_modules/fp-ts/lib/Either.js:643:56
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)|||21ca679d-fb39-4305-b19d-70f5416acb23
```
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
