### PR TITLE
chore: Export Selfcare Identity payload from inline to an external Schemas

### DIFF
--- a/.changeset/dull-scissors-learn.md
+++ b/.changeset/dull-scissors-learn.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/backoffice": patch
+---
+
+Export Selefcare Identity payload from inline to an external Schemas

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -809,12 +809,7 @@ components:
     Institution:
       $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/selfcare-schemas.yaml#/Institution"
     SelfCareIdentity:
-          type: object
-          properties:
-            identity_token:
-              type: string
-          required:
-            - identity_token
+       $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/backoffice-schemas.yaml#/SelfCareIdentity"
   securitySchemes:
     bearerAuth:
       type: http

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -68,10 +68,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                identity_token:
-                  type: string
+              $ref: "#/components/schemas/SelfCareIdentity"
         required: true
       responses:
         "200":
@@ -811,6 +808,13 @@ components:
           minimum: 0
     Institution:
       $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/selfcare-schemas.yaml#/Institution"
+    SelfCareIdentity:
+          type: object
+          properties:
+            identity_token:
+              type: string
+          required:
+            - identity_token
   securitySchemes:
     bearerAuth:
       type: http

--- a/packages/io-services-cms-models/openapi/backoffice-schemas.yaml
+++ b/packages/io-services-cms-models/openapi/backoffice-schemas.yaml
@@ -1,0 +1,7 @@
+  SelfCareIdentity:
+    type: object
+    properties:
+      identity_token:
+        type: string
+    required:
+      - identity_token


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
`openapi-codegen-ts` module is ignoring inline schemas, so in order to properly generate them we need to export them to an external Schema.

#### List of Changes
- moved `/auth` requestBody schema from inline to an external one `SelfCareIdentity`
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
