### PR TITLE
[#IOPAE-608] Add Manage Key APIs definitions

### DIFF
--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -29,6 +29,8 @@ tags:
     description: Services migration API specification
   - name: institutions
     description: Institutions API specification
+  - name: manage-keys
+    description: Manage Keys API specification
 paths:
   /info:
     get:

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -35,7 +35,7 @@ paths:
       description: Get runtime status information about the application
       operationId: info
       responses:
-        "200":
+        '200':
           description: The application is up and running
           content:
             application/json:
@@ -48,12 +48,12 @@ paths:
                   name:
                     type: string
                     description: the application name
-        "500":
+        '500':
           description: The fails to startup due to misconfiguration or unreachable dependencies
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseError"
+                $ref: '#/components/schemas/ResponseError'
   /auth: # /idp/selfcare/resolve-identity
     post:
       tags:
@@ -66,20 +66,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SelfCareIdentity"
+              $ref: '#/components/schemas/SelfCareIdentity'
         required: true
       responses:
-        "200":
+        '200':
           description: BackOffice JWT session token.
           content:
             application/jwt:
               schema:
                 type: string
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "500":
+        '500':
           description: Internal server error
   /services/migrations/ownership-claims/latest: #? valutare se mantenere la rotta as-is
     get:
@@ -91,19 +91,19 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        "200":
+        '200':
           description: Service migration status fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MigrationItemList"
-        "401":
+                $ref: '#/components/schemas/MigrationItemList'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/migrations/delegates: #? valutare se mantenere la rotta as-is
     get:
@@ -115,19 +115,19 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        "200":
+        '200':
           description: Delegates with service to migrate fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MigrationDelegateList"
-        "401":
+                $ref: '#/components/schemas/MigrationDelegateList'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/migrations/ownership-claims/{delegateId}: #? valutare se mantenere la rotta as-is
     post:
@@ -146,17 +146,17 @@ paths:
           schema:
             type: string
       responses:
-        "201":
+        '201':
           description: Delegate's services migrated successfully
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     get:
       tags:
@@ -174,21 +174,21 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: Delegate's services migration status fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MigrationData"
-        "401":
+                $ref: '#/components/schemas/MigrationData'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services:
     post:
@@ -204,24 +204,24 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ServicePayload"
+              $ref: '#/components/schemas/ServicePayload'
         required: true
       responses:
-        "201":
+        '201':
           description: Service created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ServiceLifecycle"
-        "400":
+                $ref: '#/components/schemas/ServiceLifecycle'
+        '400':
           description: Invalid payload
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     get:
       tags:
@@ -250,19 +250,19 @@ paths:
             minimum: 0
             default: 0
       responses:
-        "200":
+        '200':
           description: Services fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ServicePagination"
-        "401":
+                $ref: '#/components/schemas/ServicePagination'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/{serviceId}:
     get:
@@ -281,21 +281,21 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: Service fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ServiceLifecycle"
-        "401":
+                $ref: '#/components/schemas/ServiceLifecycle'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     put:
       tags:
@@ -317,26 +317,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ServicePayload"
+              $ref: '#/components/schemas/ServicePayload'
         required: true
       responses:
-        "200":
+        '200':
           description: Service updated successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ServiceLifecycle"
-        "400":
+                $ref: '#/components/schemas/ServiceLifecycle'
+        '400':
           description: Invalid payload
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     delete:
       tags:
@@ -354,17 +354,17 @@ paths:
           schema:
             type: string
       responses:
-        "204":
+        '204':
           description: Service deleted successfully
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/{serviceId}/logo:
     put:
@@ -387,22 +387,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Logo"
+              $ref: '#/components/schemas/Logo'
         required: true
       responses:
-        "204":
+        '204':
           description: Service logo updated successfully
-        "400":
+        '400':
           description: Invalid payload
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/{serviceId}/keys:
     get:
@@ -421,21 +421,21 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: Service keys fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SubscriptionKeys"
-        "401":
+                $ref: '#/components/schemas/SubscriptionKeys'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/{serviceId}/keys/{keyType}:
     put:
@@ -458,25 +458,25 @@ paths:
           description: Key type
           required: true
           schema:
-            $ref: "#/components/schemas/SubscriptionKeyType"
+            $ref: '#/components/schemas/SubscriptionKeyType'
       responses:
-        "200":
+        '200':
           description: Service key regenerated successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SubscriptionKeys"
-        "400":
+                $ref: '#/components/schemas/SubscriptionKeys'
+        '400':
           description: Bad request
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/{serviceId}/review:
     put:
@@ -499,22 +499,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ReviewRequest"
+              $ref: '#/components/schemas/ReviewRequest'
         required: true
       responses:
-        "204":
+        '204':
           description: Service revirew taken in charge
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "409":
+        '409':
           description: Service status is incompatible with review action request
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     patch:
       tags:
@@ -536,24 +536,24 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Comment"
+              $ref: '#/components/schemas/Comment'
         required: true
       responses:
-        "204":
+        '204':
           description: Service explained successfully
-        "400":
+        '400':
           description: Invalid payload
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "409":
+        '409':
           description: Service status is incompatible with explain action request
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /services/{serviceId}/release:
     post:
@@ -572,19 +572,19 @@ paths:
           schema:
             type: string
       responses:
-        "204":
+        '204':
           description: Service published successfully
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "409":
+        '409':
           description: Service status is incompatible with publish action request
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     get:
       tags:
@@ -602,21 +602,21 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: Fetched published service
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ServicePublication"
-        "401":
+                $ref: '#/components/schemas/ServicePublication'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
     delete:
       tags:
@@ -634,17 +634,17 @@ paths:
           schema:
             type: string
       responses:
-        "204":
+        '204':
           description: Service unpublished successfully
-        "401":
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /institutions:
     get:
@@ -656,21 +656,21 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        "200":
+        '200':
           description: Institutions fetched successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Institution"
-        "401":
+                  $ref: '#/components/schemas/Institution'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
           description: Internal server error
   /institutions/{institutionId}:
     get:
@@ -689,82 +689,143 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: Institution fetched successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Institution"
-        "401":
+                $ref: '#/components/schemas/Institution'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not found
-        "429":
+        '429':
           description: Too many requests
-        "500":
+        '500':
+          description: Internal server error
+  /keys/manage:
+    get:
+      tags:
+        - manage-keys
+      summary: Retrieve manage keys
+      description: Retrieve manage keys
+      operationId: getManageKeys
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Manage keys fetched successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriptionKeys'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '429':
+          description: Too many requests
+        '500':
+          description: Internal server error
+  /keys/manage/{keyType}:
+    put:
+      tags:
+        - manage-keys
+      summary: Regenerate manage key
+      description: Regenerate manage key by key type
+      operationId: regenerateManageKey
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: keyType
+          in: path
+          description: Key type
+          required: true
+          schema:
+            $ref: '#/components/schemas/SubscriptionKeyType'
+      responses:
+        '200':
+          description: Manage key regenerated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriptionKeys'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '429':
+          description: Too many requests
+        '500':
           description: Internal server error
 components:
   schemas:
     ServiceLifecycle:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycle"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycle'
     ServicePublication:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublication"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublication'
     ServicePayload:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePayload"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePayload'
     ServiceData:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceData"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceData'
     ServiceMetadata:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceMetadata"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceMetadata'
     ServiceLifecycleStatus:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycleStatus"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycleStatus'
     ServiceLifecycleStatusType:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycleStatusType"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycleStatusType'
     ServicePublicationStatusType:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublicationStatusType"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublicationStatusType'
     ServicePagination:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePagination"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePagination'
     PaginationResultSet:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/PaginationResultSet"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/PaginationResultSet'
     Organization:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/Organization"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/Organization'
     OrganizationFiscalCode:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/OrganizationFiscalCode"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/OrganizationFiscalCode'
     FiscalCode:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/FiscalCode"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/FiscalCode'
     Logo:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Logo"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Logo'
     SubscriptionKeys:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/SubscriptionKeys"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/SubscriptionKeys'
     SubscriptionKeyType:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/SubscriptionKeyType"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/SubscriptionKeyType'
     Cidr:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Cidr"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Cidr'
     ResponseError:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/ResponseError"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/ResponseError'
     Comment:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/Comment"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/Comment'
     ReviewRequest:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ReviewRequest"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ReviewRequest'
     Timestamp:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Timestamp"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Timestamp'
     MigrationItemList:
       type: object
       properties:
         items:
           type: array
           items:
-            $ref: "#/components/schemas/MigrationItem"
+            $ref: '#/components/schemas/MigrationItem'
     MigrationItem:
       type: object
       properties:
         status:
-          $ref: "#/components/schemas/MigrationItemStatus"
+          $ref: '#/components/schemas/MigrationItemStatus'
         delegate:
-          $ref: "#/components/schemas/MigrationItemDelegate"
+          $ref: '#/components/schemas/MigrationItemDelegate'
         lastUpdate:
-          $ref: "#/components/schemas/Timestamp"
+          $ref: '#/components/schemas/Timestamp'
       required:
         - status
         - delegate
@@ -811,10 +872,10 @@ components:
         delegates:
           type: array
           items:
-            $ref: "#/components/schemas/MigrationDelegate"
+            $ref: '#/components/schemas/MigrationDelegate'
     MigrationDelegate:
       allOf:
-        - $ref: "#/components/schemas/MigrationItemDelegate"
+        - $ref: '#/components/schemas/MigrationItemDelegate'
         - type: object
           properties:
             subscriptionCounter:
@@ -826,7 +887,7 @@ components:
       type: object
       properties:
         data:
-          $ref: "#/components/schemas/MigrationDataValue"
+          $ref: '#/components/schemas/MigrationDataValue'
     MigrationDataValue:
       type: object
       properties:
@@ -843,9 +904,9 @@ components:
           type: number
           minimum: 0
     Institution:
-      $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/selfcare-schemas.yaml#/Institution"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/selfcare-schemas.yaml#/Institution'
     SelfCareIdentity:
-       $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/backoffice-schemas.yaml#/SelfCareIdentity"
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/backoffice-schemas.yaml#/SelfCareIdentity'
   securitySchemes:
     bearerAuth:
       type: http


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add Manage Keys APIs definitions in `backoffice/openapi.yaml`
#### List of Changes
- ADD `GET /keys/manage` definition in `backoffice/openapi.yaml`, this api will allow an user to retrieve it's own Manage Keys
- ADD `PUT /keys/manage/{keyType}` definition in `backoffice/openapi.yaml`, this api will allow an user to regenerate either it's own primary or secondary Manage Key
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
