### PR TITLE
chore: Transform external clients into regular singleton instead of caching instance using react cache

### DIFF
--- a/.changeset/silent-dryers-push.md
+++ b/.changeset/silent-dryers-push.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Transform external clients into regular singleton instead of caching instance using react cache

--- a/apps/backoffice/src/app/api/health/route.ts
+++ b/apps/backoffice/src/app/api/health/route.ts
@@ -2,8 +2,12 @@ import {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
   HTTP_STATUS_OK
 } from "@/config/constants";
+import { getApimHealth } from "@/lib/be/apim-service";
 import { getAzureAccessTokenHealth } from "@/lib/be/azure-access-token";
+import { getIoServicesCmsHealth } from "@/lib/be/cms-client";
+import { getCosmosStoreHealth } from "@/lib/be/cosmos-store";
 import healthcheck from "@/lib/be/healthcheck";
+import { getLegacyCosmosHealth } from "@/lib/be/legacy-cosmos";
 import { getSelfcareHealth } from "@/lib/be/selfcare-client";
 import { getSubscriptionsMigrationHealth } from "@/lib/be/subscription-migration-client";
 import { NextResponse } from "next/server";
@@ -15,12 +19,12 @@ export const dynamic = "force-dynamic";
  */
 export async function GET() {
   const health = await healthcheck([
-    //getLegacyCosmosHealth(),
-    //getApimHealth(),
+    getLegacyCosmosHealth(),
+    getApimHealth(),
     getSelfcareHealth(),
-    //getIoServicesCmsHealth(),
+    getIoServicesCmsHealth(),
     getAzureAccessTokenHealth(),
-    //getCosmosStoreHealth(),
+    getCosmosStoreHealth(),
     getSubscriptionsMigrationHealth()
   ]);
   const status =

--- a/apps/backoffice/src/app/api/info/route.ts
+++ b/apps/backoffice/src/app/api/info/route.ts
@@ -2,8 +2,12 @@ import {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
   HTTP_STATUS_OK
 } from "@/config/constants";
+import { getApimHealth } from "@/lib/be/apim-service";
 import { getAzureAccessTokenHealth } from "@/lib/be/azure-access-token";
+import { getIoServicesCmsHealth } from "@/lib/be/cms-client";
+import { getCosmosStoreHealth } from "@/lib/be/cosmos-store";
 import healthcheck from "@/lib/be/healthcheck";
+import { getLegacyCosmosHealth } from "@/lib/be/legacy-cosmos";
 import { getSelfcareHealth } from "@/lib/be/selfcare-client";
 import { getSubscriptionsMigrationHealth } from "@/lib/be/subscription-migration-client";
 import { NextResponse } from "next/server";
@@ -19,12 +23,12 @@ export async function GET() {
   // get info from package.json
 
   const health = await healthcheck([
-    //getLegacyCosmosHealth(),
-    //getApimHealth(),
+    getLegacyCosmosHealth(),
+    getApimHealth(),
     getSelfcareHealth(),
-    //getIoServicesCmsHealth(),
+    getIoServicesCmsHealth(),
     getAzureAccessTokenHealth(),
-    //getCosmosStoreHealth(),
+    getCosmosStoreHealth(),
     getSubscriptionsMigrationHealth()
   ]);
   const status =

--- a/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
@@ -5,7 +5,7 @@ import {
   InstitutionResource,
   InstitutionResources
 } from "../../../types/selfcare/InstitutionResource";
-import { getSelfcareClient } from "../selfcare-client";
+import { getSelfcareClient, resetInstance } from "../selfcare-client";
 
 const mocks: {
   institution: Institution;
@@ -67,6 +67,9 @@ describe("Selfcare Client", () => {
         get
       });
 
+      //reset selfcare client instance
+      resetInstance();
+
       const result = await getSelfcareClient().getUserAuthorizedInstitutions(
         mocks.aSelfcareUserId
       )();
@@ -96,6 +99,9 @@ describe("Selfcare Client", () => {
         get
       });
 
+      //reset selfcare client instance
+      resetInstance();
+
       const result = await getSelfcareClient().getUserAuthorizedInstitutions(
         mocks.aSelfcareUserId
       )();
@@ -115,6 +121,9 @@ describe("Selfcare Client", () => {
       create.mockReturnValueOnce({
         get
       });
+
+      //reset selfcare client instance
+      resetInstance();
 
       const result = await getSelfcareClient().getUserAuthorizedInstitutions(
         mocks.aSelfcareUserId
@@ -139,6 +148,9 @@ describe("Selfcare Client", () => {
       create.mockReturnValueOnce({
         get
       });
+
+      //reset selfcare client instance
+      resetInstance();
 
       const result = await getSelfcareClient().getInstitutionById(
         mocks.institution.id as string
@@ -165,6 +177,9 @@ describe("Selfcare Client", () => {
         get
       });
 
+      //reset selfcare client instance
+      resetInstance();
+
       const result = await getSelfcareClient().getInstitutionById(
         mocks.institution.id as string
       )();
@@ -181,8 +196,11 @@ describe("Selfcare Client", () => {
         get
       });
 
+      //reset selfcare client instance
+      resetInstance();
+
       const result = await getSelfcareClient().getInstitutionById(
-        mocks.institution.id
+        mocks.institution.id as string
       )();
 
       expect(get).toHaveBeenCalledWith(`/institutions/${mocks.institution.id}`);

--- a/apps/backoffice/src/lib/be/cms-client.ts
+++ b/apps/backoffice/src/lib/be/cms-client.ts
@@ -1,12 +1,13 @@
-import { createClient } from "@/generated/services-cms/client";
+import { Client, createClient } from "@/generated/services-cms/client";
 import { getFetch } from "@pagopa/ts-commons/lib/agent";
 import { BooleanFromString } from "@pagopa/ts-commons/lib/booleans";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as t from "io-ts";
-import { cache } from "react";
 import { HealthChecksError } from "./errors";
+
+let ioServicesCmsClient: Client;
 
 const Config = t.type({
   API_SERVICES_CMS_URL: NonEmptyString,
@@ -25,7 +26,7 @@ const getIoServicesCmsClientConfig = () => {
   return result.right;
 };
 
-export const getIoServicesCmsClient = cache(() => {
+const buildIoServicesCmsClient = (): Client => {
   const configuration = getIoServicesCmsClientConfig();
 
   if (configuration.API_SERVICES_CMS_MOCKING) {
@@ -38,7 +39,14 @@ export const getIoServicesCmsClient = cache(() => {
     fetchApi: getFetch(process.env),
     basePath: configuration.API_SERVICES_CMS_BASE_PATH
   });
-});
+};
+
+export const getIoServicesCmsClient = (): Client => {
+  if (!ioServicesCmsClient) {
+    ioServicesCmsClient = buildIoServicesCmsClient();
+  }
+  return ioServicesCmsClient;
+};
 
 export async function getIoServicesCmsHealth() {
   try {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
**Refactor clients singleton**
#### List of Changes
- ADD client healthchecks in /info and /health Route Handler
- REMOVE react cache and transform into a classic singleton `@/lib/be/selfcare-client`
- REMOVE react cache and transform into a classic singleton `@/lib/be/apim-service`
- REMOVE react cache and transform into a classic singleton `@/lib/be/cms-client`
- REMOVE react cache and transform into a classic singleton `@/lib/be/cosmos-store`
- REMOVE react cache and transform into a classic singleton `@/lib/be/legacy-cosmos`
- REMOVE react cache and transform into a classic singleton `@/lib/be/subscription-migration-client`

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
