### PR TITLE
chore: skip currently deleted services on legacy review

### DIFF
--- a/.changeset/twenty-pigs-train.md
+++ b/.changeset/twenty-pigs-train.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Skip currently deleted services on OnRequestReviewLegacy and RequestReviewLegacyChecker

--- a/apps/io-services-cms-webapp/src/reviewer/request-review-legacy-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/request-review-legacy-handler.ts
@@ -71,33 +71,48 @@ const processItem = (
     fsmLifecycleClient.fetch,
     TE.chain(
       flow(
+        TE.fromOption(
+          () => new Error(`Service ${requestReviewLegacy.serviceId} not found `)
+        )
+      )
+    ),
+    // in case of deleted do nothing
+    TE.map(
+      O.fromPredicate(
+        (currentService) => currentService.fsm.state !== "deleted"
+      )
+    ),
+    TE.chain(
+      flow(
         O.fold(
-          () =>
-            TE.left(
-              new Error(`Service ${requestReviewLegacy.serviceId} not found `)
-            ),
+          () => TE.right(void 0),
           flow(
             // 1. set to submitted the service doing an override
             setToSubmitted,
             (submittedService) =>
-              fsmLifecycleClient.override(submittedService.id, submittedService)
+              fsmLifecycleClient.override(
+                submittedService.id,
+                submittedService
+              ),
+            // 2. create entry in service review legacy table
+            TE.chain((_) =>
+              pipe(
+                dao.insert({
+                  service_id: requestReviewLegacy.serviceId,
+                  service_version: new Date()
+                    .getTime()
+                    .toString() as NonEmptyString,
+                  ticket_id: requestReviewLegacy.ticketId,
+                  ticket_key: requestReviewLegacy.ticketKey,
+                  status: "PENDING",
+                  extra_data: {},
+                }),
+                TE.mapLeft(E.toError),
+                TE.map((_) => void 0)
+              )
+            )
           )
         )
-      )
-    ),
-    // 2. create entry in service review legacy table
-    TE.chain((_) =>
-      pipe(
-        dao.insert({
-          service_id: requestReviewLegacy.serviceId,
-          service_version: new Date().getTime().toString() as NonEmptyString,
-          ticket_id: requestReviewLegacy.ticketId,
-          ticket_key: requestReviewLegacy.ticketKey,
-          status: "PENDING",
-          extra_data: {},
-        }),
-        TE.mapLeft(E.toError),
-        TE.map((_) => void 0)
       )
     )
   );

