### PR TITLE
chore: [IOPAE-715] add institution fields to createService and updateService

### DIFF
--- a/.changeset/cool-wombats-reply.md
+++ b/.changeset/cool-wombats-reply.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+Make the setting of organization fields transparent to the user when creating and updating the service.

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -922,7 +922,41 @@ components:
     ServicePublication:
       $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublication'
     ServicePayload:
-      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePayload'
+      type: object
+      description: Service basic data
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          minLength: 1
+        require_secure_channel:
+          type: boolean
+        authorized_recipients:
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/FiscalCode'
+        authorized_cidrs:
+          description: >-
+            Allowed source IPs or CIDRs for this service.
+            When empty, every IP address it's authorized to call the IO API on
+            behalf of the service.
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Cidr'
+        max_allowed_payment_amount:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 9999999999
+          default: 0
+        metadata:
+          $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceMetadata'
+      required:
+        - name
+        - description
+        - metadata
     ServiceData:
       $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceData'
     ServiceMetadata:

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/__tests__/auth.test.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/__tests__/auth.test.ts
@@ -87,6 +87,7 @@ const getExpectedUser = (
   institution: {
     id: jwtPayload.organization.id,
     name: jwtPayload.organization.name,
+    fiscalCode: jwtPayload.organization.fiscal_code,
     role: jwtPayload.organization.roles[0].role,
     logo_url: institution.logo
   },

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
@@ -327,6 +327,7 @@ const toUser = ({
   institution: {
     id: identityTokenPayload.organization.id,
     name: identityTokenPayload.organization.name,
+    fiscalCode: identityTokenPayload.organization.fiscal_code,
     role: identityTokenPayload.organization.roles[0]?.role,
     logo_url: institution.logo
   },

--- a/apps/backoffice/src/app/api/services/[serviceId]/route.ts
+++ b/apps/backoffice/src/app/api/services/[serviceId]/route.ts
@@ -21,19 +21,27 @@ export const GET = withJWTAuthHandler(
  * @description Update an existing service by ID
  */
 export const PUT = withJWTAuthHandler(
-  (
+  async (
     request: NextRequest,
     {
       params,
       backofficeUser
     }: { params: { serviceId: string }; backofficeUser: BackOfficeUser }
-  ) =>
-    forwardIoServicesCmsRequest(
+  ) => {
+    const jsonBody = {
+      ...(await request.json()),
+      organization: {
+        name: backofficeUser.institution.name,
+        fiscal_code: backofficeUser.institution.fiscalCode
+      }
+    };
+    return forwardIoServicesCmsRequest(
       "updateService",
-      request,
+      jsonBody,
       backofficeUser,
       params
-    )
+    );
+  }
 );
 
 /**

--- a/apps/backoffice/src/app/api/services/route.ts
+++ b/apps/backoffice/src/app/api/services/route.ts
@@ -7,10 +7,23 @@ import { BackOfficeUser } from "../../../../types/next-auth";
  * @description Create a new Service with the attributes provided in the request payload
  */
 export const POST = withJWTAuthHandler(
-  (
+  async (
     request: NextRequest,
     { backofficeUser }: { backofficeUser: BackOfficeUser }
-  ) => forwardIoServicesCmsRequest("createService", request, backofficeUser)
+  ) => {
+    const jsonBody = {
+      ...(await request.json()),
+      organization: {
+        name: backofficeUser.institution.name,
+        fiscal_code: backofficeUser.institution.fiscalCode
+      }
+    };
+    return forwardIoServicesCmsRequest(
+      "createService",
+      jsonBody,
+      backofficeUser
+    );
+  }
 );
 
 /**

--- a/apps/backoffice/src/components/headers/header.tsx
+++ b/apps/backoffice/src/components/headers/header.tsx
@@ -33,8 +33,8 @@ export const Header = () => {
   useEffect(() => {
     if (session?.user) {
       const currentParty: PartySwitchItem = {
-        id: session.user.institution.id ?? "",
-        name: session.user.institution.name ?? "",
+        id: session.user.institution.id,
+        name: session.user.institution.name,
         productRole: t(`roles.${session.user.institution.role}`),
         logoUrl: session.user.institution.logo_url
       };

--- a/apps/backoffice/src/components/services/__tests__/adapters.test.ts
+++ b/apps/backoffice/src/components/services/__tests__/adapters.test.ts
@@ -8,14 +8,9 @@ import {
   fromServiceCreateUpdatePayloadToApiServicePayload
 } from "../adapters";
 
-const mockedSessionUser = {
-  institution: { name: "anInstitutionName" }
-} as any;
-
 const aValidServiceCreateUpdatePayload: ServiceCreateUpdatePayload = {
   name: "aServiceName",
   description: "aServiceDescription",
-  organization: { name: "", fiscal_code: "", department_name: "" },
   metadata: {
     web_url: "aWebUrl",
     app_ios: "anAppIosUrl",
@@ -68,23 +63,15 @@ const anApiServicePayloadResult = ({
 } as unknown) as ApiServicePayload;
 
 describe("[Services] Adapters", () => {
-  it("should return a valid Api ServicePayload if a valid frontend service payload and session user are provided", () => {
+  it("should return a valid Api ServicePayload if a valid frontend service payload is provided", () => {
     const result = fromServiceCreateUpdatePayloadToApiServicePayload(
-      aValidServiceCreateUpdatePayload,
-      mockedSessionUser
+      aValidServiceCreateUpdatePayload
     ) as t.Validation<ServiceCreateUpdatePayload>;
 
     expect(E.isRight(result));
 
     if (E.isRight(result)) {
-      const servicePayload = {
-        ...anApiServicePayloadResult,
-        organization: {
-          name: mockedSessionUser.institution.name,
-          fiscal_code: "00000000000"
-        }
-      };
-      expect(result.right).toStrictEqual(servicePayload);
+      expect(result.right).toStrictEqual(anApiServicePayloadResult);
     }
   });
 
@@ -95,8 +82,7 @@ describe("[Services] Adapters", () => {
     };
 
     const result = fromServiceCreateUpdatePayloadToApiServicePayload(
-      anInvalidServiceCreateUpdatePayload,
-      mockedSessionUser
+      anInvalidServiceCreateUpdatePayload
     ) as t.Validation<ServiceCreateUpdatePayload>;
 
     expect(E.isLeft(result));

--- a/apps/backoffice/src/lib/be/__tests__/cms-proxy.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/cms-proxy.test.ts
@@ -130,6 +130,46 @@ describe("forwardIoServicesCmsRequest tests", () => {
     expect(result.body).not.toBe(null);
   });
 
+  it("fn call with explicitly body and expect response body", async () => {
+    // Mock io-services-cms client
+    const createService = vi.fn(() =>
+      Promise.resolve(E.of({ status: 200, value: { test: "test" } }))
+    );
+    getIoServicesCmsClient.mockReturnValueOnce({
+      createService
+    });
+
+    // Mock request body
+    const aBodyPayload = {
+      name: "test",
+      description: "test"
+    };
+
+    const result = await forwardIoServicesCmsRequest(
+      "createService",
+      aBodyPayload,
+      jwtMock,
+      {
+        serviceId: "test"
+      }
+    );
+
+    expect(createService).toHaveBeenCalled();
+    expect(createService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "x-user-email": anUserEmail,
+        "x-user-id": anUserId,
+        "x-subscription-id": aSubscriptionId,
+        "x-user-groups": aUserPermissions.join(","),
+        body: aBodyPayload,
+        serviceId: "test"
+      })
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).not.toBe(null);
+  });
+
   it("request without body response", async () => {
     // Mock io-services-cms client
     const reviewService = vi.fn(() =>

--- a/apps/backoffice/src/lib/be/cms/business.ts
+++ b/apps/backoffice/src/lib/be/cms/business.ts
@@ -21,16 +21,35 @@ type PathParameters = {
  * we chose to implement intermediate APIs to do this in the B4F,
  * the following method is responsible for forwarding requests to the corresponding io-services-cms APIs
  */
-export const forwardIoServicesCmsRequest = async <
+export async function forwardIoServicesCmsRequest<
   T extends keyof IoServicesCmsClient
 >(
   operationId: T,
   nextRequest: NextRequest,
   backofficeUser: BackOfficeUser,
   pathParams?: PathParameters
-) => {
+): Promise<Response>;
+export async function forwardIoServicesCmsRequest<
+  T extends keyof IoServicesCmsClient
+>(
+  operationId: T,
+  jsonBody: any,
+  backofficeUser: BackOfficeUser,
+  pathParams?: PathParameters
+): Promise<Response>;
+export async function forwardIoServicesCmsRequest<
+  T extends keyof IoServicesCmsClient
+>(
+  operationId: T,
+  requestOrBody: NextRequest | any,
+  backofficeUser: BackOfficeUser,
+  pathParams?: PathParameters
+): Promise<Response> {
   // extract jsonBody
-  const jsonBody = nextRequest.bodyUsed && (await nextRequest.json());
+  const jsonBody =
+    "json" in requestOrBody // check NextRequest object
+      ? requestOrBody.bodyUsed && (await requestOrBody.json()) // TODO: are we sure requestOrBody.bodyUsed is the correct check before requestOrBody.json()?!?
+      : requestOrBody;
 
   // create the request payload
   const requestPayload = {
@@ -65,4 +84,4 @@ export const forwardIoServicesCmsRequest = async <
   }
 
   return NextResponse.json(value, { status });
-};
+}

--- a/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
+++ b/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
@@ -36,8 +36,7 @@ export default function EditService() {
 
   const handleConfirm = (service: ServiceCreateUpdatePayload) => {
     const maybeApiServicePayload = fromServiceCreateUpdatePayloadToApiServicePayload(
-      service,
-      session?.user
+      service
     );
     if (E.isRight(maybeApiServicePayload)) {
       serviceFetchData(

--- a/apps/backoffice/src/pages/services/new-service.tsx
+++ b/apps/backoffice/src/pages/services/new-service.tsx
@@ -27,8 +27,7 @@ export default function NewService() {
 
   const handleConfirm = (service: ServiceCreateUpdatePayload) => {
     const maybeServicePayload = fromServiceCreateUpdatePayloadToApiServicePayload(
-      service,
-      session?.user
+      service
     );
     if (E.isRight(maybeServicePayload)) {
       serviceFetchData(

--- a/apps/backoffice/types/next-auth.d.ts
+++ b/apps/backoffice/types/next-auth.d.ts
@@ -15,8 +15,8 @@ declare module "next-auth/jwt" {
 }
 
 interface BackOfficeUser extends DefaultUser {
-  institution: BackOfficeUserInstitution;
-  authorizedInstitutions: BackOfficeUserInstitution[];
+  institution: Institution;
+  authorizedInstitutions: AuthorizedInstitution[];
   permissions: string[];
   parameters: BackOfficeUserParameters;
 }
@@ -27,9 +27,18 @@ interface BackOfficeUserParameters {
   subscriptionId: string;
 }
 
-interface BackOfficeUserInstitution {
+interface Institution {
+  id: string;
+  name: string;
+  fiscalCode: string;
+  role: string;
+  logo_url?: string;
+}
+
+interface AuthorizedInstitution {
   id?: string;
   name?: string;
+  fiscalCode?: string;
   role?: string;
   logo_url?: string;
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Make the setting of organization fields transparent to the user when creating and updating the service.

#### List of Changes
<!--- Describe your changes in detail -->
- Add `organization.name` and `organization.fiscal_code` as user session fields
- Remove `organization` property from create and update service request body (B4F API)
- Add `organization` fields (picked from user session) from create and update service request body before forward request to services-cms

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve user experience and system robustness

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
