### PR TITLE
[IOPAE-507] BackOffice Internazionalization (i18n)

### DIFF
--- a/.changeset/soft-ads-train.md
+++ b/.changeset/soft-ads-train.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/backoffice": minor
+---
+
+Internazionalization (i18n)

--- a/apps/backoffice/next-i18next.config.js
+++ b/apps/backoffice/next-i18next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  i18n: {
+    // all the locales supported in the application
+    locales: ['it', 'en'],
+    // This is the default locale to be used when visiting a non-locale prefixed path
+    defaultLocale: 'it',
+  },
+  react: { useSuspense: false },
+};

--- a/apps/backoffice/next.config.js
+++ b/apps/backoffice/next.config.js
@@ -1,7 +1,10 @@
+const { i18n } = require("./next-i18next.config");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@pagopa/mui-italia"],
+  i18n,
 };
 
 module.exports = nextConfig;

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -20,9 +20,12 @@
     "@pagopa/mui-italia": "^0.9.5",
     "eslint": "8.46.0",
     "eslint-config-next": "13.4.12",
+    "i18next": "^23.4.1",
     "next": "13.4.12",
+    "next-i18next": "^14.0.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-i18next": "^13.0.3"
   },
   "devDependencies": {
     "@types/node": "20.4.5",

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -1,0 +1,30 @@
+{
+  "apikeys": {
+    "title": "API Keys",
+    "subtitle": "View and manage security keys for APIs."
+  },
+  "app": {
+    "title": "IO BackOffice"
+  },
+  "footer": {
+    "legalInfo": "<strong>PagoPA S.p.A.</strong> - Joint-stock company with sole shareholder - Share capital of 1,000,000 euros fully paid - Registered office in Rome, Piazza Colonna 370, <br /> CAP 00187 - Registration number in the Rome Company Register, Tax Code and VAT number 15376371009",
+    "preLogin": {},
+    "postLogin": {
+      "privacyPolicy": "Privacy policy",
+      "personalDataProtection": "Right to the protection of personal data",
+      "termsAndConditions": "Terms and conditions"
+    }
+  },
+  "section": {
+    "overview": "Overview",
+    "services": "Services",
+    "apikeys": "API Keys",
+    "users": "Users",
+    "groups": "Groups"
+  },
+  "services": {
+    "title": "Services",
+    "subtitle": "View and manage the services of your Institution."
+  },
+  "test": "This is a translation test"
+}

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -1,0 +1,30 @@
+{
+  "apikeys": {
+    "title": "Chiavi API",
+    "subtitle": "Visualizza e gestisci le chiavi di sicurezza per le API."
+  },
+  "app": {
+    "title": "IO BackOffice"
+  },
+  "footer": {
+    "legalInfo": "<strong>PagoPA S.p.A.</strong> - Società per azioni con socio unico - Capitale sociale di euro 1,000,000 interamente versato - Sede legale in Roma, Piazza Colonna 370, <br /> CAP 00187 - N. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009",
+    "preLogin": {},
+    "postLogin": {
+      "privacyPolicy": "Privacy policy",
+      "personalDataProtection": "Diritto alla protezione dei dati personali",
+      "termsAndConditions": "Termini e Condizioni"
+    }
+  },
+  "section": {
+    "overview": "Panoramica",
+    "services": "Servizi",
+    "apikeys": "Chiavi API",
+    "users": "Utenti",
+    "groups": "Gruppi"
+  },
+  "services": {
+    "title": "Servizi",
+    "subtitle": "Visualizza e gestisci i Servizi del tuo Ente."
+  },
+  "test": "Questo è un test di traduzione"
+}

--- a/apps/backoffice/src/components/footer/index.tsx
+++ b/apps/backoffice/src/components/footer/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { Trans, useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import {
   Footer,
@@ -18,15 +19,7 @@ const pagoPALink: RootLinkType = {
   title: pagoPACompanyLabel,
 };
 
-const companyLegalInfo = (
-  <>
-    <strong>PagoPA S.p.A.</strong> - Società per azioni con socio unico -
-    Capitale sociale di euro 1,000,000 interamente versato - Sede legale in
-    Roma, Piazza Colonna 370, <br />
-    CAP 00187 - N. di iscrizione a Registro Imprese di Roma, CF e P.IVA
-    15376371009
-  </>
-);
+const companyLegalInfo = <Trans i18nKey="footer.legalInfo" />;
 
 const languages: Languages = {
   it: {
@@ -45,24 +38,25 @@ export type AppFooterProps = {
 };
 
 export const AppFooter = ({ loggedUser, currentLanguage }: AppFooterProps) => {
+  const { t } = useTranslation();
   const router = useRouter();
   const [lang, setLang] = useState(currentLanguage);
 
   const postLoginLinks: Array<FooterLinksType> = [
     {
-      label: "privacyPolicy",
+      label: t("footer.postLogin.privacyPolicy"),
       href: "",
       ariaLabel: "Vai al link: Privacy policy",
       linkType: "internal",
     },
     {
-      label: "personalDataProtection",
+      label: t("footer.postLogin.personalDataProtection"),
       href: "",
       ariaLabel: "Vai al link: Diritto alla protezione dei dati personali",
       linkType: "internal",
     },
     {
-      label: "termsAndConditions",
+      label: t("footer.postLogin.termsAndConditions"),
       href: "",
       ariaLabel: "Vai al link: Termini e condizioni",
       linkType: "internal",

--- a/apps/backoffice/src/components/headers/top-bar.tsx
+++ b/apps/backoffice/src/components/headers/top-bar.tsx
@@ -21,6 +21,9 @@ export const TopBar = ({ user }: TopBarProps) => {
       onAssistanceClick={() => {
         console.log("Clicked/Tapped on Assistance");
       }}
+      onDocumentationClick={() => {
+        console.log("Clicked/Tapped on Documentation");
+      }}
       onLogin={() => {
         console.log("User login");
       }}

--- a/apps/backoffice/src/components/sidenav/index.tsx
+++ b/apps/backoffice/src/components/sidenav/index.tsx
@@ -14,6 +14,7 @@ import {
   ListItemIcon,
   ListItemText,
 } from "@mui/material";
+import { useTranslation } from "next-i18next";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 
@@ -28,23 +29,24 @@ export type SidenavProps = {
 };
 
 export const Sidenav = ({ onNavItemClick }: SidenavProps) => {
+  const { t } = useTranslation();
   const router = useRouter();
 
   const menu: Array<SidenavItem> = [
     {
       href: "/",
       icon: <Dashboard fontSize="inherit" />,
-      text: "Panoramica",
+      text: "section.overview",
     },
     {
       href: "/services",
       icon: <NoteAlt fontSize="inherit" />,
-      text: "Servizi",
+      text: "section.services",
     },
     {
       href: "/apikeys",
       icon: <VpnKey fontSize="inherit" />,
-      text: "API Key",
+      text: "section.apikeys",
     },
   ];
 
@@ -71,7 +73,7 @@ export const Sidenav = ({ onNavItemClick }: SidenavProps) => {
               onClick={() => handleListItemClick(index)}
             >
               <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.text} />
+              <ListItemText primary={t(item.text)} />
             </ListItemButton>
           </NextLink>
         ))}
@@ -85,7 +87,7 @@ export const Sidenav = ({ onNavItemClick }: SidenavProps) => {
             <ListItemIcon>
               <People fontSize="inherit" />
             </ListItemIcon>
-            <ListItemText primary="Utenti" />
+            <ListItemText primary={t("section.users")} />
             <ListItemIcon>
               <ExitToAppRounded color="action" />
             </ListItemIcon>
@@ -96,7 +98,7 @@ export const Sidenav = ({ onNavItemClick }: SidenavProps) => {
             <ListItemIcon>
               <SupervisedUserCircle fontSize="inherit" />
             </ListItemIcon>
-            <ListItemText primary="Gruppi" />
+            <ListItemText primary={t("section.groups")} />
             <ListItemIcon>
               <ExitToAppRounded color="action" />
             </ListItemIcon>

--- a/apps/backoffice/src/components/utils/page-html-head-title.tsx
+++ b/apps/backoffice/src/components/utils/page-html-head-title.tsx
@@ -1,0 +1,18 @@
+import { useTranslation } from "next-i18next";
+import Head from "next/head";
+
+export type PageHtmlHeadTitleProps = {
+  section: string;
+};
+
+export const PageHtmlHeadTitle = ({ section }: PageHtmlHeadTitleProps) => {
+  const { t } = useTranslation();
+  return (
+    <Head>
+      <title>
+        {t("app.title")} | {t(`section.${section}`)}
+      </title>
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </Head>
+  );
+};

--- a/apps/backoffice/src/components/utils/page-html-head-title.tsx
+++ b/apps/backoffice/src/components/utils/page-html-head-title.tsx
@@ -7,11 +7,12 @@ export type PageHtmlHeadTitleProps = {
 
 export const PageHtmlHeadTitle = ({ section }: PageHtmlHeadTitleProps) => {
   const { t } = useTranslation();
+
+  const getTitle = () => `${t("app.title")} | ${t(`section.${section}`)}`;
+
   return (
     <Head>
-      <title>
-        {t("app.title")} | {t(`section.${section}`)}
-      </title>
+      <title>{getTitle()}</title>
       <meta name="viewport" content="width=device-width, initial-scale=1" />
     </Head>
   );

--- a/apps/backoffice/src/pages/_app.tsx
+++ b/apps/backoffice/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { AppProvider } from "@/providers/app";
 import "@/styles/globals.css";
 import { NextPage } from "next";
+import { appWithTranslation } from "next-i18next";
 import type { AppProps } from "next/app";
 import { ReactElement, ReactNode } from "react";
 
@@ -19,4 +20,4 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
   return <AppProvider>{pageContent}</AppProvider>;
 };
 
-export default App;
+export default appWithTranslation(App);

--- a/apps/backoffice/src/pages/apikeys/index.tsx
+++ b/apps/backoffice/src/pages/apikeys/index.tsx
@@ -1,17 +1,27 @@
-import { AppLayout } from "@/layouts/app-layout";
-import { PageLayout } from "@/layouts/page-layout";
-import Head from "next/head";
+import { PageHtmlHeadTitle } from "@/components/utils/page-html-head-title";
+import { AppLayout, PageLayout } from "@/layouts";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ReactElement } from "react";
 
 export default function ApiKeys() {
+  const { t } = useTranslation();
+
   return (
     <>
-      <Head>
-        <title>IO BackOffice | API Key</title>
-      </Head>
+      <PageHtmlHeadTitle section="apikeys" />
       <main>contenuto pagina API Key</main>
     </>
   );
+}
+
+export async function getStaticProps({ locale }: any) {
+  return {
+    props: {
+      // pass the translation props to the page component
+      ...(await serverSideTranslations(locale)),
+    },
+  };
 }
 
 ApiKeys.getLayout = function getLayout(page: ReactElement) {

--- a/apps/backoffice/src/pages/index.tsx
+++ b/apps/backoffice/src/pages/index.tsx
@@ -1,17 +1,27 @@
+import { PageHtmlHeadTitle } from "@/components/utils/page-html-head-title";
 import { AppLayout, PageLayout } from "@/layouts";
-import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ReactElement } from "react";
 
 export default function Home() {
+  const { t } = useTranslation();
+
   return (
     <>
-      <Head>
-        <title>IO BackOffice | Panoramica</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
-      <main>contenuto pagina panoramica</main>
+      <PageHtmlHeadTitle section="overview" />
+      <main>{t("test")}</main>
     </>
   );
+}
+
+export async function getStaticProps({ locale }: any) {
+  return {
+    props: {
+      // pass the translation props to the page component
+      ...(await serverSideTranslations(locale)),
+    },
+  };
 }
 
 Home.getLayout = function getLayout(page: ReactElement) {

--- a/apps/backoffice/src/pages/services/[serviceId].tsx
+++ b/apps/backoffice/src/pages/services/[serviceId].tsx
@@ -1,19 +1,20 @@
+import { PageHtmlHeadTitle } from "@/components/utils/page-html-head-title";
 import { AppLayout, PageLayout } from "@/layouts";
 import { Box, Button } from "@mui/material";
-import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
 export default function ServiceDetails() {
+  const { t } = useTranslation();
   const router = useRouter();
   const serviceId = router.query.serviceId as string;
 
   return (
     <>
-      <Head>
-        <title>IO BackOffice | Dettagli Servizio</title>
-      </Head>
+      <PageHtmlHeadTitle section="services" />
       <main>
         <Box>contenuto pagina dettagli servizio {serviceId}</Box>
         <Box paddingY={3}>
@@ -30,6 +31,14 @@ export default function ServiceDetails() {
       </main>
     </>
   );
+}
+
+export async function getServerSideProps({ locale }: any) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale)),
+    },
+  };
 }
 
 ServiceDetails.getLayout = function getLayout(page: ReactElement) {

--- a/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
+++ b/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
@@ -1,19 +1,21 @@
+import { PageHtmlHeadTitle } from "@/components/utils/page-html-head-title";
 import { AppLayout, PageLayout } from "@/layouts";
 import { Box, Button } from "@mui/material";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
 export default function EditService() {
+  const { t } = useTranslation();
   const router = useRouter();
   const serviceId = router.query.serviceId as string;
 
   return (
     <>
-      <Head>
-        <title>IO BackOffice | Modifica Servizio</title>
-      </Head>
+      <PageHtmlHeadTitle section="services" />
       <main>
         <Box>contenuto pagina {serviceId}</Box>
         <Box paddingY={3}>
@@ -30,6 +32,14 @@ export default function EditService() {
       </main>
     </>
   );
+}
+
+export async function getServerSideProps({ locale }: any) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale)),
+    },
+  };
 }
 
 EditService.getLayout = function getLayout(page: ReactElement) {

--- a/apps/backoffice/src/pages/services/index.tsx
+++ b/apps/backoffice/src/pages/services/index.tsx
@@ -1,15 +1,17 @@
+import { PageHtmlHeadTitle } from "@/components/utils/page-html-head-title";
 import { AppLayout, PageLayout } from "@/layouts";
 import { Box, Button } from "@mui/material";
-import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import NextLink from "next/link";
 import { ReactElement } from "react";
 
 export default function Services() {
+  const { t } = useTranslation();
+
   return (
     <>
-      <Head>
-        <title>IO BackOffice | Servizi</title>
-      </Head>
+      <PageHtmlHeadTitle section="services" />
       <main>
         <Box>contenuto pagina lista servizi</Box>
         <Box paddingY={3}>
@@ -37,6 +39,15 @@ export default function Services() {
       </main>
     </>
   );
+}
+
+export async function getStaticProps({ locale }: any) {
+  return {
+    props: {
+      // pass the translation props to the page component
+      ...(await serverSideTranslations(locale)),
+    },
+  };
 }
 
 Services.getLayout = function getLayout(page: ReactElement) {

--- a/apps/backoffice/src/pages/services/new-service.tsx
+++ b/apps/backoffice/src/pages/services/new-service.tsx
@@ -1,15 +1,17 @@
+import { PageHtmlHeadTitle } from "@/components/utils/page-html-head-title";
 import { AppLayout, PageLayout } from "@/layouts";
 import { Box, Button } from "@mui/material";
-import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import NextLink from "next/link";
 import { ReactElement } from "react";
 
 export default function NewService() {
+  const { t } = useTranslation();
+
   return (
     <>
-      <Head>
-        <title>IO BackOffice | Nuovo Servizio</title>
-      </Head>
+      <PageHtmlHeadTitle section="services" />
       <main>
         <Box>contenuto pagina</Box>
         <Box paddingY={3}>
@@ -26,6 +28,15 @@ export default function NewService() {
       </main>
     </>
   );
+}
+
+export async function getStaticProps({ locale }: any) {
+  return {
+    props: {
+      // pass the translation props to the page component
+      ...(await serverSideTranslations(locale)),
+    },
+  };
 }
 
 NewService.getLayout = function getLayout(page: ReactElement) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,7 +351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.8.7":
   version: 7.22.6
   resolution: "@babel/runtime@npm:7.22.6"
   dependencies:
@@ -1105,9 +1105,12 @@ __metadata:
     "@vitest/coverage-v8": ^0.34.1
     eslint: 8.46.0
     eslint-config-next: 13.4.12
+    i18next: ^23.4.1
     next: 13.4.12
+    next-i18next: ^14.0.0
     react: 18.2.0
     react-dom: 18.2.0
+    react-i18next: ^13.0.3
     typescript: 5.1.6
     vitest: ^0.34.1
   languageName: unknown
@@ -1868,6 +1871,16 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 0196dacc275ac3ce89d7364885cb08e7fb61f53ca101f65886dbf1daf9b7eb05c0943e2e4bbd01b0cc5e50f37e0eea7e4cbe97d0304094411ac73e1b7998f4da
+  languageName: node
+  linkType: hard
+
+"@types/hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
   languageName: node
   linkType: hard
 
@@ -3669,6 +3682,13 @@ __metadata:
   version: 2.1.4
   resolution: "cookiejar@npm:2.1.4"
   checksum: c4442111963077dc0e5672359956d6556a195d31cbb35b528356ce5f184922b99ac48245ac05ed86cf993f7df157c56da10ab3efdadfed79778a0d9b1b092d5b
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3":
+  version: 3.32.0
+  resolution: "core-js@npm:3.32.0"
+  checksum: 52921395028550e4c9d21d47b9836439bb5b6b9eefc34d45a3948a68d81fdd093acc0fadf69f9cf632b82f01f95f22f484408a93dd9e940b19119ac204cd2925
   languageName: node
   linkType: hard
 
@@ -5949,7 +5969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -5969,6 +5989,15 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
+  languageName: node
+  linkType: hard
+
+"html-parse-stringify@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "html-parse-stringify@npm:3.0.1"
+  dependencies:
+    void-elements: 3.1.0
+  checksum: 334fdebd4b5c355dba8e95284cead6f62bf865a2359da2759b039db58c805646350016d2017875718bc3c4b9bf81a0d11be5ee0cf4774a3a5a7b97cde21cfd67
   languageName: node
   linkType: hard
 
@@ -6068,6 +6097,22 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"i18next-fs-backend@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "i18next-fs-backend@npm:2.1.5"
+  checksum: 4607e879de8195ff0bf11bdb2367f1c45f947160404b64f52be7e438ae27288e0d11a9b53a4bde2d75a77ac7f3255aa531a4381870e278e72f85ead222ffed31
+  languageName: node
+  linkType: hard
+
+"i18next@npm:^23.4.1":
+  version: 23.4.1
+  resolution: "i18next@npm:23.4.1"
+  dependencies:
+    "@babel/runtime": ^7.22.5
+  checksum: d9283d3de5e4ea2e55f61bd8ada98b5aef1b7db35a69c8ccf193367c5cbee6f795a67c5cd8a7af511e56c12b021b91d97253863b6c2336726925d20518fb02cc
   languageName: node
   linkType: hard
 
@@ -7722,6 +7767,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-i18next@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "next-i18next@npm:14.0.0"
+  dependencies:
+    "@babel/runtime": ^7.20.13
+    "@types/hoist-non-react-statics": ^3.3.1
+    core-js: ^3
+    hoist-non-react-statics: ^3.3.2
+    i18next-fs-backend: ^2.1.5
+  peerDependencies:
+    i18next: ^23.0.1
+    next: ">= 12.0.0"
+    react: ">= 17.0.2"
+    react-i18next: ^13.0.0
+  checksum: a699f6fdee650a2456c463d59910bf38d9f891d224c00de639b15740e8cbf939a2469c8c733007b4f1c2fe0f85c18d43b6f1e814f2127ef30a0d3a28a354dc1d
+  languageName: node
+  linkType: hard
+
 "next@npm:13.4.12":
   version: 13.4.12
   resolution: "next@npm:13.4.12"
@@ -8907,6 +8970,24 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+  languageName: node
+  linkType: hard
+
+"react-i18next@npm:^13.0.3":
+  version: 13.0.3
+  resolution: "react-i18next@npm:13.0.3"
+  dependencies:
+    "@babel/runtime": ^7.22.5
+    html-parse-stringify: ^3.0.1
+  peerDependencies:
+    i18next: ">= 23.2.3"
+    react: ">= 16.8.0"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 5b23c517204ac7ce66191368b185bb278c34e75778714ffdae84dd4672fdaf8c500c7965cb87508c686de55ac7c8853f05134ee61aa21add1b8c8e02bcc0a0a4
   languageName: node
   linkType: hard
 
@@ -11050,6 +11131,13 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 39d270e78be0ce06cb348c6c1e92517aa7269ad8c51f5432349849ca1615c18eeaeb635a49d16eedcb9b77a7a19186723f906d286d819368c15d086cecacfb0d
+  languageName: node
+  linkType: hard
+
+"void-elements@npm:3.1.0":
+  version: 3.1.0
+  resolution: "void-elements@npm:3.1.0"
+  checksum: 0390f818107fa8fce55bb0a5c3f661056001c1d5a2a48c28d582d4d847347c2ab5b7f8272314cac58acf62345126b6b09bea623a185935f6b1c3bbce0dfd7f7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add multilingual _(Italian, English)_ feature to IO BackOffice.
_Follow the commit history for a step-by-step understanding of the implementation._

Below is the documentation followed in the development of the feature:
- [NextJS official docs](https://nextjs.org/docs/pages/building-your-application/routing/internationalization)
- [Codemotion tutorial](https://www.codemotion.com/magazine/frontend/multilingual-site-in-next-js-with-next-i18next/)

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/c10d62c5-6ceb-4b1b-a79b-ee848eb6ae55


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
