### PR TITLE
[#IOPAE-621] ADD Authorized CIDRs B4F API api route placeholders, and mws mocks

### DIFF
--- a/.changeset/big-pumas-sip.md
+++ b/.changeset/big-pumas-sip.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/backoffice": patch
+---
+
+ADD GET, PUT /keys/manage/cidrs B4F API api route placeholders, and mocks msw

--- a/apps/backoffice/mocks/data/backend-data.ts
+++ b/apps/backoffice/mocks/data/backend-data.ts
@@ -1,5 +1,7 @@
 import { faker } from "@faker-js/faker/locale/it";
 import packageJson from "../../package.json";
+import { ManageKeyCIDRs } from "@/generated/api/ManageKeyCIDRs";
+import { Cidr } from "@/generated/api/Cidr";
 
 const MAX_ARRAY_LENGTH = 20;
 
@@ -83,6 +85,20 @@ export const aMockServicePublication = {
 export const aMockServiceKeys = {
   primary_key: faker.string.alphanumeric(32),
   secondary_key: faker.string.alphanumeric(32)
+};
+
+export const aMockManageKeysCIDRs: ManageKeyCIDRs = {
+  cidrs: [
+    ...Array.from(
+      Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys()
+    )
+  ].map(
+    _ =>
+      `${faker.internet.ipv4()}/${faker.helpers.rangeToNumber({
+        min: 0,
+        max: 32
+      })}` as Cidr
+  )
 };
 
 const getMockServicePagination = (limit?: number, offset?: number) => {

--- a/apps/backoffice/mocks/handlers/backend-handlers.ts
+++ b/apps/backoffice/mocks/handlers/backend-handlers.ts
@@ -6,6 +6,7 @@ import { faker } from "@faker-js/faker/locale/it";
 import { rest } from "msw";
 import {
   aMockJwtSessionToken,
+  aMockManageKeysCIDRs,
   aMockServiceKeys,
   aMockServicePagination,
   aMockServicePublication,
@@ -332,6 +333,31 @@ export const buildHandlers = () => {
       ];
 
       return res(...resultArray[0]);
+    }),
+    rest.get(`${baseURL}/keys/manage/cidrs`, (_, res, ctx) => {
+      const resultArray = [
+        [ctx.status(200), ctx.json(getManageKeysCIDRs200Response())],
+        [ctx.status(401), ctx.json(null)],
+        [ctx.status(403), ctx.json(null)],
+        [ctx.status(404), ctx.json(null)],
+        [ctx.status(429), ctx.json(null)],
+        [ctx.status(500), ctx.json(null)]
+      ];
+
+      return res(...resultArray[0]);
+    }),
+    rest.put(`${baseURL}/keys/manage/cidrs`, (_, res, ctx) => {
+      const resultArray = [
+        [ctx.status(200), ctx.json(getManageKeysCIDRs200Response())],
+        [ctx.status(400), ctx.json(null)],
+        [ctx.status(401), ctx.json(null)],
+        [ctx.status(403), ctx.json(null)],
+        [ctx.status(404), ctx.json(null)],
+        [ctx.status(429), ctx.json(null)],
+        [ctx.status(500), ctx.json(null)]
+      ];
+
+      return res(...resultArray[0]);
     })
   ];
 };
@@ -398,6 +424,10 @@ export function getGetServiceKeys200Response() {
 
 export function getRegenerateServiceKey200Response() {
   return aMockServiceKeys;
+}
+
+export function getManageKeysCIDRs200Response() {
+  return aMockManageKeysCIDRs;
 }
 
 export function getGetPublishedService200Response() {

--- a/apps/backoffice/src/app/api/keys/manage/cidrs/route.ts
+++ b/apps/backoffice/src/app/api/keys/manage/cidrs/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * @description Retrieve manage key authorized CIDRs
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { keyType: string } }
+) {
+  return NextResponse.json({ message: "Not Implemented" });
+}
+
+/**
+ * @description Update manage key authorized CIDRs
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { keyType: string } }
+) {
+  return NextResponse.json({ message: "Not Implemented" });
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Add Manage Keys Authorized CIDRs APIs route handler placeholders.

#### List of Changes
- ADD `GET /keys/manage/cidrs` route handler placeholders, this api will retrieve the Authorized CIDRs associated to the Manage Keys currently in use(which is located in auth JWT).
- ADD `PUT /keys/manage/cidrs` route handler placeholders, this api will update the Authorized CIDRs associated to the Manage Keys currently in use(which is located in auth JWT).

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
