### PR TITLE
[IOPAE-700] Add create service button and empty state on services page

### DIFF
--- a/.changeset/real-lamps-behave.md
+++ b/.changeset/real-lamps-behave.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+Add create service button and empty state on services page

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -208,7 +208,8 @@
     },
     "services": {
       "title": "Services",
-      "description": "View and manage your institution's services."
+      "description": "View and manage your institution's services.",
+      "empty": "There are no services for this institution yet."
     },
     "service": {
       "address": "Address",
@@ -263,6 +264,7 @@
   },
   "service": {
     "actions": {
+      "create": "Create a service",
       "delete": "Delete",
       "edit": "Edit",
       "history": "View service history",

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -208,7 +208,8 @@
     },
     "services": {
       "title": "Servizi",
-      "description": "Visualizza e gestisci i servizi del tuo ente."
+      "description": "Visualizza e gestisci i servizi del tuo ente.",
+      "empty": "Non ci sono ancora servizi per questo ente."
     },
     "service": {
       "address": "Indirizzo",
@@ -263,6 +264,7 @@
   },
   "service": {
     "actions": {
+      "create": "Crea un servizio",
       "delete": "Elimina",
       "edit": "Modifica",
       "history": "Vedi storia del servizio",

--- a/apps/backoffice/src/components/__tests__/empty-state.test.tsx
+++ b/apps/backoffice/src/components/__tests__/empty-state.test.tsx
@@ -1,25 +1,45 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { useSession } from "next-auth/react";
 import React from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { Mock, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { EmptyState } from "../empty-state";
+
+vi.mock("next-auth/react");
+
+const mockUseSession = useSession as Mock;
 
 let emptyStateLabel = "emptyStateLabel";
 let ctaLabel = "ctaLabel";
 let ctaRoute = "/ctaRoute";
+let requiredPermissions = [""];
 
 const getEmptyStateComponent = () => (
   <EmptyState
     emptyStateLabel={emptyStateLabel}
     ctaLabel={ctaLabel}
     ctaRoute={ctaRoute}
+    requiredPermissions={requiredPermissions}
   ></EmptyState>
 );
+
+beforeAll(() => {
+  mockUseSession.mockReturnValue({
+    status: "authenticated",
+    data: {
+      user: {
+        permissions: ["permission1", "permission2"],
+        institution: { role: "aRole" }
+      }
+    }
+  });
+});
 
 // needed to clean document (react dom)
 afterEach(cleanup);
 
 describe("[EmptyState] Component", () => {
   it("Should render the empty state component", () => {
+    requiredPermissions = ["permission1"];
     render(getEmptyStateComponent());
     const aButton = screen.getByRole("button", {
       name: ctaLabel
@@ -38,7 +58,24 @@ describe("[EmptyState] Component", () => {
     );
   });
 
+  it("Should render the empty state component WITHOUT cta button if requiredPermissions doesn't match", () => {
+    requiredPermissions = ["aDifferentPermission"];
+    const { queryByRole } = render(getEmptyStateComponent());
+
+    const aButton = queryByRole("button", {
+      name: ctaLabel
+    });
+
+    expect(aButton).toBeNull();
+    expect(document.getElementById("empty-state")).toBeInTheDocument();
+    expect(document.getElementById("empty-state-label")).toHaveTextContent(
+      emptyStateLabel
+    );
+    expect(document.getElementById("empty-state-cta")).not.toBeInTheDocument();
+  });
+
   it("Should render the button with empty label if ctaLabel is an empty string", () => {
+    requiredPermissions = ["permission1"];
     ctaLabel = "";
     ctaRoute = "";
     render(getEmptyStateComponent());
@@ -59,6 +96,7 @@ describe("[EmptyState] Component", () => {
   });
 
   it("Should render the component with empty text if component label is empty string", () => {
+    requiredPermissions = ["permission1"];
     emptyStateLabel = "";
     render(getEmptyStateComponent());
 

--- a/apps/backoffice/src/components/empty-state/index.tsx
+++ b/apps/backoffice/src/components/empty-state/index.tsx
@@ -1,7 +1,11 @@
+import { RequiredAuthorizations } from "@/types/auth";
+import { hasRequiredAuthorizations } from "@/utils/auth-util";
 import { Box, Typography } from "@mui/material";
 import { ButtonNaked } from "@pagopa/mui-italia";
+import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import NextLink from "next/link";
+import { useState } from "react";
 
 export type EmptyStateProps = {
   /** Descriptive label for empty state */
@@ -10,25 +14,44 @@ export type EmptyStateProps = {
   ctaLabel: string;
   /** The path or URL to navigate to */
   ctaRoute: string;
-};
+} & RequiredAuthorizations;
 
-export const EmptyState = ({ ...props }: EmptyStateProps) => {
+export const EmptyState = ({
+  requiredPermissions,
+  requiredRole,
+  ...props
+}: EmptyStateProps) => {
   const { t } = useTranslation();
+  const { data: session } = useSession();
+
+  const [showCta] = useState(
+    hasRequiredAuthorizations(session, {
+      requiredPermissions,
+      requiredRole
+    })
+  );
+
+  const renderCta = () => {
+    if (showCta)
+      return (
+        <NextLink href={props.ctaRoute}>
+          <ButtonNaked
+            id="empty-state-cta"
+            color="primary"
+            size="medium"
+            sx={{ verticalAlign: "unset" }}
+          >
+            {t(props.ctaLabel)}
+          </ButtonNaked>
+        </NextLink>
+      );
+  };
+
   return (
     <Box id="empty-state" padding={3} bgcolor={"#EEEEEE"}>
       <Box padding={3} bgcolor={"#FFFFFF"}>
         <Typography id="empty-state-label" variant="body2" textAlign={"center"}>
-          {t(props.emptyStateLabel)}{" "}
-          <NextLink href={props.ctaRoute}>
-            <ButtonNaked
-              id="empty-state-cta"
-              color="primary"
-              size="medium"
-              sx={{ verticalAlign: "unset" }}
-            >
-              {t(props.ctaLabel)}
-            </ButtonNaked>
-          </NextLink>
+          {t(props.emptyStateLabel)} {renderCta()}
         </Typography>
       </Box>
     </Box>

--- a/apps/backoffice/src/pages/services/index.tsx
+++ b/apps/backoffice/src/pages/services/index.tsx
@@ -1,6 +1,9 @@
+import { AccessControl } from "@/components/access-control";
+import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/headers";
 import { AppLayout, PageLayout } from "@/layouts";
-import { Box, Button } from "@mui/material";
+import { Add } from "@mui/icons-material";
+import { Box, Button, Grid } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import NextLink from "next/link";
@@ -9,14 +12,39 @@ import { ReactElement } from "react";
 const pageTitleLocaleKey = "routes.services.title";
 const pageDescriptionLocaleKey = "routes.services.description";
 
+const CREATE_SERVICE_ROUTE = "/services/new-service";
+
 export default function Services() {
   const { t } = useTranslation();
 
   return (
     <>
-      <PageHeader
-        title={pageTitleLocaleKey}
-        description={pageDescriptionLocaleKey}
+      <Grid container spacing={0} paddingRight={3}>
+        <Grid item xs>
+          <PageHeader
+            title={pageTitleLocaleKey}
+            description={pageDescriptionLocaleKey}
+          />
+        </Grid>
+        <Grid item xs="auto">
+          <AccessControl requiredPermissions={["ApiServiceWrite"]}>
+            <NextLink
+              href={CREATE_SERVICE_ROUTE}
+              passHref
+              style={{ textDecoration: "none" }}
+            >
+              <Button size="medium" variant="contained" startIcon={<Add />}>
+                {t("service.actions.create")}
+              </Button>
+            </NextLink>
+          </AccessControl>
+        </Grid>
+      </Grid>
+      <EmptyState
+        emptyStateLabel="routes.services.empty"
+        ctaLabel="service.actions.create"
+        ctaRoute={CREATE_SERVICE_ROUTE}
+        requiredPermissions={["ApiServiceWrite"]}
       />
       <Box paddingY={3}>
         <NextLink
@@ -24,19 +52,8 @@ export default function Services() {
           passHref
           style={{ textDecoration: "none" }}
         >
-          <Button size="medium" variant="contained">
-            Dettaglio servizio
-          </Button>
-        </NextLink>
-      </Box>
-      <Box>
-        <NextLink
-          href={`/services/new-service`}
-          passHref
-          style={{ textDecoration: "none" }}
-        >
-          <Button size="medium" variant="contained">
-            Nuovo Servizio
+          <Button size="small" variant="contained">
+            Test dettaglio servizio
           </Button>
         </NextLink>
       </Box>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added UX/UI for managing new service creation on the **services** page.

**Note 1:** _Watch video below to better appreciate developments._
**Note 2:** _At **00:15 sec** of video below you can appreciate the access control introduced on "create service" buttons and link inside services page: in that case, the new logged user doesn't have _**ApiServiceWrite**_ permission and conseguently no service create actions are available on screen.._
#### List of Changes
- added new translations
- updated **EmptyState** component to manage `RequiredAuthorizations` props
- added _ServiceCreate_ ux/ui on services page
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/1759fedd-4617-47fb-885a-8d994320aabb


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
