### PR TITLE
[#IOPAE-536] Automatic Service Approval Capability

### DIFF
--- a/.changeset/strong-frogs-beam.md
+++ b/.changeset/strong-frogs-beam.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Add Automatic Service Approval Capability in RequestReviewHandler

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Please refer to our [development guide](./docs/terraform-development.md) before 
 
 The table below describes the _features that can be activated/deactivated_, either globally or by restricting them to specific users, by modifying specific configuration parameters, called **_FeatureFlags_**, in the application.
 
-| Configuration Parameter                            | Value Type     | Description                                                                                        |
-| -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
-| `USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST` | `List<String>` | **Automatically approve** review requests for **services** related to Users in the inclusion list. |
+| Configuration Parameter                            | Value Type     | Description                                                                                        | Example               |
+| -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- | --------------------- |
+| `USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST` | `List<String>` | **Automatically approve** review requests for **services** related to Users in the inclusion list. | `user1,user2,..userN` |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # IO Services CMS
+
 Manages Service lifecycle and publication.
 
 [![Infra Drift Detection](https://github.com/pagopa/io-services-cms/actions/workflows/infra-drift-detection.yml/badge.svg?branch=master)](https://github.com/pagopa/io-services-cms/actions/workflows/infra-drift-detection.yml)
@@ -11,13 +12,24 @@ Manages Service lifecycle and publication.
 ![architecture](./docs/infra.drawio.svg)
 
 ## Folder structure
+
 TBD need to clear
 
 ## Development
 
 ### Cloud resources
+
 Cloud resources are defined using terraform for infrastructure-as-code development. There are two terraform projects in this repository:
-* `infra` define the resources used by the application
-* `.identity` connects GitHub's workflow to be executed by our custom runners (hence inheriting resource access policies). 
+
+- `infra` define the resources used by the application
+- `.identity` connects GitHub's workflow to be executed by our custom runners (hence inheriting resource access policies).
 
 Please refer to our [development guide](./docs/terraform-development.md) before contributing.
+
+## Feature Flags
+
+The table below describes the _features that can be activated/deactivated_, either globally or by restricting them to specific users, by modifying specific configuration parameters, called **_FeatureFlags_**, in the application.
+
+| Configuration Parameter                            | Value Type     | Description                                                                                        |
+| -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
+| `USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST` | `List<String>` | **Automatically approve** review requests for **services** related to Users in the inclusion list. |

--- a/apps/io-services-cms-webapp/env.example
+++ b/apps/io-services-cms-webapp/env.example
@@ -71,3 +71,9 @@ SERVICEID_QUALITY_CHECK_EXCLUSION_LIST=
 
 # UserId List allowed to sync services from CMS to Legacy
 USERID_CMS_TO_LEGACY_SYNC_INCLUSION_LIST=
+# UserId List allowed to sync services from Legacy to CMS
+USERID_LEGACY_TO_CMS_SYNC_INCLUSION_LIST=
+# UserId List allowed to sync JIRA ticket events from Legacy to CMS
+USERID_REQUEST_REVIEW_LEGACY_INCLUSION_LIST=
+# UserId List allowed to automatic service approval
+USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST=

--- a/apps/io-services-cms-webapp/src/config.ts
+++ b/apps/io-services-cms-webapp/src/config.ts
@@ -157,17 +157,26 @@ const ServiceIdQualityCheckExclusionList = t.type({
 });
 
 const FeatureFlags = t.type({
-  // UserId List allowed to sync services from CMS to Legacy
+  /**
+   * UserId List allowed to sync services from CMS to Legacy
+   * @deprecated this feature flag will be removed in future releases
+   */
   USERID_CMS_TO_LEGACY_SYNC_INCLUSION_LIST: withDefault(
     CommaSeparatedListOf(NonEmptyString),
     []
   ),
-  // UserId List allowed to sync services from CMS to Legacy
+  /**
+   * UserId List allowed to sync services from CMS to Legacy
+   * @deprecated this feature flag will be removed in future releases
+   */
   USERID_LEGACY_TO_CMS_SYNC_INCLUSION_LIST: withDefault(
     CommaSeparatedListOf(NonEmptyString),
     []
   ),
-  // UserId List allowed to sync JIRA ticket events from Legacy to CMS
+  /**
+   * UserId List allowed to sync JIRA ticket events from Legacy to CMS
+   * @deprecated this feature flag will be removed in future releases
+   */
   USERID_REQUEST_REVIEW_LEGACY_INCLUSION_LIST: withDefault(
     CommaSeparatedListOf(NonEmptyString),
     []

--- a/apps/io-services-cms-webapp/src/config.ts
+++ b/apps/io-services-cms-webapp/src/config.ts
@@ -172,6 +172,11 @@ const FeatureFlags = t.type({
     CommaSeparatedListOf(NonEmptyString),
     []
   ),
+  // UserId List allowed to automatic service approval
+  USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST: withDefault(
+    CommaSeparatedListOf(NonEmptyString),
+    []
+  ),
 });
 
 // Global app configuration

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -13,11 +13,11 @@ import {
   SUBSCRIPTION_CIDRS_COLLECTION_NAME,
   SubscriptionCIDRsModel,
 } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/Option";
 import * as RA from "fp-ts/ReadonlyArray";
 import * as RR from "fp-ts/ReadonlyRecord";
 import { pipe } from "fp-ts/lib/function";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { getConfigOrThrow } from "./config";
 import { createRequestHistoricizationHandler } from "./historicizer/request-historicization-handler";
 import {
@@ -33,7 +33,6 @@ import { createRequestReviewHandler } from "./reviewer/request-review-handler";
 import { createReviewCheckerHandler } from "./reviewer/review-checker-handler";
 import { createRequestSyncCmsHandler } from "./synchronizer/request-sync-cms-handler";
 import { createRequestSyncLegacyHandler } from "./synchronizer/request-sync-legacy-handler";
-import { apimProxy } from "./utils/apim-proxy";
 import {
   cosmosdbClient,
   cosmosdbInstance as legacyCosmosDbInstance,
@@ -47,8 +46,9 @@ import { handler as onServicePublicationChangeHandler } from "./watchers/on-serv
 import { createWebServer } from "./webservice";
 
 import { createRequestReviewLegacyHandler } from "./reviewer/request-review-legacy-handler";
-import { initTelemetryClient } from "./utils/applicationinsight";
 import { createReviewLegacyCheckerHandler } from "./reviewer/review-legacy-checker-handler";
+import { initTelemetryClient } from "./utils/applicationinsight";
+import { apimProxy } from "./utils/apim-proxy";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
 const BASE_PATH = require("../host.json").extensions.http.routePrefix;
@@ -115,11 +115,10 @@ export const httpEntryPoint = pipe(
 export const createRequestReviewEntryPoint = createRequestReviewHandler(
   getDao(config),
   jiraProxy(jiraClient(config)),
-  apimProxy(
-    getApimClient(config, config.AZURE_SUBSCRIPTION_ID),
-    config.AZURE_APIM_RESOURCE_GROUP,
-    config.AZURE_APIM
-  )
+  apimProxy(apimClient, config.AZURE_APIM_RESOURCE_GROUP, config.AZURE_APIM),
+  fsmLifecycleClient,
+  apimClient,
+  config
 );
 
 export const createRequestPublicationEntryPoint =

--- a/apps/io-services-cms-webapp/src/reviewer/__tests__/request-review-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/__tests__/request-review-handler.test.ts
@@ -196,9 +196,10 @@ describe("Service Review Handler", () => {
       aDelegate
     );
     expect(mainMockServiceReviewDao.insert).toBeCalledWith(aDbInsertData);
+    expect(mockFsmLifecycleClient.approve).not.toHaveBeenCalled();
   });
 
-  it("should approve the service in when the user is in inclusionList", async () => {
+  it("should approve the service when the user is in inclusionList", async () => {
     const mockConfig = {
       USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST: [anUserId],
     } as unknown as IConfig;
@@ -253,6 +254,7 @@ describe("Service Review Handler", () => {
     expect(mainMockApimProxy.getDelegateFromServiceId).not.toBeCalled();
     expect(mockJiraProxy.createJiraIssue).not.toBeCalled();
     expect(mainMockServiceReviewDao.insert).toBeCalledWith(aDbInsertData);
+    expect(mockFsmLifecycleClient.approve).not.toHaveBeenCalled();
   });
 
   it("should have a generic error if getPendingJiraIssueByServiceId returns an Error", async () => {
@@ -285,6 +287,7 @@ describe("Service Review Handler", () => {
     expect(mainMockApimProxy.getDelegateFromServiceId).not.toBeCalled();
     expect(mockJiraProxy.createJiraIssue).not.toBeCalled();
     expect(mainMockServiceReviewDao.insert).not.toBeCalled();
+    expect(mockFsmLifecycleClient.approve).not.toHaveBeenCalled();
   });
 
   it("should have a generic error if getDelegateFromServiceId returns an ApimError", async () => {
@@ -316,6 +319,7 @@ describe("Service Review Handler", () => {
     expect(mockApimProxy.getDelegateFromServiceId).toBeCalledWith(aService.id);
     expect(mainMockJiraProxy.createJiraIssue).not.toBeCalled();
     expect(mainMockServiceReviewDao.insert).not.toBeCalled();
+    expect(mockFsmLifecycleClient.approve).not.toHaveBeenCalled();
   });
 
   it("should have a generic error if createJiraIssue returns an Error", async () => {
@@ -352,6 +356,7 @@ describe("Service Review Handler", () => {
     );
     expect(mockJiraProxy.createJiraIssue).toBeCalledWith(aService, aDelegate);
     expect(mainMockServiceReviewDao.insert).not.toBeCalled();
+    expect(mockFsmLifecycleClient.approve).not.toHaveBeenCalled();
   });
 
   it("should have a generic error if insert on db returns an Error", async () => {
@@ -389,5 +394,6 @@ describe("Service Review Handler", () => {
       aDelegate
     );
     expect(mockServiceReviewDao.insert).toBeCalledWith(aDbInsertData);
+    expect(mockFsmLifecycleClient.approve).not.toHaveBeenCalled();
   });
 });

--- a/apps/io-services-cms-webapp/src/reviewer/request-review-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/request-review-handler.ts
@@ -1,14 +1,20 @@
-import { Queue } from "@io-services-cms/models";
+import { ApiManagementClient } from "@azure/arm-apimanagement";
+import { Queue, ServiceLifecycle } from "@io-services-cms/models";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
+import * as B from "fp-ts/lib/boolean";
 import { flow, pipe } from "fp-ts/lib/function";
 import { Json } from "io-ts-types";
+import { IConfig } from "../config";
 import { withJsonInput } from "../lib/azure/misc";
+import { CreateJiraIssueResponse } from "../lib/clients/jira-client";
 import { ApimProxy } from "../utils/apim-proxy";
-import { ServiceReviewDao } from "../utils/service-review-dao";
+import { isUserAllowedForAutomaticApproval } from "../utils/feature-flag-handler";
 import { JiraProxy } from "../utils/jira-proxy";
+import { ServiceReviewDao } from "../utils/service-review-dao";
 
 const parseIncomingMessage = (
   queueItem: Json
@@ -19,10 +25,73 @@ const parseIncomingMessage = (
     E.mapLeft(flow(readableReport, (_) => new Error(_)))
   );
 
+const createJiraTicket =
+  (apimProxy: ApimProxy, jiraProxy: JiraProxy) =>
+  (
+    service: Queue.RequestReviewItem
+  ): TE.TaskEither<Error, CreateJiraIssueResponse> =>
+    pipe(
+      service.id,
+      apimProxy.getDelegateFromServiceId,
+      TE.mapLeft(E.toError),
+      TE.chain((delegate) =>
+        pipe(
+          jiraProxy.createJiraIssue(service, delegate),
+          TE.mapLeft(E.toError)
+        )
+      )
+    );
+
+const saveTicketReference =
+  (dao: ServiceReviewDao, service: Queue.RequestReviewItem) =>
+  (ticket: CreateJiraIssueResponse) =>
+    pipe(
+      dao.insert({
+        service_id: service.id,
+        service_version: service.version,
+        ticket_id: ticket.id,
+        ticket_key: ticket.key,
+        status: "PENDING",
+        extra_data: {},
+      }),
+      TE.mapLeft(E.toError)
+    );
+
+const approveService =
+  (fsmLifecycleClient: ServiceLifecycle.FsmClient) =>
+  (service: Queue.RequestReviewItem): TE.TaskEither<Error, void> =>
+    pipe(
+      fsmLifecycleClient.approve(service.id, {
+        approvalDate: new Date().toISOString() as NonEmptyString,
+      }),
+      TE.map((_) => void 0)
+    );
+
+const sendServiceToReview =
+  (dao: ServiceReviewDao, jiraProxy: JiraProxy, apimProxy: ApimProxy) =>
+  (service: Queue.RequestReviewItem): TE.TaskEither<Error, void> =>
+    pipe(
+      service.id,
+      jiraProxy.getPendingJiraIssueByServiceId,
+      TE.chain(
+        flow(
+          O.fold(
+            () => createJiraTicket(apimProxy, jiraProxy)(service),
+            TE.right
+          )
+        )
+      ),
+      TE.chain(saveTicketReference(dao, service)),
+      TE.map((_) => void 0)
+    );
+
 export const createRequestReviewHandler = (
   dao: ServiceReviewDao,
   jiraProxy: JiraProxy,
-  apimProxy: ApimProxy
+  apimProxy: ApimProxy,
+  fsmLifecycleClient: ServiceLifecycle.FsmClient,
+  apimClient: ApiManagementClient,
+  config: IConfig
 ): ReturnType<typeof withJsonInput> =>
   withJsonInput((_context, queueItem) =>
     pipe(
@@ -31,38 +100,11 @@ export const createRequestReviewHandler = (
       TE.fromEither,
       TE.chain((service) =>
         pipe(
-          service.id,
-          jiraProxy.getPendingJiraIssueByServiceId,
+          isUserAllowedForAutomaticApproval(config, apimClient, service.id),
           TE.chain(
-            flow(
-              O.fold(
-                () =>
-                  pipe(
-                    service.id,
-                    apimProxy.getDelegateFromServiceId,
-                    TE.mapLeft(E.toError),
-                    TE.chain((delegate) =>
-                      pipe(
-                        jiraProxy.createJiraIssue(service, delegate),
-                        TE.mapLeft(E.toError)
-                      )
-                    )
-                  ),
-                TE.right
-              )
-            )
-          ),
-          TE.chain((ticket) =>
-            pipe(
-              dao.insert({
-                service_id: service.id,
-                service_version: service.version,
-                ticket_id: ticket.id,
-                ticket_key: ticket.key,
-                status: "PENDING",
-                extra_data: {},
-              }),
-              TE.mapLeft(E.toError)
+            B.fold(
+              () => sendServiceToReview(dao, jiraProxy, apimProxy)(service),
+              () => approveService(fsmLifecycleClient)(service)
             )
           )
         )

--- a/apps/io-services-cms-webapp/src/utils/feature-flag-handler.ts
+++ b/apps/io-services-cms-webapp/src/utils/feature-flag-handler.ts
@@ -19,7 +19,7 @@ const isElementAllowedOnList =
   (list: ReadonlyArray<NonEmptyString>) => (element: NonEmptyString) =>
     list.includes(wildcard) || list.includes(element);
 
-const isUserEnabledToSync = (
+const isUserIncludedInList = (
   config: IConfig,
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString,
@@ -27,6 +27,10 @@ const isUserEnabledToSync = (
 ): TE.TaskEither<Error, boolean> => {
   if (allAllowed(inclusionList)) {
     return TE.right(true);
+  }
+
+  if (inclusionList.length === 0) {
+    return TE.right(false);
   }
 
   return pipe(
@@ -64,7 +68,7 @@ export const isUserEnabledForCmsToLegacySync = (
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString
 ): TE.TaskEither<Error, boolean> =>
-  isUserEnabledToSync(
+  isUserIncludedInList(
     config,
     apimClient,
     serviceId,
@@ -83,11 +87,30 @@ export const isUserEnabledForLegacyToCmsSync = (
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString
 ): TE.TaskEither<Error, boolean> =>
-  isUserEnabledToSync(
+  isUserIncludedInList(
     config,
     apimClient,
     serviceId,
     config.USERID_LEGACY_TO_CMS_SYNC_INCLUSION_LIST
+  );
+
+/**
+ *
+ * @param config
+ * @param apimClient
+ * @param serviceId
+ * @returns
+ */
+export const isUserAllowedForAutomaticApproval = (
+  config: IConfig,
+  apimClient: ApiManagementClient,
+  serviceId: NonEmptyString
+): TE.TaskEither<Error, boolean> =>
+  isUserIncludedInList(
+    config,
+    apimClient,
+    serviceId,
+    config.USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST
   );
 
 /**

--- a/apps/io-services-cms-webapp/src/utils/feature-flag-handler.ts
+++ b/apps/io-services-cms-webapp/src/utils/feature-flag-handler.ts
@@ -19,7 +19,7 @@ const isElementAllowedOnList =
   (list: ReadonlyArray<NonEmptyString>) => (element: NonEmptyString) =>
     list.includes(wildcard) || list.includes(element);
 
-const isUserIncludedInList = (
+const isServiceOwnerIncludedInList = (
   config: IConfig,
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString,
@@ -68,7 +68,7 @@ export const isUserEnabledForCmsToLegacySync = (
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString
 ): TE.TaskEither<Error, boolean> =>
-  isUserIncludedInList(
+  isServiceOwnerIncludedInList(
     config,
     apimClient,
     serviceId,
@@ -87,7 +87,7 @@ export const isUserEnabledForLegacyToCmsSync = (
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString
 ): TE.TaskEither<Error, boolean> =>
-  isUserIncludedInList(
+  isServiceOwnerIncludedInList(
     config,
     apimClient,
     serviceId,
@@ -106,7 +106,7 @@ export const isUserAllowedForAutomaticApproval = (
   apimClient: ApiManagementClient,
   serviceId: NonEmptyString
 ): TE.TaskEither<Error, boolean> =>
-  isUserIncludedInList(
+  isServiceOwnerIncludedInList(
     config,
     apimClient,
     serviceId,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
As disclosed in #326 we are introducing an `Automatic Service Approval mechanism`.
#### List of Changes
- Added `USERID_AUTOMATIC_SERVICE_APPROVAL_INCLUSION_LIST` config
- Added `isUserAllowedForAutomaticApproval` feature flag utility method
- Refactor `request-review-handler`
- Add the Automatic Service Approval capability in `request-review-handler`
- Add `unit test` for automatic service approval
- Introduced FeatureFlags in `README.md`

<!--- Describe your changes in detail -->

#### Motivation and Context
Some trusted PAs and relative Technological Partners, may massively create and submit for review new services, so in a short time interval we can receive thousands request for service approval, which will cause an excessive overload on L1 service reviews.

To Solve this we will implements an automatic approval mechanism for submitted services for such PAs and Technological Partners.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
