### PR TITLE
chore: skip currently deleted services on legacy review

### DIFF
--- a/.changeset/lazy-balloons-pull.md
+++ b/.changeset/lazy-balloons-pull.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Skip currently Deleted Services on OnRequestReviewLegacy and RequestReviewLegacyChecker

--- a/.github/workflows/azure-deploy.yaml
+++ b/.github/workflows/azure-deploy.yaml
@@ -31,6 +31,10 @@ jobs:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           container_app_environment_name: ${{ secrets.AZURE_CONTAINER_APP_ENVIRONMENT_NAME }}
           resource_group_name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+<<<<<<< Updated upstream
+=======
+          self_hosted_runner_image_tag: v1.4.2@sha256:330b40e255e12c798f4a6e784efc3189e12316499dd399a3e3e6487c9b32f824
+>>>>>>> Stashed changes
           pat_token: ${{ secrets.BOT_TOKEN }}
 
   runner_job:

--- a/apps/io-services-cms-webapp/src/lib/clients/__tests__/jira-legacy-client.test.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/__tests__/jira-legacy-client.test.ts
@@ -74,19 +74,30 @@ describe("[JiraLegacyClient] searchJiraIssueByServiceId", () => {
     }
   });
 
+<<<<<<< Updated upstream
   it("should return the deserializzation error if searchJiraIssueByServiceId body extractions json end up in failure", async () => {
     const mockHeaders = new Map();
     mockHeaders.set("anHeader", "anHeaderValue");
 
+=======
+  it("should return the deserializzation error if searchJiraIssueByServiceId body extractions both json and text end up in failure", async () => {
+>>>>>>> Stashed changes
     const mockFetch = vitest.fn().mockImplementation(async () => ({
       json: vitest.fn(() =>
         Promise.reject(new Error("Bad Error on JSON deserialize"))
       ),
+<<<<<<< Updated upstream
       headers: {
         forEach: (callback) => mockHeaders.forEach(callback),
         get: (key) => mockHeaders.get(key),
       },
       status: 500,
+=======
+      text: vitest.fn(() =>
+        Promise.reject(new Error("Bad Error on Text deserialize"))
+      ),
+      status: 429,
+>>>>>>> Stashed changes
     }));
 
     const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
@@ -103,7 +114,37 @@ describe("[JiraLegacyClient] searchJiraIssueByServiceId", () => {
     if (E.isLeft(issues)) {
       expect(issues.left).toHaveProperty(
         "message",
+<<<<<<< Updated upstream
         'Error parsing Jira response, statusCode: 500, headers: {"anHeader":"anHeaderValue"}, error: Bad Error on JSON deserialize'
+=======
+        "Error parsing Jira response: Bad Error on JSON deserialize"
+      );
+    }
+  });
+
+  it("should return the text response if searchJiraIssueByServiceId body is not a valid json", async () => {
+    const mockFetch = vitest.fn().mockImplementation(async () => ({
+      json: vitest.fn(() => Promise.reject(new Error("Bad Error"))),
+      text: vitest.fn(() => Promise.resolve("Not Json Response")),
+      status: 429,
+    }));
+
+    const client = jiraLegacyClient(JIRA_CONFIG, mockFetch);
+
+    const issues = await client.searchJiraIssueByServiceId(aServiceId)();
+
+    expect(mockFetch).toBeCalledWith(expect.any(String), {
+      body: expect.any(String),
+      headers: expect.any(Object),
+      method: "POST",
+    });
+
+    expect(E.isLeft(issues)).toBeTruthy();
+    if (E.isLeft(issues)) {
+      expect(issues.left).toHaveProperty(
+        "message",
+        "Received a not JSON response from JIRA, the content is: Not Json Response"
+>>>>>>> Stashed changes
       );
     }
   });

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
@@ -119,9 +119,12 @@ export const jiraLegacyClient = (
       ),
       TE.chain((response) =>
         pipe(
-          TE.tryCatch(
-            () => response.json(),
+          TE.tryCatch(() => response.json(), E.toError),
+          TE.fold(
+            // in case the response does not contain a valid json body, we try to parse the response as text
+            // and include the content in the error message so that will be logged
             (err) =>
+<<<<<<< Updated upstream
               new Error(
                 `Error parsing Jira response, statusCode: ${
                   response.status
@@ -129,6 +132,27 @@ export const jiraLegacyClient = (
                   E.toError(err).message
                 }`
               )
+=======
+              pipe(
+                TE.tryCatch(() => response.text(), E.toError),
+                TE.mapLeft(
+                  () =>
+                    new Error(
+                      `Error parsing Jira response: ${E.toError(err).message}`
+                    )
+                ),
+                TE.fold(
+                  (err) => TE.left(err),
+                  (text) =>
+                    TE.left(
+                      new Error(
+                        `Received a not JSON response from JIRA, the content is: ${text}`
+                      )
+                    )
+                )
+              ),
+            (responseBody) => TE.right(responseBody)
+>>>>>>> Stashed changes
           ),
           TE.chain((responseBody) =>
             pipe(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
In order to prevent unmwanted status changes from `deleted` -> `other_status` we will skip services marked as `deleted` in `OnRequestReviewLegacy` and `RequestReviewLegacyChecker` Azure Funtions
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
