### PR TITLE
[#IOPAE-493] Service review legacy checker

### DIFF
--- a/.changeset/fifty-actors-punch.md
+++ b/.changeset/fifty-actors-punch.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/models": minor
+"io-services-cms-webapp": minor
+---
+
+ADD ServiceReviewLegacyChecker Azure Function

--- a/apps/io-services-cms-webapp/ServiceReviewLegacyChecker/function.json
+++ b/apps/io-services-cms-webapp/ServiceReviewLegacyChecker/function.json
@@ -1,0 +1,12 @@
+{
+  "bindings": [
+    {
+      "schedule": "0 8-19 * * 1-5",
+      "name": "serviceReviewLegacyCheckerTimer",
+      "type": "timerTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "serviceReviewLegacyCheckerEntryPoint"
+}

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -17,6 +17,7 @@ import * as O from "fp-ts/Option";
 import * as RA from "fp-ts/ReadonlyArray";
 import * as RR from "fp-ts/ReadonlyRecord";
 import { pipe } from "fp-ts/lib/function";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { getConfigOrThrow } from "./config";
 import { createRequestHistoricizationHandler } from "./historicizer/request-historicization-handler";
 import {
@@ -47,6 +48,7 @@ import { handler as onServicePublicationChangeHandler } from "./watchers/on-serv
 import { createWebServer } from "./webservice";
 
 import { initTelemetryClient } from "./utils/applicationinsight";
+import { createReviewLegacyCheckerHandler } from "./reviewer/review-legacy-checker-handler";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
 const BASE_PATH = require("../host.json").extensions.http.routePrefix;
@@ -139,6 +141,18 @@ export const serviceReviewCheckerEntryPoint = createReviewCheckerHandler(
   jiraProxy(jiraClient(config)),
   fsmLifecycleClient
 );
+
+export const serviceReviewLegacyCheckerEntryPoint =
+  createReviewLegacyCheckerHandler(
+    getDao({
+      ...config,
+      REVIEWER_DB_TABLE: `${config.REVIEWER_DB_TABLE}-legacy` as NonEmptyString,
+    }),
+    jiraProxy(
+      jiraClient({ ...config, JIRA_PROJECT_NAME: "IES" as NonEmptyString })
+    ),
+    fsmLifecycleClient
+  );
 
 export const onServiceLifecycleChangeEntryPoint = pipe(
   onServiceLifecycleChangeHandler(config),

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -146,7 +146,7 @@ export const serviceReviewLegacyCheckerEntryPoint =
   createReviewLegacyCheckerHandler(
     getDao({
       ...config,
-      REVIEWER_DB_TABLE: `${config.REVIEWER_DB_TABLE}-legacy` as NonEmptyString,
+      REVIEWER_DB_TABLE: `${config.REVIEWER_DB_TABLE}_legacy` as NonEmptyString,
     }),
     jiraProxy(
       jiraClient({ ...config, JIRA_PROJECT_NAME: "IES" as NonEmptyString })

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -18,7 +18,6 @@ import * as RA from "fp-ts/ReadonlyArray";
 import * as RR from "fp-ts/ReadonlyRecord";
 import { pipe } from "fp-ts/lib/function";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { getConfigOrThrow } from "./config";
 import { createRequestHistoricizationHandler } from "./historicizer/request-historicization-handler";
 import {

--- a/apps/io-services-cms-webapp/src/reviewer/__tests__/review-checker-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/__tests__/review-checker-handler.test.ts
@@ -211,18 +211,16 @@ describe("[Service Review Checker Handler] updateReview", () => {
     const result = await updateReview(
       mainMockServiceReviewDao,
       mockFsmLifecycleClient
-    )(
-      TE.of([
-        {
-          issue: aJiraIssue1,
-          item: anItem1,
-        },
-        {
-          issue: aJiraIssue2,
-          item: anItem2,
-        },
-      ] as unknown as IssueItemPair[])
-    )();
+    )([
+      {
+        issue: aJiraIssue1,
+        item: anItem1,
+      },
+      {
+        issue: aJiraIssue2,
+        item: anItem2,
+      },
+    ] as unknown as IssueItemPair[])();
 
     expect(E.isRight(result)).toBeTruthy();
 
@@ -255,7 +253,7 @@ describe("[Service Review Checker Handler] updateReview", () => {
     const result = await updateReview(
       mainMockServiceReviewDao,
       mockFsmLifecycleClient
-    )(TE.of([] as unknown as IssueItemPair[]))();
+    )([] as unknown as IssueItemPair[])();
 
     expect(E.isRight(result)).toBeTruthy();
 
@@ -288,14 +286,12 @@ describe("[Service Review Checker Handler] updateReview", () => {
     const result = await updateReview(
       mockServiceReviewDao,
       mockFsmLifecycleClient
-    )(
-      TE.of([
-        {
-          issue: aJiraIssue1,
-          item: anItem1,
-        },
-      ] as unknown as IssueItemPair[])
-    )();
+    )([
+      {
+        issue: aJiraIssue1,
+        item: anItem1,
+      },
+    ] as unknown as IssueItemPair[])();
 
     expect(E.isLeft(result)).toBeTruthy();
     if (E.isLeft(result)) {
@@ -328,14 +324,12 @@ describe("[Service Review Checker Handler] updateReview", () => {
     const result = await updateReview(
       mockServiceReviewDao,
       mockFsmLifecycleClient
-    )(
-      TE.of([
-        {
-          issue: aJiraIssue1,
-          item: anItem1,
-        },
-      ] as unknown as IssueItemPair[])
-    )();
+    )([
+      {
+        issue: aJiraIssue1,
+        item: anItem1,
+      },
+    ] as unknown as IssueItemPair[])();
 
     // updateReview result
     expect(E.isRight(result)).toBeTruthy();

--- a/apps/io-services-cms-webapp/src/reviewer/__tests__/review-legacy-checker-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/__tests__/review-legacy-checker-handler.test.ts
@@ -224,10 +224,8 @@ describe("Service Review Legacy Checker Handler tests", () => {
         );
 
       const mockFsmLifecycleClient = {
-        getStore: vi.fn(() => ({
-          fetch: mockFetch,
-        })),
         override: vi.fn((_, service) => TE.right(service)),
+        fetch: mockFetch,
       } as unknown as ServiceLifecycle.FsmClient;
 
       const result = await updateReview(
@@ -246,8 +244,7 @@ describe("Service Review Legacy Checker Handler tests", () => {
       ] as unknown as IssueItemPair[])();
 
       expect(E.isRight(result)).toBeTruthy();
-      expect(mockFsmLifecycleClient.getStore).toBeCalledTimes(2);
-      expect(mockFsmLifecycleClient.getStore().fetch).toBeCalledTimes(2);
+      expect(mockFsmLifecycleClient.fetch).toBeCalledTimes(2);
       expect(mockFsmLifecycleClient.override).toBeCalledTimes(2);
 
       // Test1: approve
@@ -300,10 +297,8 @@ describe("Service Review Legacy Checker Handler tests", () => {
       );
 
       const mockFsmLifecycleClient = {
-        getStore: vi.fn(() => ({
-          fetch: mockFetch,
-        })),
         override: vi.fn(() => TE.left(new Error("Error overriding service"))),
+        fetch: mockFetch,
       } as unknown as ServiceLifecycle.FsmClient;
 
       const mockServiceReviewDao_onUpdateStatus = vi.fn(() =>
@@ -333,8 +328,7 @@ describe("Service Review Legacy Checker Handler tests", () => {
         expect(result.left.message).eq("Error overriding service");
       }
 
-      expect(mockFsmLifecycleClient.getStore).toBeCalled();
-      expect(mockFsmLifecycleClient.getStore().fetch).toBeCalled();
+      expect(mockFsmLifecycleClient.fetch).toBeCalled();
       expect(mockFsmLifecycleClient.override).toBeCalled();
       expect(mockServiceReviewDao.updateStatus).toBeCalled();
       expect(mockServiceReviewDao_onUpdateStatus).not.toBeCalled();
@@ -357,13 +351,9 @@ describe("Service Review Legacy Checker Handler tests", () => {
     });
 
     it("Should fails when fetch return none", async () => {
-      const mockFetch = vi.fn(() => TE.right(O.none));
-
       const mockFsmLifecycleClient = {
-        getStore: vi.fn(() => ({
-          fetch: mockFetch,
-        })),
         override: vi.fn((_, service) => TE.right(service)),
+        fetch: vi.fn(() => TE.right(O.none)),
       } as unknown as ServiceLifecycle.FsmClient;
 
       const mockServiceReviewDao_onUpdateStatus = vi.fn(() =>
@@ -395,8 +385,7 @@ describe("Service Review Legacy Checker Handler tests", () => {
         );
       }
 
-      expect(mockFsmLifecycleClient.getStore).toBeCalled();
-      expect(mockFsmLifecycleClient.getStore().fetch).toBeCalled();
+      expect(mockFsmLifecycleClient.fetch).toBeCalled();
       expect(mockFsmLifecycleClient.override).not.toBeCalled();
       expect(mockServiceReviewDao.updateStatus).toBeCalled();
       expect(mockServiceReviewDao_onUpdateStatus).not.toBeCalled();

--- a/apps/io-services-cms-webapp/src/reviewer/__tests__/review-legacy-checker-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/__tests__/review-legacy-checker-handler.test.ts
@@ -1,0 +1,405 @@
+import { ServiceLifecycle } from "@io-services-cms/models";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+import { QueryResult } from "pg";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JiraIssue } from "../../lib/clients/jira-client";
+import { ServiceReviewRowDataTable } from "../../utils/service-review-dao";
+import {
+  IssueItemPair,
+  buildIssueItemPairs,
+  updateReview,
+} from "../review-legacy-checker-handler";
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+const mockContext = {
+  log: {
+    error: vi.fn((_) => console.error(_)),
+    info: vi.fn((_) => console.info(_)),
+    warn: vi.fn((_) => console.warn(_)),
+  },
+} as any;
+
+const aService = {
+  id: "s1",
+  data: {
+    name: "aServiceName" as NonEmptyString,
+    description: "aServiceDescription",
+    authorized_recipients: [],
+    max_allowed_payment_amount: 123,
+    metadata: {
+      address: "via tal dei tali 123",
+      email: "service@email.it",
+      pec: "service@pec.it",
+      scope: "LOCAL",
+    },
+    organization: {
+      name: "anOrganizationName",
+      fiscal_code: "12345678901",
+    },
+    require_secure_channel: false,
+  },
+} as unknown as ServiceLifecycle.definitions.Service;
+
+const aService2 = {
+  ...aService,
+  id: "s2",
+} as unknown as ServiceLifecycle.definitions.Service;
+
+const anItem1: ServiceReviewRowDataTable = {
+  service_id: "s1" as NonEmptyString,
+  service_version: "v1" as NonEmptyString,
+  ticket_id: "tid1" as NonEmptyString,
+  ticket_key: "tk1" as NonEmptyString,
+  status: "PENDING",
+};
+
+const anItem2: ServiceReviewRowDataTable = {
+  service_id: "s2" as NonEmptyString,
+  service_version: "v2" as NonEmptyString,
+  ticket_id: "tid2" as NonEmptyString,
+  ticket_key: "tk2" as NonEmptyString,
+  status: "PENDING",
+};
+
+const anItemList: ServiceReviewRowDataTable[] = [anItem1, anItem2];
+
+const aJiraIssue1: JiraIssue = {
+  id: anItem1.ticket_id,
+  key: anItem1.ticket_key,
+  fields: {
+    comment: {
+      comments: [
+        { body: "comment 1" },
+        { body: "a *formatted* comment … {{some code}} ." },
+      ],
+    },
+    status: {
+      name: "Completata",
+    },
+    statuscategorychangedate: "2023-05-12T15:10:05.173+0200" as NonEmptyString,
+  },
+};
+const aJiraIssue2: JiraIssue = {
+  id: anItem2.ticket_id,
+  key: anItem2.ticket_key,
+  fields: {
+    comment: {
+      comments: [{ body: "reason comment 1" }, { body: "reason comment 2" }],
+    },
+    status: {
+      name: "REJECTED",
+    },
+    statuscategorychangedate: "2023-05-12T15:24:09.173+0200" as NonEmptyString,
+  },
+};
+
+const anInsertQueryResult: QueryResult = {
+  command: "string",
+  rowCount: 1,
+  oid: 1,
+  fields: [],
+  rows: [],
+};
+
+const mainMockServiceReviewDao = {
+  insert: vi.fn(),
+  executeOnPending: vi.fn(),
+  updateStatus: vi.fn((data: ServiceReviewRowDataTable) => {
+    return TE.of(anInsertQueryResult);
+  }),
+};
+
+const mainMockJiraProxy = {
+  createJiraIssue: vi.fn(),
+  searchJiraIssuesByKeyAndStatus: vi.fn(),
+  getJiraIssueByServiceId: vi.fn(),
+  getPendingJiraIssueByServiceId: vi.fn(),
+};
+
+describe("Service Review Legacy Checker Handler tests", () => {
+  describe("buildIssueItemPairs", () => {
+    it("should build TWO IssueItemPairs given 2 jira issues, an APPROVED one and a REJECTED one", async () => {
+      mainMockJiraProxy.searchJiraIssuesByKeyAndStatus.mockImplementationOnce(
+        () =>
+          TE.of({
+            startAt: 0,
+            total: 2,
+            issues: [aJiraIssue1, aJiraIssue2],
+          })
+      );
+
+      const result = await buildIssueItemPairs(mainMockJiraProxy)(anItemList)();
+
+      expect(E.isRight(result)).toBeTruthy();
+      if (E.isRight(result)) {
+        expect(result.right).toStrictEqual([
+          {
+            issue: aJiraIssue1,
+            item: anItem1,
+          },
+          {
+            issue: aJiraIssue2,
+            item: anItem2,
+          },
+        ]);
+      }
+    });
+
+    it("should build EMPTY IssueItemPair given ZERO jira issues", async () => {
+      mainMockJiraProxy.searchJiraIssuesByKeyAndStatus.mockImplementationOnce(
+        () =>
+          TE.of({
+            startAt: 0,
+            total: 0,
+            issues: [],
+          })
+      );
+
+      const result = await buildIssueItemPairs(mainMockJiraProxy)([])();
+
+      expect(E.isRight(result)).toBeTruthy();
+      if (E.isRight(result)) {
+        expect(result.right).toStrictEqual([]);
+      }
+    });
+
+    it("should build EMPTY IssueItemPair given EMPTY jira issues response", async () => {
+      mainMockJiraProxy.searchJiraIssuesByKeyAndStatus.mockImplementationOnce(
+        () =>
+          TE.of({
+            startAt: 0,
+            total: 0,
+            issues: [],
+          })
+      );
+
+      const result = await buildIssueItemPairs(mainMockJiraProxy)(anItemList)();
+
+      expect(E.isRight(result)).toBeTruthy();
+      if (E.isRight(result)) {
+        expect(result.right).toStrictEqual([]);
+      }
+    });
+
+    it("should return Error if searchJiraIssuesByKeyAndStatus returns an error", async () => {
+      mainMockJiraProxy.searchJiraIssuesByKeyAndStatus.mockImplementationOnce(
+        () => TE.left(new Error())
+      );
+
+      const result = await buildIssueItemPairs(mainMockJiraProxy)(anItemList)();
+
+      expect(E.isLeft(result)).toBeTruthy();
+      if (E.isLeft(result)) {
+        expect(result.left).toStrictEqual(new Error());
+      }
+    });
+  });
+
+  describe("updateReview", () => {
+    it("should update TWO PENDING service review given TWO IssueItemPairs, one with APPROVED jira status and one with REJECTED jira status", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          TE.right(
+            O.some({
+              ...aService,
+              fsm: { state: "submitted" },
+            })
+          )
+        )
+        .mockImplementationOnce(() =>
+          TE.right(
+            O.some({
+              ...aService2,
+              fsm: { state: "submitted" },
+            })
+          )
+        );
+
+      const mockFsmLifecycleClient = {
+        getStore: vi.fn(() => ({
+          fetch: mockFetch,
+        })),
+        override: vi.fn((_, service) => TE.right(service)),
+      } as unknown as ServiceLifecycle.FsmClient;
+
+      const result = await updateReview(
+        mainMockServiceReviewDao,
+        mockFsmLifecycleClient,
+        mockContext
+      )([
+        {
+          issue: aJiraIssue1,
+          item: anItem1,
+        },
+        {
+          issue: aJiraIssue2,
+          item: anItem2,
+        },
+      ] as unknown as IssueItemPair[])();
+
+      expect(E.isRight(result)).toBeTruthy();
+      expect(mockFsmLifecycleClient.getStore).toBeCalledTimes(2);
+      expect(mockFsmLifecycleClient.getStore().fetch).toBeCalledTimes(2);
+      expect(mockFsmLifecycleClient.override).toBeCalledTimes(2);
+
+      // Test1: approve
+      expect(mockFsmLifecycleClient.override).toBeCalledWith(aService.id, {
+        ...aService,
+        fsm: { state: "approved" },
+      });
+
+      // Test2: reject
+      expect(mockFsmLifecycleClient.override).toBeCalledWith(aService2.id, {
+        ...aService2,
+        fsm: { state: "rejected" },
+      });
+
+      expect(mainMockServiceReviewDao.updateStatus).toBeCalledTimes(2);
+      expect(mainMockServiceReviewDao.updateStatus).toBeCalledWith({
+        ...anItem1,
+        status: "APPROVED",
+      });
+      expect(mainMockServiceReviewDao.updateStatus).toBeCalledWith({
+        ...anItem2,
+        status: aJiraIssue2.fields.status.name,
+      });
+    });
+
+    it("should not change service review status if it receives an empty issueItemPair", async () => {
+      const mockFsmLifecycleClient =
+        vi.fn() as unknown as ServiceLifecycle.FsmClient;
+      const result = await updateReview(
+        mainMockServiceReviewDao,
+        mockFsmLifecycleClient,
+        mockContext
+      )([])();
+
+      expect(E.isRight(result)).toBeTruthy();
+
+      expect(mockFsmLifecycleClient).not.toBeCalled();
+
+      expect(mainMockServiceReviewDao.updateStatus).not.toBeCalled();
+    });
+
+    it("Should not write on DB when an error appen while overriding", async () => {
+      const mockFetch = vi.fn(() =>
+        TE.right(
+          O.some({
+            ...aService,
+            fsm: { state: "submitted" },
+          })
+        )
+      );
+
+      const mockFsmLifecycleClient = {
+        getStore: vi.fn(() => ({
+          fetch: mockFetch,
+        })),
+        override: vi.fn(() => TE.left(new Error("Error overriding service"))),
+      } as unknown as ServiceLifecycle.FsmClient;
+
+      const mockServiceReviewDao_onUpdateStatus = vi.fn(() =>
+        Promise.resolve({} as QueryResult)
+      );
+      const mockServiceReviewDao = {
+        insert: vi.fn(),
+        executeOnPending: vi.fn(),
+        updateStatus: vi.fn((_: ServiceReviewRowDataTable) =>
+          TE.fromTask(mockServiceReviewDao_onUpdateStatus)
+        ),
+      };
+
+      const result = await updateReview(
+        mockServiceReviewDao,
+        mockFsmLifecycleClient,
+        mockContext
+      )([
+        {
+          issue: aJiraIssue1,
+          item: anItem1,
+        },
+      ] as unknown as IssueItemPair[])();
+
+      expect(E.isLeft(result)).toBeTruthy();
+      if (E.isLeft(result)) {
+        expect(result.left.message).eq("Error overriding service");
+      }
+
+      expect(mockFsmLifecycleClient.getStore).toBeCalled();
+      expect(mockFsmLifecycleClient.getStore().fetch).toBeCalled();
+      expect(mockFsmLifecycleClient.override).toBeCalled();
+      expect(mockServiceReviewDao.updateStatus).toBeCalled();
+      expect(mockServiceReviewDao_onUpdateStatus).not.toBeCalled();
+    });
+
+    it("should not change service review status if it receives an empty issueItemPair", async () => {
+      const mockFsmLifecycleClient =
+        vi.fn() as unknown as ServiceLifecycle.FsmClient;
+      const result = await updateReview(
+        mainMockServiceReviewDao,
+        mockFsmLifecycleClient,
+        mockContext
+      )([])();
+
+      expect(E.isRight(result)).toBeTruthy();
+
+      expect(mockFsmLifecycleClient).not.toBeCalled();
+
+      expect(mainMockServiceReviewDao.updateStatus).not.toBeCalled();
+    });
+
+    it("Should fails when fetch return none", async () => {
+      const mockFetch = vi.fn(() => TE.right(O.none));
+
+      const mockFsmLifecycleClient = {
+        getStore: vi.fn(() => ({
+          fetch: mockFetch,
+        })),
+        override: vi.fn((_, service) => TE.right(service)),
+      } as unknown as ServiceLifecycle.FsmClient;
+
+      const mockServiceReviewDao_onUpdateStatus = vi.fn(() =>
+        Promise.resolve({} as QueryResult)
+      );
+      const mockServiceReviewDao = {
+        insert: vi.fn(),
+        executeOnPending: vi.fn(),
+        updateStatus: vi.fn((_: ServiceReviewRowDataTable) =>
+          TE.fromTask(mockServiceReviewDao_onUpdateStatus)
+        ),
+      };
+
+      const result = await updateReview(
+        mockServiceReviewDao,
+        mockFsmLifecycleClient,
+        mockContext
+      )([
+        {
+          issue: aJiraIssue1,
+          item: anItem1,
+        },
+      ] as unknown as IssueItemPair[])();
+
+      expect(E.isLeft(result)).toBeTruthy();
+      if (E.isLeft(result)) {
+        expect(result.left.message).eq(
+          `Service ${anItem1.service_id} not found cannot ovverride after legacy review`
+        );
+      }
+
+      expect(mockFsmLifecycleClient.getStore).toBeCalled();
+      expect(mockFsmLifecycleClient.getStore().fetch).toBeCalled();
+      expect(mockFsmLifecycleClient.override).not.toBeCalled();
+      expect(mockServiceReviewDao.updateStatus).toBeCalled();
+      expect(mockServiceReviewDao_onUpdateStatus).not.toBeCalled();
+    });
+  });
+});

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -121,7 +121,7 @@ const makeServiceLifecycleApply = (
 ) =>
   pipe(
     serviceReview.service_id,
-    fsmLifecycleClient.getStore().fetch,
+    fsmLifecycleClient.fetch,
     TE.chain(
       flow(
         O.fold(

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -1,8 +1,8 @@
 import { Context } from "@azure/functions";
 import { ServiceLifecycle } from "@io-services-cms/models";
 import { sequenceT } from "fp-ts/lib/Apply";
-import * as O from "fp-ts/lib/Option";
 import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as TE from "fp-ts/lib/TaskEither";
 import { flow, pipe } from "fp-ts/lib/function";
@@ -18,7 +18,9 @@ const logPrefix = "ServiceReviewLegacyChecker";
 
 export type ProcessedJiraIssue = JiraIssue & {
   fields: JiraIssue["fields"] & {
-    status: JiraIssue["fields"]["status"] & { name: "APPROVED" | "REJECTED" };
+    status: JiraIssue["fields"]["status"] & {
+      name: "APPROVED" | "REJECTED" | "DONE" | "Completata";
+    };
   };
 };
 
@@ -96,7 +98,10 @@ export const updateReview =
           pipe(
             dao.updateStatus({
               ...item,
-              status: issue.fields.status.name,
+              status:
+                issue.fields.status.name === "REJECTED"
+                  ? "REJECTED"
+                  : "APPROVED",
             }),
             TE.mapLeft((err) => {
               logger.logError(err, "Error updating legacy review status on DB");

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -88,10 +88,10 @@ export const updateReview =
     fsmLifecycleClient: ServiceLifecycle.FsmClient,
     context: Context
   ) =>
-  (data: IssueItemPair[]): TE.TaskEither<Error, void> => {
+  (issueItemPairs: IssueItemPair[]): TE.TaskEither<Error, void> => {
     const logger = getLogger(context, logPrefix, "updateReview");
     return pipe(
-      data,
+      issueItemPairs,
       RA.traverse(TE.ApplicativePar)(({ issue, item }) =>
         sequenceT(TE.ApplicativeSeq)(
           makeServiceLifecycleApply(item, issue, fsmLifecycleClient),

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -1,0 +1,161 @@
+import { Context } from "@azure/functions";
+import { ServiceLifecycle } from "@io-services-cms/models";
+import { sequenceT } from "fp-ts/lib/Apply";
+import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
+import * as RA from "fp-ts/lib/ReadonlyArray";
+import * as TE from "fp-ts/lib/TaskEither";
+import { flow, pipe } from "fp-ts/lib/function";
+import { JiraIssue } from "../lib/clients/jira-client";
+import { JiraProxy } from "../utils/jira-proxy";
+import { getLogger } from "../utils/logger";
+import {
+  ServiceReviewDao,
+  ServiceReviewRowDataTable,
+} from "../utils/service-review-dao";
+
+const logPrefix = "ServiceReviewLegacyChecker";
+
+export type ProcessedJiraIssue = JiraIssue & {
+  fields: JiraIssue["fields"] & {
+    status: JiraIssue["fields"]["status"] & { name: "APPROVED" | "REJECTED" };
+  };
+};
+
+export type IssueItemPair = {
+  issue: ProcessedJiraIssue;
+  item: ServiceReviewRowDataTable;
+};
+
+export const processBatchOfReviews =
+  (
+    context: Context,
+    dao: ServiceReviewDao,
+    jiraProxy: JiraProxy,
+    fsmLifecycleClient: ServiceLifecycle.FsmClient
+  ) =>
+  (items: ServiceReviewRowDataTable[]) =>
+    pipe(
+      items,
+      buildIssueItemPairs(jiraProxy),
+      TE.chain(updateReview(dao, fsmLifecycleClient, context))
+    );
+
+/**
+ * Build an array of Issue/Item pairs
+ * @param jiraProxy
+ * @returns
+ */
+export const buildIssueItemPairs =
+  (jiraProxy: JiraProxy) => (items: ServiceReviewRowDataTable[]) =>
+    pipe(
+      // from pending items to their relative jira issues
+      jiraProxy.searchJiraIssuesByKeyAndStatus(
+        items.map((item) => item.ticket_key),
+        ["APPROVED", "REJECTED", "DONE", "Completata"]
+      ),
+      TE.map((jiraResponse) => jiraResponse.issues),
+      // consider only the issues associated with a pending review
+      // is it needed? searchJiraIssuesByKey should not give issues unrelate to pending reviews
+      TE.map((issues) => {
+        const itemsMap = new Map(items.map((i) => [i.ticket_id, i]));
+        return (
+          issues
+            // associate each issue with its pending review
+            .map((issue) => ({
+              issue,
+              item: itemsMap.get(issue.id),
+            }))
+            // be sure the pending review is not undefined
+            .filter((_): _ is IssueItemPair => typeof _.item !== "undefined")
+        );
+      })
+    );
+
+/**
+ * For each pair, compose a sub-procedure of actions to be executed one after another
+ * first we want to apply the transition to the service
+ * then we update the pending review status.
+ * @param dao
+ * @param store
+ * @returns
+ */
+export const updateReview =
+  (
+    dao: ServiceReviewDao,
+    fsmLifecycleClient: ServiceLifecycle.FsmClient,
+    context: Context
+  ) =>
+  (data: IssueItemPair[]): TE.TaskEither<Error, void> => {
+    const logger = getLogger(context, logPrefix, "updateReview");
+    return pipe(
+      data,
+      RA.traverse(TE.ApplicativePar)(({ issue, item }) =>
+        sequenceT(TE.ApplicativeSeq)(
+          makeServiceLifecycleApply(item, issue, fsmLifecycleClient),
+          pipe(
+            dao.updateStatus({
+              ...item,
+              status: issue.fields.status.name,
+            }),
+            TE.mapLeft((err) => {
+              logger.logError(err, "Error updating legacy review status on DB");
+              return E.toError(err);
+            })
+          )
+        )
+      ),
+      TE.map((_) => void 0)
+    );
+  };
+
+const makeServiceLifecycleApply = (
+  serviceReview: ServiceReviewRowDataTable,
+  jiraIssue: ProcessedJiraIssue,
+  fsmLifecycleClient: ServiceLifecycle.FsmClient
+) =>
+  pipe(
+    serviceReview.service_id,
+    fsmLifecycleClient.getStore().fetch,
+    TE.chain(
+      flow(
+        O.fold(
+          () =>
+            TE.left(
+              new Error(
+                `Service ${serviceReview.service_id} not found cannot ovverride after legacy review`
+              )
+            ),
+          flow(
+            updateServiceLifecycleStatus(jiraIssue.fields.status.name),
+            (updateService) =>
+              fsmLifecycleClient.override(updateService.id, updateService),
+            TE.map((_) => void 0)
+          )
+        )
+      )
+    )
+  );
+
+const updateServiceLifecycleStatus =
+  (issueStatus: JiraIssue["fields"]["status"]["name"]) =>
+  (service: ServiceLifecycle.ItemType): ServiceLifecycle.ItemType => ({
+    ...service,
+    fsm: {
+      ...service.fsm,
+      state:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        issueStatus === "REJECTED" ? ("rejected" as any) : ("approved" as any),
+    },
+  });
+
+export const createReviewLegacyCheckerHandler =
+  (
+    dao: ServiceReviewDao,
+    jiraProxy: JiraProxy,
+    fsmLifecycleClient: ServiceLifecycle.FsmClient
+  ) =>
+  (context: Context): Promise<unknown> =>
+    dao.executeOnPending(
+      processBatchOfReviews(context, dao, jiraProxy, fsmLifecycleClient)
+    )();

--- a/apps/io-services-cms-webapp/src/utils/logger.ts
+++ b/apps/io-services-cms-webapp/src/utils/logger.ts
@@ -17,6 +17,8 @@ export type ErrorResponseTypes =
   | IResponseErrorTooManyRequests
   | IResponseErrorInternal;
 
+type LogLevel = "info" | "warn" | "error";
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const getLogger = (
   context: Context,
@@ -57,6 +59,19 @@ export const getLogger = (
     context.log.error(
       `${logPrefix}|${step}|UNKNOWN_ERROR=${JSON.stringify(errs)}`
     ),
+  log: (level: LogLevel, message: string): void => {
+    switch (level) {
+      case "warn":
+        context.log.warn(`${logPrefix}|${step}|MESSAGE: ${message}`);
+        break;
+      case "error":
+        context.log.error(`${logPrefix}|${step}|MESSAGE: ${message}`);
+        break;
+      default:
+        context.log.info(`${logPrefix}|${step}|MESSAGE: ${message}`);
+        break;
+    }
+  },
 });
 
 const handleErrorResponseType = (errorResponse: ErrorResponseTypes) =>

--- a/infra/src/webapp.tf
+++ b/infra/src/webapp.tf
@@ -231,16 +231,17 @@ module "webapp_functions_app" {
   app_settings = merge(
     local.webapp_functions_app_settings,
     {
-      "AzureWebJobs.LegacyServiceWatcher.Disabled"      = "0"
-      "AzureWebJobs.ServiceLifecycleWatcher.Disabled"   = "0"
-      "AzureWebJobs.ServicePublicationWatcher.Disabled" = "0"
-      "AzureWebJobs.ServiceReviewChecker.Disabled"      = "0"
-      "AzureWebJobs.ServiceHistoryWatcher.Disabled"     = "1"
-      "AzureWebJobs.OnRequestHistoricization.Disabled"  = "0"
-      "AzureWebJobs.OnRequestPublication.Disabled"      = "0"
-      "AzureWebJobs.OnRequestReview.Disabled"           = "0"
-      "AzureWebJobs.OnRequestSyncCms.Disabled"          = "1"
-      "AzureWebJobs.OnRequestSyncLegacy.Disabled"       = "1"
+      "AzureWebJobs.LegacyServiceWatcher.Disabled"       = "0"
+      "AzureWebJobs.ServiceLifecycleWatcher.Disabled"    = "0"
+      "AzureWebJobs.ServicePublicationWatcher.Disabled"  = "0"
+      "AzureWebJobs.ServiceReviewChecker.Disabled"       = "0"
+      "AzureWebJobs.ServiceHistoryWatcher.Disabled"      = "1"
+      "AzureWebJobs.OnRequestHistoricization.Disabled"   = "0"
+      "AzureWebJobs.OnRequestPublication.Disabled"       = "0"
+      "AzureWebJobs.OnRequestReview.Disabled"            = "0"
+      "AzureWebJobs.OnRequestSyncCms.Disabled"           = "1"
+      "AzureWebJobs.OnRequestSyncLegacy.Disabled"        = "1"
+      "AzureWebJobs.ServiceReviewLegacyChecker.Disabled" = "1"
     }
   )
 
@@ -255,6 +256,7 @@ module "webapp_functions_app" {
     "AzureWebJobs.OnRequestReview.Disabled",
     "AzureWebJobs.OnRequestSyncCms.Disabled",
     "AzureWebJobs.OnRequestSyncLegacy.Disabled",
+    "AzureWebJobs.ServiceReviewLegacyChecker.Disabled",
   ]
 
   subnet_id = module.app_snet.id
@@ -289,16 +291,17 @@ module "webapp_functions_app_staging_slot" {
   app_settings = merge(
     local.webapp_functions_app_settings,
     {
-      "AzureWebJobs.LegacyServiceWatcher.Disabled"      = "1"
-      "AzureWebJobs.ServiceLifecycleWatcher.Disabled"   = "1"
-      "AzureWebJobs.ServicePublicationWatcher.Disabled" = "1"
-      "AzureWebJobs.ServiceReviewChecker.Disabled"      = "1"
-      "AzureWebJobs.ServiceHistoryWatcher.Disabled"     = "1"
-      "AzureWebJobs.OnRequestHistoricization.Disabled"  = "1"
-      "AzureWebJobs.OnRequestPublication.Disabled"      = "1"
-      "AzureWebJobs.OnRequestReview.Disabled"           = "1"
-      "AzureWebJobs.OnRequestSyncCms.Disabled"          = "1"
-      "AzureWebJobs.OnRequestSyncLegacy.Disabled"       = "1"
+      "AzureWebJobs.LegacyServiceWatcher.Disabled"       = "1"
+      "AzureWebJobs.ServiceLifecycleWatcher.Disabled"    = "1"
+      "AzureWebJobs.ServicePublicationWatcher.Disabled"  = "1"
+      "AzureWebJobs.ServiceReviewChecker.Disabled"       = "1"
+      "AzureWebJobs.ServiceHistoryWatcher.Disabled"      = "1"
+      "AzureWebJobs.OnRequestHistoricization.Disabled"   = "1"
+      "AzureWebJobs.OnRequestPublication.Disabled"       = "1"
+      "AzureWebJobs.OnRequestReview.Disabled"            = "1"
+      "AzureWebJobs.OnRequestSyncCms.Disabled"           = "1"
+      "AzureWebJobs.OnRequestSyncLegacy.Disabled"        = "1"
+      "AzureWebJobs.ServiceReviewLegacyChecker.Disabled" = "1"
     }
   )
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
#### List of Changes
Add New `ServiceReviewLegacyChecker`, Azure Function that will sync any Jira Legacy status change to the imported legacy services.

<!--- Describe your changes in detail -->
- ADD ServiceReviewLegacyChecker AF `function.json`
- ADD AzureWebJobs.ServiceReviewLegacyChecker.Disabled in `webapp.tf`
- ADD `ServiceReviewLegacyChecker` Azure Function
- ADD Unit Test for `ReviewLegacyCheckerHandler`
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When a Service is Submitted for an approval on Legacy Service a Jira Ticket is created, the workflow on those tickets needs to be tracked in order to correctly intercept all Legacy service status change and sync them in `io-services-cms`

#### How Has This Been Tested?
Unit Test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
