### PR TITLE
[IOPAE-580] Add DialogProvider component

### DIFF
--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -3,6 +3,8 @@
     "title": "IO BackOffice"
   },
   "buttons": {
+    "cancel": "Cancel",
+    "confirm": "Confirm",
     "copyToClipboard": "Copy to clipboard"
   },
   "copied": "Copied",

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -3,6 +3,8 @@
     "title": "IO BackOffice"
   },
   "buttons": {
+    "cancel": "Annulla",
+    "confirm": "Conferma",
     "copyToClipboard": "Copy to clipboard"
   },
   "copied": "Copiato",

--- a/apps/backoffice/src/components/dialog-provider/index.tsx
+++ b/apps/backoffice/src/components/dialog-provider/index.tsx
@@ -1,0 +1,100 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle
+} from "@mui/material";
+import { useTranslation } from "next-i18next";
+import { ReactNode, createContext, useContext, useState } from "react";
+
+type DialogOptions = {
+  /** dialog title */
+  title: string;
+  /** dialog body message */
+  message?: string;
+  /** label for cancel button: if specified, overwrite default value */
+  cancelButtonLabel?: string;
+  /** label for confirm button: if specified, overwrite default value */
+  confirmButtonLabel?: string;
+};
+
+type PromiseInfo = {
+  resolve: (value: boolean | PromiseLike<boolean>) => void;
+  reject: (reason?: any) => void;
+};
+
+type ShowDialogHandler = (options: DialogOptions) => Promise<boolean>;
+
+// Create the context so we can use it in our App
+const DialogContext = createContext<ShowDialogHandler>(() => {
+  throw new Error("Component is not wrapped with a DialogProvider.");
+});
+
+const DialogProvider: React.FC<{
+  children: ReactNode;
+}> = ({ children }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [options, setOptions] = useState<DialogOptions>({ title: "" });
+  const [promiseInfo, setPromiseInfo] = useState<PromiseInfo>();
+
+  const showDialog: ShowDialogHandler = options => {
+    // When the dialog is shown, keep the promise info so we can resolve later
+    return new Promise<boolean>((resolve, reject) => {
+      setPromiseInfo({ resolve, reject });
+      setOptions(options);
+      setOpen(true);
+    });
+  };
+
+  const handleConfirm = () => {
+    // if the Confirm button gets clicked, resolve with `true`
+    setOpen(false);
+    promiseInfo?.resolve(true);
+    setPromiseInfo(undefined);
+  };
+
+  const handleCancel = () => {
+    // if the dialog gets canceled, resolve with `false`
+    setOpen(false);
+    promiseInfo?.resolve(false);
+    setPromiseInfo(undefined);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={handleCancel}>
+        <DialogTitle>{options.title}</DialogTitle>
+        <DialogContent sx={{ minWidth: "600px" }}>
+          {options.message && (
+            <DialogContentText>{options.message}</DialogContentText>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ padding: "16px 24px" }}>
+          <Button variant="outlined" onClick={handleCancel}>
+            {options.cancelButtonLabel
+              ? t(options.cancelButtonLabel)
+              : t("buttons.cancel")}
+          </Button>
+          <Button variant="contained" onClick={handleConfirm}>
+            {options.confirmButtonLabel
+              ? t(options.confirmButtonLabel)
+              : t("buttons.confirm")}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <DialogContext.Provider value={showDialog}>
+        {children}
+      </DialogContext.Provider>
+    </>
+  );
+};
+
+// By calling `useDialog()` in a component we will be able to use the `showDialog()` function
+export const useDialog = () => {
+  return useContext(DialogContext);
+};
+
+export default DialogProvider;

--- a/apps/backoffice/src/providers/app.tsx
+++ b/apps/backoffice/src/providers/app.tsx
@@ -1,3 +1,4 @@
+import DialogProvider from "@/components/dialog-provider";
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { theme } from "@pagopa/mui-italia"; // MUI Italia theme
 import { ReactNode } from "react";
@@ -10,7 +11,7 @@ export const AppProvider = ({ children }: AppProviderProps) => {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      {children}
+      <DialogProvider>{children}</DialogProvider>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added DialogProvider component to perform modal dialg operations programmatically.

**Dialog Options:**
```
type DialogOptions = {
  /** dialog title */
  title: string;
  /** dialog body message */
  message?: string;
  /** label for cancel button: if specified, overwrite default value */
  cancelButtonLabel?: string;
  /** label for confirm button: if specified, overwrite default value */
  confirmButtonLabel?: string;
};
```

**How to use it:**
```
const showDialog = useDialog();

const handleShowDialog = async () => {
  const confirmed = await showDialog({
    title: "Test title",
    message: "This is a test message body."
  });
  if (confirmed) {
    console.log("Operation confirmed");
  } else {
    console.warn("Operation canceled");
  }
};
```
_See this example below in Screenshot section._

#### List of Changes
- Added **DialogProvider** component
- Register provider in App
- Add cancel/confirm default buttons label translations
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/b4df4ec4-a95e-4f53-a0e3-23df2b7881c0


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
