### PR TITLE
[#IOPAE-737] ADD GET health api in B4F

### DIFF
--- a/.changeset/quiet-comics-draw.md
+++ b/.changeset/quiet-comics-draw.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+ADD GET /health API in Backoffice B4F

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -49,6 +49,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Info'
+  /health:
+    get:
+      description: Get health application status
+      operationId: health
+      responses:
+        '200':
+          description: The application is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+        '500':
+          description: The application is unhealthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
   /auth: # /idp/selfcare/resolve-identity
     post:
       tags:
@@ -852,6 +869,12 @@ components:
         errorMessage:
           type: string
           description: the component failure message
+    Health:
+      type: object
+      properties:
+        status:
+          type: string
+          description: the application health status
     ServiceLifecycle:
       $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycle'
     ServicePublication:

--- a/apps/backoffice/src/app/api/health/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { HealthChecksError } from "../../../../lib/be/errors";
+import { GET } from "../route";
+
+const { getLegacyCosmosHealth } = vi.hoisted(() => ({
+  getLegacyCosmosHealth: vi.fn().mockReturnValue(Promise.resolve())
+}));
+
+const { getSelfcareHealth } = vi.hoisted(() => ({
+  getSelfcareHealth: vi.fn().mockReturnValue(Promise.resolve())
+}));
+
+const { getIoServicesCmsHealth } = vi.hoisted(() => ({
+  getIoServicesCmsHealth: vi.fn().mockReturnValue(Promise.resolve())
+}));
+
+const { getApimHealth } = vi.hoisted(() => ({
+  getApimHealth: vi.fn().mockReturnValue({
+    getLegacyCosmosHealth: vi.fn().mockReturnValue(Promise.resolve())
+  })
+}));
+
+vi.mock("@/lib/be/legacy-cosmos", () => ({
+  getLegacyCosmosHealth
+}));
+
+vi.mock("@/lib/be/selfcare-client", () => ({
+  getSelfcareHealth
+}));
+
+vi.mock("@/lib/be/cms-client", () => ({
+  getIoServicesCmsHealth
+}));
+
+vi.mock("@/lib/be/apim-service", () => ({
+  getApimHealth
+}));
+
+describe("test backend api info()", () => {
+  it("should return 200 on healthcheck succed", async () => {
+    const result = await GET();
+
+    //extract jsonBody from NextResponse
+    const jsonResponse = await new Response(result.body).json();
+
+    expect(result.status).toBe(200);
+    expect(jsonResponse).toStrictEqual({
+      status: "ok"
+    });
+  });
+
+  it("should return 500 on at least one healthcheck fails", async () => {
+    getLegacyCosmosHealth.mockReturnValueOnce(
+      Promise.reject(
+        new HealthChecksError(
+          "legacy-cosmos-db",
+          new Error("error reaching db")
+        )
+      )
+    );
+
+    const result = await GET();
+
+    //extract jsonBody from NextResponse
+    const jsonResponse = await new Response(result.body).json();
+
+    expect(result.status).toBe(500);
+    expect(jsonResponse).toStrictEqual({
+      status: "fail"
+    });
+  });
+});

--- a/apps/backoffice/src/app/api/health/route.ts
+++ b/apps/backoffice/src/app/api/health/route.ts
@@ -1,0 +1,31 @@
+import {
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_OK
+} from "@/config/constants";
+import { getApimHealth } from "@/lib/be/apim-service";
+import { getIoServicesCmsHealth } from "@/lib/be/cms-client";
+import healthcheck from "@/lib/be/healthcheck";
+import { getLegacyCosmosHealth } from "@/lib/be/legacy-cosmos";
+import { getSelfcareHealth } from "@/lib/be/selfcare-client";
+import { NextResponse } from "next/server";
+
+/**
+ * `api/healt` route handler
+ * @returns project _name_ and _version_
+ */
+export async function GET() {
+  const health = await healthcheck([
+    getLegacyCosmosHealth(),
+    getApimHealth(),
+    getSelfcareHealth(),
+    getIoServicesCmsHealth()
+  ]);
+  const status =
+    health.status === "ok" ? HTTP_STATUS_OK : HTTP_STATUS_INTERNAL_SERVER_ERROR;
+
+  const response = {
+    status: health.status
+  };
+
+  return NextResponse.json(response, { status });
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add a lightweight HealthCheck api, this API will be used by Azure to determine if the application is Healthy or not
#### List of Changes
- ADD `GET /health` API in Backoffice B4F `openapi.yaml`
- Implement  `GET /health`Route Handler
- ADD Unit tests for `GET /health`Route Handler
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
