### PR TITLE
[IOPAE-756] Add equality check on update service form

### DIFF
--- a/.changeset/pink-cherries-repeat.md
+++ b/.changeset/pink-cherries-repeat.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Add equality check on update service form: avoid to send update and notify user if initial form values are equal to submitted values

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -196,6 +196,7 @@
   "notifications": {
     "exceptionError": "Applicative exception",
     "httpError": "Http error",
+    "noChangeError": "Warning, no changes made",
     "success": "Operation completed successfully",
     "validationError": "Data validation error"
   },

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -196,6 +196,7 @@
   "notifications": {
     "exceptionError": "Eccezione applicativa",
     "httpError": "Errore Http",
+    "noChangeError": "Attenzione, nessuna modifica effettuata",
     "success": "Operazione completata con successo",
     "validationError": "Errore di validazione dati"
   },

--- a/apps/backoffice/src/components/services/service-create-update/service-builder-step-1.tsx
+++ b/apps/backoffice/src/components/services/service-create-update/service-builder-step-1.tsx
@@ -135,12 +135,14 @@ export const ServiceBuilderStep1 = () => {
             />
           </Grid>
           <Grid item xs={6}>
-            <TextFieldController
+            {/*
+             // TODO should be developed in the next MVPs
+             <TextFieldController
               name="metadata.localScope"
               label="Aree locali di competenza"
               placeholder="Inserisci aree locali"
               disabled
-            />
+            /> */}
           </Grid>
         </Grid>
         <TextFieldController
@@ -155,6 +157,8 @@ export const ServiceBuilderStep1 = () => {
             />
           }
         />
+        {/* 
+        // TODO should be developed in the next MVPs
         <TextFieldController
           name="topic"
           label="Argomento del servizio"
@@ -180,7 +184,7 @@ export const ServiceBuilderStep1 = () => {
             />
           }
           disabled
-        />
+        /> */}
       </FormStepSectionWrapper>
       <ServicePreview
         isOpen={isPreviewOpen}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add equality check on update service form: avoid to send update and notify user if initial form values are equal to submitted values.

**Watch the video to appreciate the development.**

#### List of Changes
- added notification translations
- added equality check on **CreateUpdateProcess** component
- minor: hide some create/update service form fields that should be developed in next MVPs
<!--- Describe your changes in detail -->

#### Motivation and Context
Avoid saving multiple identical versions of the same service.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/6108df78-0efc-4956-bafe-aeba3259e7e4


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
