### PR TITLE
[IOPAE-585] Add Snackbar Provider component

### DIFF
--- a/.changeset/lucky-humans-fetch.md
+++ b/.changeset/lucky-humans-fetch.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/backoffice": minor
+---
+
+Added SnackbarProvider component

--- a/apps/backoffice/src/components/snackbar-provider/index.tsx
+++ b/apps/backoffice/src/components/snackbar-provider/index.tsx
@@ -1,0 +1,84 @@
+import { AlertColor, Box } from "@mui/material";
+import { Alert, Snackbar, Typography } from "@mui/material";
+import { createContext, useContext, useState } from "react";
+
+type SnackbarOptions = (item: SnackbarItem) => void;
+
+type SnackbarItem = {
+  /** The severity of the alert. This defines the color and icon used.  */
+  severity: AlertColor;
+  /** Alert title */
+  title?: string;
+  /** Alert body message content */
+  message?: string;
+};
+
+const SnackbarContext = createContext<SnackbarOptions>(() => {
+  console.error("Component is not wrapped with a SnackbarProvider.");
+});
+
+const SnackbarProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [open, setOpen] = useState(false);
+  const [alert, setAlert] = useState<SnackbarItem>({
+    severity: "success",
+    title: "",
+    message: ""
+  });
+
+  const handleClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+  };
+
+  /** Used to show a snackbar notification content */
+  const showSnackbar: SnackbarOptions = ({ severity, title, message }) => {
+    setAlert({ severity, title: title ?? "", message: message ?? "" });
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <Snackbar
+        open={open}
+        autoHideDuration={4000}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right"
+        }}
+        sx={{ marginTop: "31px", minWidth: "400px" }}
+      >
+        <Alert
+          onClose={handleClose}
+          severity={alert.severity}
+          sx={{ width: "100%" }}
+        >
+          <Box width="400px">
+            {alert.title ? (
+              <Typography variant="body2" fontWeight={600}>
+                {alert.title}
+              </Typography>
+            ) : null}
+            <Typography variant="body2">{alert.message}</Typography>
+          </Box>
+        </Alert>
+      </Snackbar>
+      <SnackbarContext.Provider value={showSnackbar}>
+        {children}
+      </SnackbarContext.Provider>
+    </>
+  );
+};
+
+export const useSnackbar = () => {
+  return useContext(SnackbarContext);
+};
+
+export default SnackbarProvider;

--- a/apps/backoffice/src/providers/app.tsx
+++ b/apps/backoffice/src/providers/app.tsx
@@ -1,4 +1,5 @@
 import DialogProvider from "@/components/dialog-provider";
+import SnackbarProvider from "@/components/snackbar-provider";
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { theme } from "@pagopa/mui-italia"; // MUI Italia theme
 import { ReactNode } from "react";
@@ -11,7 +12,9 @@ export const AppProvider = ({ children }: AppProviderProps) => {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <DialogProvider>{children}</DialogProvider>
+      <DialogProvider>
+        <SnackbarProvider>{children}</SnackbarProvider>
+      </DialogProvider>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added **SnackbarProvider** component to perform notification programmatically in form of _MUI Snackbar alerts_.

**Snackbar Options:**
```
type SnackbarOptions = (item: SnackbarItem) => void;

type SnackbarItem = {
  /** The severity of the alert. This defines the color and icon used.  */
  severity: AlertColor;
  /** Alert title */
  title?: string;
  /** Alert body message content */
  message?: string;
};
```

**How to use it:**
```
import { useSnackbar } from "@/components/snackbar-provider";

const showSnackbar = useSnackbar();
...
return (
...
<Button
   size="medium"
    variant="contained"
    onClick={() =>
        showSnackbar({
          severity: "success",
          title: "Operation completed",
          message: "This is a successful notification with title and message..."
        })
      }
>
   Test Success
</Button>
```
_See this example below in Screenshot section._

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/3beaec81-99a1-4de0-a792-489025a14c5f


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
