### PR TITLE
[#IOPAE-510] Removed Jira call and update status mapping on LegacyServiceWatcher

### DIFF
--- a/.changeset/lemon-rockets-knock.md
+++ b/.changeset/lemon-rockets-knock.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Removed Jira call and update status mapping on LegacyServiceWatcher

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -27,7 +27,6 @@ import { getDatabase } from "./lib/azure/cosmos";
 import { processBatchOf, setBindings } from "./lib/azure/misc";
 import { getApimClient } from "./lib/clients/apim-client";
 import { jiraClient } from "./lib/clients/jira-client";
-import { jiraLegacyClient } from "./lib/clients/jira-legacy-client";
 import { createRequestPublicationHandler } from "./publicator/request-publication-handler";
 import { createRequestReviewHandler } from "./reviewer/request-review-handler";
 import { createReviewCheckerHandler } from "./reviewer/review-checker-handler";
@@ -181,7 +180,7 @@ export const onServicePublicationChangeEntryPoint = pipe(
 );
 
 export const onLegacyServiceChangeEntryPoint = pipe(
-  onLegacyServiceChangeHandler(jiraLegacyClient(config), config, apimClient),
+  onLegacyServiceChangeHandler(config, apimClient),
   processBatchOf(LegacyService, { parallel: false }),
   setBindings((results) => ({
     requestSyncCms: pipe(

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -180,7 +180,7 @@ export const onServicePublicationChangeEntryPoint = pipe(
 );
 
 export const onLegacyServiceChangeEntryPoint = pipe(
-  onLegacyServiceChangeHandler(config, apimClient),
+  onLegacyServiceChangeHandler(config, apimClient, legacyServiceModel),
   processBatchOf(LegacyService, { parallel: false }),
   setBindings((results) => ({
     requestSyncCms: pipe(

--- a/apps/io-services-cms-webapp/src/watchers/__tests__/on-legacy-service-change.test.ts
+++ b/apps/io-services-cms-webapp/src/watchers/__tests__/on-legacy-service-change.test.ts
@@ -402,9 +402,8 @@ describe("On Legacy Service Change Handler", () => {
         find: vi.fn(() => TE.right(O.some(previousService))),
       } as unknown as ServiceModel;
 
-      const result = await serviceWasPublished(
-        currentService,
-        mockServiceModel
+      const result = await serviceWasPublished(mockServiceModel)(
+        currentService
       )();
 
       expect(E.isRight(result)).toBeTruthy();
@@ -430,9 +429,8 @@ describe("On Legacy Service Change Handler", () => {
         find: vi.fn(() => TE.right(O.some(previousService))),
       } as unknown as ServiceModel;
 
-      const result = await serviceWasPublished(
-        currentService,
-        mockServiceModel
+      const result = await serviceWasPublished(mockServiceModel)(
+        currentService
       )();
 
       expect(E.isRight(result)).toBeTruthy();
@@ -452,9 +450,8 @@ describe("On Legacy Service Change Handler", () => {
         find: vi.fn(() => TE.left(new Error("should not be called"))),
       } as unknown as ServiceModel;
 
-      const result = await serviceWasPublished(
-        currentService,
-        mockServiceModel
+      const result = await serviceWasPublished(mockServiceModel)(
+        currentService
       )();
 
       expect(mockServiceModel.find).not.toHaveBeenCalled();

--- a/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
+++ b/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
@@ -103,10 +103,8 @@ const legacyToCms = (item: LegacyService, legacyServiceModel: ServiceModel) =>
     ),
     TE.map(
       flow(
-        O.fold(
-          () => getLegacyToCmsStatus(item),
-          (wasPublished) => getLegacyToCmsStatus(item, wasPublished)
-        )
+        O.getOrElse(() => false),
+        (wasPublished) => getLegacyToCmsStatus(item, wasPublished)
       )
     ),
     TE.map((statusList) =>

--- a/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
+++ b/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
@@ -1,11 +1,11 @@
 import { ApiManagementClient } from "@azure/arm-apimanagement";
 import { LegacyService, Queue } from "@io-services-cms/models";
-import { Service } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/lib/Option";
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as TE from "fp-ts/lib/TaskEither";
-import { pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import { IConfig } from "../config";
 import { isUserEnabledForLegacyToCmsSync } from "../utils/feature-flag-handler";
 
@@ -18,26 +18,34 @@ type RequestSyncCmsAction = Action<
   Queue.RequestSyncCmsItem[]
 >;
 
-const onLegacyServiceChangeHandler = (item: Service): RequestSyncCmsAction =>
-  pipe(legacyToCms(item), (docs) => ({ requestSyncCms: docs }));
+const onLegacyServiceChangeHandler =
+  (legacyServiceModel: ServiceModel) =>
+  (item: LegacyService): TE.TaskEither<Error, RequestSyncCmsAction> =>
+    pipe(
+      legacyToCms(item, legacyServiceModel),
+      TE.map((docs) => ({ requestSyncCms: docs }))
+    );
 
-const isDeletedService = (service: Service) =>
+const isDeletedService = (service: LegacyService) =>
   service.serviceName.startsWith("DELETED");
 
 const getLegacyToCmsStatus = (
-  service: Service
+  service: LegacyService,
+  wasPublished: boolean = false
 ): Array<Queue.RequestSyncCmsItem["fsm"]["state"]> => {
   if (isDeletedService(service)) {
     return ["deleted", "unpublished"];
   } else if (service.isVisible) {
     return ["approved", "published"];
+  } else if (wasPublished) {
+    return ["approved", "unpublished"];
   } else {
     return ["draft"];
   }
 };
 
 const fromLegacyToCmsService = (
-  service: Service,
+  service: LegacyService,
   status: Queue.RequestSyncCmsItem["fsm"]["state"]
 ): Queue.RequestSyncCmsItem => ({
   id: service.serviceId,
@@ -82,18 +90,83 @@ const fromLegacyToCmsService = (
       : "LifecycleItemType",
 });
 
-const getDescription = (service: Service) =>
+const getDescription = (service: LegacyService) =>
   service.serviceMetadata?.description ?? ("-" as NonEmptyString);
 
-const legacyToCms = (item: Service) =>
-  pipe(getLegacyToCmsStatus(item), (statusList) =>
-    statusList.map((status) => fromLegacyToCmsService(item, status))
+const legacyToCms = (item: LegacyService, legacyServiceModel: ServiceModel) =>
+  pipe(
+    item,
+    O.fromPredicate((item) => !isDeletedService(item) && !item.isVisible),
+    O.fold(
+      () => TE.right(O.none), // evitiamo la chiamata a Jira quando non serve, simulando una sua risposta vuota
+      (_) => serviceWasPublished(item, legacyServiceModel)
+    ),
+    TE.map(
+      flow(
+        O.fold(
+          () => getLegacyToCmsStatus(item),
+          (wasPublished) => getLegacyToCmsStatus(item, wasPublished)
+        )
+      )
+    ),
+    TE.map((statusList) =>
+      statusList.map((status) => fromLegacyToCmsService(item, status))
+    )
   );
+
+const serviceWasPublished = (
+  item: LegacyService,
+  legacyServiceModel: ServiceModel
+): TE.TaskEither<Error, O.Option<boolean>> =>
+  pipe(
+    item,
+    buildPreviousVersionId,
+    O.fold(
+      () => TE.right(O.some(false)),
+      (previousId) =>
+        pipe(
+          legacyServiceModel.find([previousId, item.serviceId]),
+          TE.mapLeft(
+            (e) => new Error(`Error while retrieving previous service ${e}`)
+          ),
+          TE.chainW(
+            flow(
+              O.fold(
+                () =>
+                  TE.left(
+                    new Error(
+                      `Previous service version was not found ${previousId}`
+                    )
+                  ),
+                (service) => TE.right(O.some(service.isVisible))
+              )
+            )
+          )
+        )
+    )
+  );
+
+const buildPreviousVersionId = (
+  item: LegacyService
+): O.Option<NonEmptyString> => {
+  if (item.version === 0) {
+    return O.none;
+  }
+
+  const previousVersionId = item.version - 1;
+
+  return O.some(
+    `${item.serviceId}-${previousVersionId
+      .toString()
+      .padStart(16, "0")}` as NonEmptyString
+  );
+};
 
 export const handler =
   (
     config: IConfig,
-    apimClient: ApiManagementClient
+    apimClient: ApiManagementClient,
+    legacyServiceModel: ServiceModel
   ): RTE.ReaderTaskEither<
     { item: LegacyService },
     Error,
@@ -106,12 +179,22 @@ export const handler =
       O.map(() =>
         pipe(
           isUserEnabledForLegacyToCmsSync(config, apimClient, item.serviceId),
-          TE.map((isUserEnabled) =>
+          TE.chainW((isUserEnabled) =>
             pipe(
               item,
               O.fromPredicate((_) => isUserEnabled),
-              O.map(onLegacyServiceChangeHandler),
-              O.getOrElse(() => noAction)
+              O.map(
+                flow(
+                  onLegacyServiceChangeHandler(legacyServiceModel),
+                  TE.mapLeft(
+                    (e) =>
+                      new Error(
+                        `Error while processing serviceId ${item.serviceId}, the reason was => ${e.message}, the stack was => ${e.stack}`
+                      )
+                  )
+                )
+              ),
+              O.getOrElse(() => TE.right(noAction))
             )
           )
         )

--- a/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
+++ b/apps/io-services-cms-webapp/src/watchers/on-legacy-service-change.ts
@@ -112,7 +112,7 @@ const legacyToCms = (item: LegacyService, legacyServiceModel: ServiceModel) =>
     )
   );
 
-const serviceWasPublished = (
+export const serviceWasPublished = (
   item: LegacyService,
   legacyServiceModel: ServiceModel
 ): TE.TaskEither<Error, boolean> =>

--- a/packages/io-services-cms-models/src/queue/index.ts
+++ b/packages/io-services-cms-models/src/queue/index.ts
@@ -78,7 +78,7 @@ export const RequestSyncLegacyItem = t.intersection([
   t.type({
     ...omitIsVisible(LegacyService.types[0].types[0].props),
     ...LegacyService.types[0].types[1].props,
-    ...LegacyService.types[1].props,
+    ...LegacyService.types[2].props,
   }),
   t.partial({ isVisible: t.boolean }),
 ]);

--- a/packages/io-services-cms-models/src/service-legacy/index.ts
+++ b/packages/io-services-cms-models/src/service-legacy/index.ts
@@ -3,8 +3,10 @@ import * as t from "io-ts";
 
 export const LegacyService = t.intersection([
   Service,
+  t.type({ version: t.number }),
   t.partial({
     cmsTag: t.boolean,
   }),
 ]);
+
 export type LegacyService = t.TypeOf<typeof LegacyService>;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Removed Jira call and update status mapping on LegacyServiceWatcher
#### List of Changes
- Removed `Jira REST API call` on `LegacyServiceWatcher`
- Add Fetch `previous service Version` to correctly intercept `unpublish actions` on legacy.
- Update `status mapping` on `LegacyServiceWatcher`
- Update `LegacyServiceWatcher Unit Test` according to the changes
<!--- Describe your changes in detail -->

#### Motivation and Context
When a service is submitted for a review or a review is rejected, on the legacy service management application, the service Itself will not change, so no Change Feed notification will be intercepted by this watcher, this means that we need to intercept the creation of new Jira Ticket and Jira ticket status changes on dedicated Functions to fully sync those kind of changes on legacy and sync in io-services-cms.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