--- a/apps/io-services-cms-webapp/src/reviewer/request-review-legacy-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/request-review-legacy-handler.ts
@@ -70,10 +70,8 @@ const processItem = (
     requestReviewLegacy.serviceId,
     fsmLifecycleClient.fetch,
     TE.chain(
-      flow(
-        TE.fromOption(
-          () => new Error(`Service ${requestReviewLegacy.serviceId} not found `)
-        )
+      TE.fromOption(
+        () => new Error(`Service ${requestReviewLegacy.serviceId} not found `)
       )
     ),
     // in case of deleted do nothing

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -135,6 +135,7 @@ const makeServiceLifecycleApply = (
             ),
           flow(
             buildUpdatedServiceLifecycleItem(jiraIssue.fields.status.name),
+            O.fromPredicate((service) => service.fsm.state !== "deleted"),
             O.fold(
               () => {
                 logger.log(
@@ -158,23 +159,18 @@ const makeServiceLifecycleApply = (
 
 const buildUpdatedServiceLifecycleItem =
   (issueStatus: JiraIssue["fields"]["status"]["name"]) =>
-  (service: ServiceLifecycle.ItemType): O.Option<ServiceLifecycle.ItemType> =>
-    pipe(
-      service,
-      O.fromPredicate((srv) => srv.fsm.state !== "deleted"),
-      O.map((srv) => ({
-        ...srv,
-        fsm: {
-          ...srv.fsm,
-          state:
-            issueStatus === "REJECTED"
-              ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                ("rejected" as any)
-              : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                ("approved" as any),
-        },
-      }))
-    );
+  (service: ServiceLifecycle.ItemType): ServiceLifecycle.ItemType => ({
+    ...service,
+    fsm: {
+      ...service.fsm,
+      state:
+        issueStatus === "REJECTED"
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ("rejected" as any)
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ("approved" as any),
+    },
+  });
 
 export const createReviewLegacyCheckerHandler =
   (

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -94,7 +94,7 @@ export const updateReview =
       issueItemPairs,
       RA.traverse(TE.ApplicativePar)(({ issue, item }) =>
         sequenceT(TE.ApplicativeSeq)(
-          makeServiceLifecycleApply(item, issue, fsmLifecycleClient, context),
+          makeServiceLifecycleApply(context)(item, issue, fsmLifecycleClient),
           pipe(
             dao.updateStatus({
               ...item,
@@ -114,48 +114,54 @@ export const updateReview =
     );
   };
 
-const makeServiceLifecycleApply = (
-  serviceReview: ServiceReviewRowDataTable,
-  jiraIssue: ProcessedJiraIssue,
-  fsmLifecycleClient: ServiceLifecycle.FsmClient,
-  context: Context
-) => {
-  const logger = getLogger(context, logPrefix, "makeServiceLifecycleApply");
-  return pipe(
-    serviceReview.service_id,
-    fsmLifecycleClient.fetch,
-    TE.chain(
-      flow(
-        O.fold(
-          () =>
-            TE.left(
-              new Error(
-                `Service ${serviceReview.service_id} not found cannot ovverride after legacy review`
-              )
-            ),
-          flow(
-            O.fromPredicate((service) => service.fsm.state !== "deleted"),
-            O.fold(
-              () => {
-                logger.log(
-                  "warn",
-                  `Service ${serviceReview.service_id} is deleted, skipping it`
-                );
-                return TE.right(void 0);
-              },
-              flow(
-                buildUpdatedServiceLifecycleItem(jiraIssue.fields.status.name),
-                (updateService) =>
-                  fsmLifecycleClient.override(updateService.id, updateService),
-                TE.map((_) => void 0)
+const makeServiceLifecycleApply =
+  (context: Context) =>
+  (
+    serviceReview: ServiceReviewRowDataTable,
+    jiraIssue: ProcessedJiraIssue,
+    fsmLifecycleClient: ServiceLifecycle.FsmClient
+  ) => {
+    const logger = getLogger(context, logPrefix, "makeServiceLifecycleApply");
+    return pipe(
+      serviceReview.service_id,
+      fsmLifecycleClient.fetch,
+      TE.chain(
+        flow(
+          O.fold(
+            () =>
+              TE.left(
+                new Error(
+                  `Service ${serviceReview.service_id} not found cannot ovverride after legacy review`
+                )
+              ),
+            flow(
+              O.fromPredicate((service) => service.fsm.state !== "deleted"),
+              O.fold(
+                () => {
+                  logger.log(
+                    "warn",
+                    `Service ${serviceReview.service_id} is deleted, skipping it`
+                  );
+                  return TE.right(void 0);
+                },
+                flow(
+                  buildUpdatedServiceLifecycleItem(
+                    jiraIssue.fields.status.name
+                  ),
+                  (updateService) =>
+                    fsmLifecycleClient.override(
+                      updateService.id,
+                      updateService
+                    ),
+                  TE.map((_) => void 0)
+                )
               )
             )
           )
         )
       )
-    )
-  );
-};
+    );
+  };
 
 const buildUpdatedServiceLifecycleItem =
   (issueStatus: JiraIssue["fields"]["status"]["name"]) =>

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -134,7 +134,6 @@ const makeServiceLifecycleApply = (
               )
             ),
           flow(
-            buildUpdatedServiceLifecycleItem(jiraIssue.fields.status.name),
             O.fromPredicate((service) => service.fsm.state !== "deleted"),
             O.fold(
               () => {
@@ -144,11 +143,12 @@ const makeServiceLifecycleApply = (
                 );
                 return TE.right(void 0);
               },
-              (updateService) =>
-                pipe(
+              flow(
+                buildUpdatedServiceLifecycleItem(jiraIssue.fields.status.name),
+                (updateService) =>
                   fsmLifecycleClient.override(updateService.id, updateService),
-                  TE.map((_) => void 0)
-                )
+                TE.map((_) => void 0)
+              )
             )
           )
         )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
In order to prevent unwanted status changes from `deleted` -> `other_status` we will skip services marked as `deleted` in `OnRequestReviewLegacy` and `RequestReviewLegacyChecker` Azure Functions
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
