### PR TITLE
fix: [IOPAE-517] NextJS Routing conflict: rename page apikeys to keys

### DIFF
--- a/.changeset/fluffy-wombats-check.md
+++ b/.changeset/fluffy-wombats-check.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/backoffice": patch
+---
+
+Fix apikeys page route (renamed to keys)

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -1,8 +1,4 @@
 {
-  "apikeys": {
-    "title": "API Keys",
-    "subtitle": "View and manage security keys for APIs."
-  },
   "app": {
     "title": "IO BackOffice"
   },
@@ -18,13 +14,9 @@
   "section": {
     "overview": "Overview",
     "services": "Services",
-    "apikeys": "API Keys",
+    "keys": "API Keys",
     "users": "Users",
     "groups": "Groups"
-  },
-  "services": {
-    "title": "Services",
-    "subtitle": "View and manage the services of your Institution."
   },
   "test": "This is a translation test"
 }

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -1,8 +1,4 @@
 {
-  "apikeys": {
-    "title": "Chiavi API",
-    "subtitle": "Visualizza e gestisci le chiavi di sicurezza per le API."
-  },
   "app": {
     "title": "IO BackOffice"
   },
@@ -18,13 +14,9 @@
   "section": {
     "overview": "Panoramica",
     "services": "Servizi",
-    "apikeys": "Chiavi API",
+    "keys": "Chiavi API",
     "users": "Utenti",
     "groups": "Gruppi"
-  },
-  "services": {
-    "title": "Servizi",
-    "subtitle": "Visualizza e gestisci i Servizi del tuo Ente."
   },
   "test": "Questo è un test di traduzione"
 }

--- a/apps/backoffice/src/components/sidenav/index.tsx
+++ b/apps/backoffice/src/components/sidenav/index.tsx
@@ -44,9 +44,9 @@ export const Sidenav = ({ onNavItemClick }: SidenavProps) => {
       text: "section.services",
     },
     {
-      href: "/apikeys",
+      href: "/keys",
       icon: <VpnKey fontSize="inherit" />,
-      text: "section.apikeys",
+      text: "section.keys",
     },
   ];
 

--- a/apps/backoffice/src/pages/keys/index.tsx
+++ b/apps/backoffice/src/pages/keys/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ReactElement } from "react";
 
-export default function ApiKeys() {
+export default function Keys() {
   const { t } = useTranslation();
 
   return (
@@ -24,7 +24,7 @@ export async function getStaticProps({ locale }: any) {
   };
 }
 
-ApiKeys.getLayout = function getLayout(page: ReactElement) {
+Keys.getLayout = function getLayout(page: ReactElement) {
   return (
     <AppLayout>
       <PageLayout title="API Key">{page}</PageLayout>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The routing of the "_**API Keys"**_ section _(where Manage key will be present)_, was defined by the `apikeys` route _(io-services-cms/apps/backoffice/src/pages/apikeys/index.tsx)_

**Problem:**
The fact that route name starts with **"api"** generates a conflict in the _NextJs routing system_ which identifies that route as a _Route Handler API_ _(io-services-cms/apps/backoffice/src/app/api/ …)_

**Solution:**
We rename the route `apikeys` in `keys` _(io-services-cms/apps/backoffice/src/pages/keys/index.tsx)_
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
