### PR TITLE
fix:[#IOPAE-638] Handle Jira Issue status name case change

### DIFF
--- a/.changeset/famous-ducks-cry.md
+++ b/.changeset/famous-ducks-cry.md
@@ -2,4 +2,4 @@
 "io-services-cms-webapp": patch
 ---
 
-Handle changed jira issue status names
+Handle Jira Issue status name case change

--- a/.changeset/famous-ducks-cry.md
+++ b/.changeset/famous-ducks-cry.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Handle changed jira issue status names

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-client.ts
@@ -19,22 +19,6 @@ export const CreateJiraIssueResponse = t.type({
 });
 export type CreateJiraIssueResponse = t.TypeOf<typeof CreateJiraIssueResponse>;
 
-export const JiraIssueStatus = t.union([
-  // TODO: maybe get these literal values from config?
-  t.literal("NEW"),
-  t.literal("REVIEW"),
-  t.literal("REJECTED"),
-  t.literal("APPROVED"),
-  t.literal("New"),
-  t.literal("Review"),
-  t.literal("Rejected"),
-  t.literal("Approved"),
-  // FIXME : delete after removing jira legacy client
-  t.literal("DONE"),
-  t.literal("Completata"),
-]);
-export type JiraIssueStatus = t.TypeOf<typeof JiraIssueStatus>;
-
 export const JiraIssue = t.type({
   id: NonEmptyString,
   key: NonEmptyString,
@@ -43,7 +27,7 @@ export const JiraIssue = t.type({
       comments: t.readonlyArray(t.type({ body: t.string })),
     }),
     status: t.type({
-      name: JiraIssueStatus,
+      name: t.string,
     }),
     statuscategorychangedate: withDefault(
       NonEmptyString,

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-client.ts
@@ -25,6 +25,10 @@ export const JiraIssueStatus = t.union([
   t.literal("REVIEW"),
   t.literal("REJECTED"),
   t.literal("APPROVED"),
+  t.literal("New"),
+  t.literal("Review"),
+  t.literal("Rejected"),
+  t.literal("Approved"),
   // FIXME : delete after removing jira legacy client
   t.literal("DONE"),
   t.literal("Completata"),

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
@@ -14,18 +14,6 @@ import { JIRA_REST_API_PATH, SearchJiraIssuesPayload } from "./jira-client";
 
 export const JIRA_SERVICE_TAG_PREFIX = "devportal-service-";
 
-export const JiraLegacyIssueStatus = t.union([
-  t.literal("NEW"),
-  t.literal("New"),
-  t.literal("REVIEW"),
-  t.literal("Review"),
-  t.literal("REJECTED"),
-  t.literal("Rejected"),
-  t.literal("DONE"),
-  t.literal("Completata"), // Status DONE will return this value as name
-]);
-export type JiraLegacyIssueStatus = t.TypeOf<typeof JiraLegacyIssueStatus>;
-
 export const JiraLegacyIssue = t.type({
   id: NonEmptyString,
   key: NonEmptyString,
@@ -35,7 +23,7 @@ export const JiraLegacyIssue = t.type({
         comments: t.readonlyArray(t.type({ body: t.string })),
       }),
       status: t.type({
-        name: JiraLegacyIssueStatus,
+        name: t.string,
       }),
     }),
     t.partial({

--- a/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/jira-legacy-client.ts
@@ -16,8 +16,11 @@ export const JIRA_SERVICE_TAG_PREFIX = "devportal-service-";
 
 export const JiraLegacyIssueStatus = t.union([
   t.literal("NEW"),
+  t.literal("New"),
   t.literal("REVIEW"),
+  t.literal("Review"),
   t.literal("REJECTED"),
+  t.literal("Rejected"),
   t.literal("DONE"),
   t.literal("Completata"), // Status DONE will return this value as name
 ]);

--- a/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
@@ -16,7 +16,9 @@ import {
 
 export type ProcessedJiraIssue = JiraIssue & {
   fields: JiraIssue["fields"] & {
-    status: JiraIssue["fields"]["status"] & { name: "APPROVED" | "REJECTED" };
+    status: JiraIssue["fields"]["status"] & {
+      name: "APPROVED" | "REJECTED" | "Approved" | "Rejected";
+    };
   };
 };
 
@@ -34,6 +36,7 @@ const makeServiceLifecycleApply = (
 ) => {
   switch (jiraIssue.fields.status.name) {
     case "REJECTED":
+    case "Rejected":
       return pipe(
         {
           reason: jiraIssue.fields.comment.comments
@@ -44,6 +47,7 @@ const makeServiceLifecycleApply = (
         TE.map((_) => void 0)
       );
     case "APPROVED":
+    case "Approved":
       return pipe(
         {
           approvalDate: jiraIssue.fields.statuscategorychangedate,
@@ -151,7 +155,10 @@ export const updateReview =
           pipe(
             dao.updateStatus({
               ...item,
-              status: issue.fields.status.name,
+              status:
+                issue.fields.status.name.toUpperCase() === "APPROVED"
+                  ? "APPROVED"
+                  : "REJECTED",
             }),
             TE.mapLeft((err) => {
               logger.logError(

--- a/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
@@ -14,16 +14,8 @@ import {
   ServiceReviewRowDataTable,
 } from "../utils/service-review-dao";
 
-export type ProcessedJiraIssue = JiraIssue & {
-  fields: JiraIssue["fields"] & {
-    status: JiraIssue["fields"]["status"] & {
-      name: "APPROVED" | "REJECTED" | "Approved" | "Rejected";
-    };
-  };
-};
-
 export type IssueItemPair = {
-  issue: ProcessedJiraIssue;
+  issue: JiraIssue;
   item: ServiceReviewRowDataTable;
 };
 
@@ -31,12 +23,12 @@ const logPrefix = "ReviewerCheckerHandler";
 
 const makeServiceLifecycleApply = (
   serviceReview: ServiceReviewRowDataTable,
-  jiraIssue: ProcessedJiraIssue,
+  jiraIssue: JiraIssue,
   fsmLifecycleClient: ServiceLifecycle.FsmClient
 ) => {
-  switch (jiraIssue.fields.status.name) {
+  const jiraIssueStatus = decodeJiraIssueStatus(jiraIssue);
+  switch (jiraIssueStatus) {
     case "REJECTED":
-    case "Rejected":
       return pipe(
         {
           reason: jiraIssue.fields.comment.comments
@@ -47,7 +39,6 @@ const makeServiceLifecycleApply = (
         TE.map((_) => void 0)
       );
     case "APPROVED":
-    case "Approved":
       return pipe(
         {
           approvalDate: jiraIssue.fields.statuscategorychangedate,
@@ -56,8 +47,6 @@ const makeServiceLifecycleApply = (
         TE.map((_) => void 0)
       );
     default:
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _: never = jiraIssue.fields.status.name;
       throw new Error("It should not happen");
   }
 };
@@ -155,10 +144,7 @@ export const updateReview =
           pipe(
             dao.updateStatus({
               ...item,
-              status:
-                issue.fields.status.name.toUpperCase() === "APPROVED"
-                  ? "APPROVED"
-                  : "REJECTED",
+              status: decodeJiraIssueStatus(issue),
             }),
             TE.mapLeft((err) => {
               logger.logError(
@@ -174,6 +160,13 @@ export const updateReview =
       TE.map((_) => void 0)
     );
   };
+
+const decodeJiraIssueStatus = (issue: JiraIssue): "APPROVED" | "REJECTED" => {
+  if (issue.fields.status.name.toUpperCase() === "APPROVED") {
+    return "APPROVED";
+  }
+  return "REJECTED";
+};
 
 export const processBatchOfReviews =
   (

--- a/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-legacy-checker-handler.ts
@@ -19,7 +19,7 @@ const logPrefix = "ServiceReviewLegacyChecker";
 export type ProcessedJiraIssue = JiraIssue & {
   fields: JiraIssue["fields"] & {
     status: JiraIssue["fields"]["status"] & {
-      name: "APPROVED" | "REJECTED" | "DONE" | "Completata";
+      name: "APPROVED" | "REJECTED" | "Rejected" | "DONE" | "Completata";
     };
   };
 };
@@ -99,7 +99,7 @@ export const updateReview =
             dao.updateStatus({
               ...item,
               status:
-                issue.fields.status.name === "REJECTED"
+                issue.fields.status.name.toUpperCase() === "REJECTED"
                   ? "REJECTED"
                   : "APPROVED",
             }),

--- a/apps/io-services-cms-webapp/src/utils/__tests__/jira-proxy.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/jira-proxy.test.ts
@@ -1,17 +1,16 @@
-import { describe, expect, it, vitest } from "vitest";
-import * as config from "../../config";
-import { Delegate, jiraProxy } from "../jira-proxy";
 import { ServiceLifecycle } from "@io-services-cms/models";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
+import { describe, expect, it, vitest } from "vitest";
+import * as config from "../../config";
 import {
   JiraAPIClient,
   JiraIssue,
-  JiraIssueStatus,
   SearchJiraIssuesResponse,
   jiraClient,
 } from "../../lib/clients/jira-client";
+import { Delegate, JiraIssueStatusFilter, jiraProxy } from "../jira-proxy";
 
 const JIRA_CONFIG = {
   JIRA_NAMESPACE_URL: "anUrl",
@@ -137,10 +136,7 @@ describe("Service Review Proxy", () => {
       "anIssueKey-1" as NonEmptyString,
       "anIssueKey-2" as NonEmptyString,
     ];
-    const searchStatuses: JiraIssueStatus[] = [
-      "APPROVED",
-      "REJECTED",
-    ];
+    const searchStatuses: JiraIssueStatusFilter[] = ["APPROVED", "REJECTED"];
     const serviceReviews = await proxy.searchJiraIssuesByKeyAndStatus(
       searchKeys,
       searchStatuses
@@ -237,5 +233,4 @@ describe("Service Review Proxy", () => {
       expect(serviceReview.left.message).toBe("Jira API returns an error");
     }
   });
-
 });

--- a/apps/io-services-cms-webapp/src/utils/jira-proxy.ts
+++ b/apps/io-services-cms-webapp/src/utils/jira-proxy.ts
@@ -7,7 +7,6 @@ import {
   CreateJiraIssueResponse,
   JiraAPIClient,
   JiraIssue,
-  JiraIssueStatus,
   SearchJiraIssuesPayload,
   SearchJiraIssuesResponse,
 } from "../lib/clients/jira-client";
@@ -18,6 +17,15 @@ const formatOptionalStringValue = (value?: string) =>
 const formatIssueTitle = (serviceId: NonEmptyString) =>
   `Review #${serviceId}` as NonEmptyString;
 
+// DONE and Completata will be removed whe legacy jira will be removed
+export type JiraIssueStatusFilter =
+  | "NEW"
+  | "REVIEW"
+  | "REJECTED"
+  | "APPROVED"
+  | "DONE"
+  | "Completata";
+
 export type JiraProxy = {
   readonly createJiraIssue: (
     service: ServiceLifecycle.definitions.Service,
@@ -25,7 +33,7 @@ export type JiraProxy = {
   ) => TE.TaskEither<Error, CreateJiraIssueResponse>;
   readonly searchJiraIssuesByKeyAndStatus: (
     jiraIssueKeys: ReadonlyArray<NonEmptyString>,
-    jiraIssueStatuses: ReadonlyArray<JiraIssueStatus>
+    jiraIssueStatuses: ReadonlyArray<JiraIssueStatusFilter>
   ) => TE.TaskEither<Error, SearchJiraIssuesResponse>;
   readonly getJiraIssueByServiceId: (
     serviceId: NonEmptyString
@@ -122,7 +130,7 @@ export const jiraProxy = (jiraClient: JiraAPIClient): JiraProxy => {
 
   const buildSearchJiraIssuesByKeyAndStatusPayload = (
     jiraIssueKeys: ReadonlyArray<NonEmptyString>,
-    jiraIssueStatuses: ReadonlyArray<JiraIssueStatus>
+    jiraIssueStatuses: ReadonlyArray<JiraIssueStatusFilter>
   ) => ({
     ...buildSearchIssuesBasePayload(
       `project = ${
@@ -136,7 +144,7 @@ export const jiraProxy = (jiraClient: JiraAPIClient): JiraProxy => {
 
   const searchJiraIssuesByKeyAndStatus = (
     jiraIssueKeys: ReadonlyArray<NonEmptyString>,
-    jiraIssueStatuses: ReadonlyArray<JiraIssueStatus>
+    jiraIssueStatuses: ReadonlyArray<JiraIssueStatusFilter>
   ): TE.TaskEither<Error, SearchJiraIssuesResponse> =>
     jiraClient.searchJiraIssues(
       buildSearchJiraIssuesByKeyAndStatusPayload(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Handle changed jira issue status names
Jira api seems to be inconsistent, the field `issue.fields.status.name` sometimes is returned in UPPERCASE, sometime in PascalCase, so we are removing the field validator(which was an union of io-ts literals, which are case sensitive), and normalize it when is needed.
#### List of Changes
- Remove Type JiraIssueStatus`type literal.
- Add `decodeJiraIssueStatus` in `review-checker-handler.ts` to normalize the value before saving it on DB.

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
