### PR TITLE
fix: [IOPAE-741] publish non approved service

### DIFF
--- a/.changeset/beige-singers-push.md
+++ b/.changeset/beige-singers-push.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Fix response on Publish Service for non approved service

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/publish-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/publish-service.test.ts
@@ -136,7 +136,7 @@ describe("publishService", () => {
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
-    blobService: mockBlobService
+    blobService: mockBlobService,
   });
 
   setAppContext(app, mockContext);
@@ -150,12 +150,13 @@ describe("publishService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(response.statusCode).toBe(500); // FIXME: the publish of a non-existing service is allowed by the 'autopublish' feature, so it is not possible to receive a 404 error.
+    expect(response.statusCode).toBe(404);
   });
 
   it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
     await servicePublicationStore.save("s1", {
       ...aServicePub,
+      id: "s1" as NonEmptyString,
       fsm: { state: "published" },
     })();
 
@@ -186,6 +187,7 @@ describe("publishService", () => {
   it("should publish a service", async () => {
     await servicePublicationStore.save("s1", {
       ...aServicePub,
+      id: "s1" as NonEmptyString,
       fsm: { state: "unpublished" },
     })();
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/publish-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/publish-service.ts
@@ -75,7 +75,10 @@ const retrieveServicePublicationTask =
           O.map(({ id }) => TE.right(id)),
           O.getOrElseW(() =>
             TE.left(
-              ResponseErrorNotFound("Not found", `${serviceId} not found`)
+              ResponseErrorNotFound(
+                "Not found",
+                `no item with id ${serviceId} found`
+              )
             )
           )
         )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fix the bug mentioned in IOPAE-741 ticket regarding the response returned when the publish API was called for a non approved Service.

Before Calling the FSM Publication publish method we now check for service existence and return a 404 response in negative cases.

**Before the fix the response was**:
```json
HTTP 500 INTERNAL SERVER ERROR
{
    "detail": "Error executing endpoint handler: Cannot read properties of undefined (reading 'data')",
    "status": 500,
    "title": "Internal server error"
}
```

**After the fix the response is**:
```json
HTTP 404 NOT FOUND
{ 
    "detail": "no item with id s1 found", 
    "status": 404, 
    "title": "Not found" 
}
```

PS: Another way to solve the issue can be done by renaming the action `publish` on `FSM Publication` for transition from `'*'` -> `published` to avoid overlapping

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
