### PR TITLE
[IOPAE-784] Update service details drawer

### DIFF
--- a/.changeset/nervous-countries-reflect.md
+++ b/.changeset/nervous-countries-reflect.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Update service details drawer

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -293,6 +293,7 @@
       "pec": "Pec",
       "phone": "Phone",
       "privacyUrl": "Privacy",
+      "sensitive": "Sensitive service",
       "serviceId": "Service ID",
       "status": "Status",
       "supportUrl": "Support url",

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -293,6 +293,7 @@
       "pec": "Pec",
       "phone": "Telefono",
       "privacyUrl": "Privacy",
+      "sensitive": "Servizio sensibile",
       "serviceId": "ID Servizio",
       "status": "Stato",
       "supportUrl": "Url di supporto",

--- a/apps/backoffice/src/components/cards/card-rows.tsx
+++ b/apps/backoffice/src/components/cards/card-rows.tsx
@@ -1,17 +1,19 @@
 import { Grid, Stack, Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import NextLink from "next/link";
-import { ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { ApiKeyValue } from "../api-keys";
 import { CopyToClipboard } from "../copy-to-clipboard";
 import { LoaderSkeleton } from "../loaders";
-import React from "react";
+import { MarkdownView } from "../markdown-view";
 
 export type CardRowType = {
   /** row label, shown on left */
   label: string;
   /** row value, shown on right */
   value?: string | ReactNode;
+  /** if `true`, renders value on a new line _(the default behaviour renders value inline, with its label on left)_ */
+  renderValueOnNewLine?: boolean;
   /** If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis.
    * _(This is the default behaviour)_ */
   noWrap?: boolean;
@@ -76,17 +78,20 @@ export const CardRows = ({ rows }: CardRowsProps) => {
       case "link":
         return renderValue(
           row.value,
-          <NextLink
-            href={(row.value as string) ?? "/"}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {renderTextValue(row)}
-          </NextLink>
+          row.value ? (
+            <NextLink
+              href={row.value as string}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {renderTextValue(row)}
+            </NextLink>
+          ) : (
+            renderTextValue(row)
+          )
         );
       case "markdown":
-        // todo: to be implemented
-        return <span>{row.value}</span>;
+        return <MarkdownView>{(row.value as string) ?? ""}</MarkdownView>;
       default:
         return renderValue(
           row.value,
@@ -111,12 +116,12 @@ export const CardRows = ({ rows }: CardRowsProps) => {
           marginTop={2}
           alignItems="center"
         >
-          <Grid item xs={4}>
+          <Grid item xs={row.renderValueOnNewLine ? 12 : 4}>
             <Typography variant="body2" noWrap>
               {t(row.label)}
             </Typography>
           </Grid>
-          <Grid item xs={8}>
+          <Grid item xs={row.renderValueOnNewLine ? 12 : 8}>
             <Stack direction="row" alignItems="center" spacing={0.5}>
               {manageRowValue(row)}
             </Stack>

--- a/apps/backoffice/src/components/markdown-view/index.ts
+++ b/apps/backoffice/src/components/markdown-view/index.ts
@@ -1,0 +1,1 @@
+export * from "./markdown-view";

--- a/apps/backoffice/src/components/markdown-view/markdown-view.tsx
+++ b/apps/backoffice/src/components/markdown-view/markdown-view.tsx
@@ -1,0 +1,20 @@
+import Markdown from "react-markdown";
+
+export type MarkdownViewProps = {
+  /** string value with markdown syntax to be rendered */
+  children?: string;
+};
+
+/** Renders markdown syntax */
+export const MarkdownView = ({ children }: MarkdownViewProps) => {
+  return (
+    <span style={{ fontSize: "16px" }}>
+      <Markdown
+        unwrapDisallowed
+        allowedElements={["p", "strong", "em", "ul", "ol", "li", "a"]}
+      >
+        {children}
+      </Markdown>
+    </span>
+  );
+};

--- a/apps/backoffice/src/components/services/service-info.tsx
+++ b/apps/backoffice/src/components/services/service-info.tsx
@@ -1,11 +1,12 @@
 import { ServiceLifecycleStatusTypeEnum } from "@/generated/api/ServiceLifecycleStatusType";
 import { Service } from "@/types/service";
-import { Category, ReadMore } from "@mui/icons-material";
+import { Category, PrivacyTip, ReadMore } from "@mui/icons-material";
 import { Box, Stack, Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import { ServiceStatus } from ".";
 import { CardDetails, CardRowType, CardRows } from "../cards";
 import { useDrawer } from "../drawer-provider";
+import { MarkdownView } from "../markdown-view";
 
 export type ServiceInfoProps = {
   data?: Service;
@@ -16,8 +17,8 @@ export const ServiceInfo = ({ data }: ServiceInfoProps) => {
   const { t } = useTranslation();
   const { openDrawer } = useDrawer();
 
-  /** row list for minified information card */
-  const buildRowsMin = () => {
+  /** row list for minified/basic information card */
+  const buildRowsMin = (valueOnNewLine?: boolean) => {
     const rowsMin: CardRowType[] = [];
     rowsMin.push({
       label: "routes.service.status",
@@ -28,18 +29,21 @@ export const ServiceInfo = ({ data }: ServiceInfoProps) => {
         label: "routes.service.visibility",
         value: data?.visibility
           ? t(`service.visibility.${data?.visibility}`)
-          : undefined
+          : undefined,
+        renderValueOnNewLine: valueOnNewLine
       });
     }
     rowsMin.push(
       {
         label: "routes.service.serviceId",
-        value: data?.id
+        value: data?.id,
+        renderValueOnNewLine: valueOnNewLine
       },
       {
         label: "routes.service.lastUpdate",
         value: data?.lastUpdate,
-        kind: "datetime"
+        kind: "datetime",
+        renderValueOnNewLine: valueOnNewLine
       }
     );
     return rowsMin;
@@ -47,45 +51,71 @@ export const ServiceInfo = ({ data }: ServiceInfoProps) => {
 
   /** row list for full drawer details */
   const rowsExt: CardRowType[] = [
-    ...buildRowsMin(),
-    { label: "routes.service.name", value: data?.name }
+    ...buildRowsMin(true),
+    {
+      label: "routes.service.name",
+      value: data?.name,
+      renderValueOnNewLine: true
+    }
   ];
 
   /** row list for full drawer details */
   const rowsLinksContacts: CardRowType[] = [
     {
       label: "routes.service.privacyUrl",
-      value: data?.metadata.privacy_url,
-      kind: "link"
+      value: data?.metadata.privacy_url ?? "",
+      kind: "link",
+      renderValueOnNewLine: true
     },
     {
       label: "routes.service.tosUrl",
-      value: data?.metadata.tos_url,
-      kind: "link"
+      value: data?.metadata.tos_url ?? "",
+      kind: "link",
+      renderValueOnNewLine: true
     },
-    { label: "routes.service.phone", value: data?.metadata.phone },
+    {
+      label: "routes.service.phone",
+      value: data?.metadata.phone ?? "",
+      renderValueOnNewLine: true
+    },
     {
       label: "routes.service.supportUrl",
-      value: data?.metadata.support_url,
-      kind: "link"
+      value: data?.metadata.support_url ?? "",
+      kind: "link",
+      renderValueOnNewLine: true
     },
     {
       label: "routes.service.webUrl",
-      value: data?.metadata.web_url,
-      kind: "link"
+      value: data?.metadata.web_url ?? "",
+      kind: "link",
+      renderValueOnNewLine: true
     },
-    { label: "routes.service.address", value: data?.metadata.address },
-    { label: "routes.service.email", value: data?.metadata.email },
-    { label: "routes.service.pec", value: data?.metadata.pec },
+    {
+      label: "routes.service.address",
+      value: data?.metadata.address ?? "",
+      renderValueOnNewLine: true
+    },
+    {
+      label: "routes.service.email",
+      value: data?.metadata.email ?? "",
+      renderValueOnNewLine: true
+    },
+    {
+      label: "routes.service.pec",
+      value: data?.metadata.pec ?? "",
+      renderValueOnNewLine: true
+    },
     {
       label: "routes.service.appIos",
-      value: data?.metadata.app_ios,
-      kind: "link"
+      value: data?.metadata.app_ios ?? "",
+      kind: "link",
+      renderValueOnNewLine: true
     },
     {
       label: "routes.service.appAndroid",
-      value: data?.metadata.app_android,
-      kind: "link"
+      value: data?.metadata.app_android ?? "",
+      kind: "link",
+      renderValueOnNewLine: true
     }
   ];
 
@@ -97,17 +127,29 @@ export const ServiceInfo = ({ data }: ServiceInfoProps) => {
     </Box>
   );
 
+  const renderSensitiveService = () => {
+    if (data?.require_secure_channel)
+      return (
+        <Stack direction="row" alignContent="center" spacing={1} marginTop={3}>
+          <PrivacyTip sx={{ fontSize: "24px" }} />
+          <Typography variant="body2">
+            {t("routes.service.sensitive")}
+          </Typography>
+        </Stack>
+      );
+  };
+
   const openDetails = () => {
     const content = (
-      <Box width="25vw">
+      <Box width="25vw" marginBottom={5}>
         <Stack direction="row" spacing={1} marginBottom={4}>
           <Category color="inherit" />
           <Typography variant="h6">{t("service.details")}</Typography>
         </Stack>
-        {renderSectionTitle("routes.service.information")}
         <CardRows rows={rowsExt} />
         {renderSectionTitle("routes.service.description")}
-        <Typography variant="body2">{data?.description}</Typography>
+        <MarkdownView>{data?.description}</MarkdownView>
+        {renderSensitiveService()}
         {renderSectionTitle("routes.service.linksContacts")}
         <CardRows rows={rowsLinksContacts} />
       </Box>

--- a/apps/backoffice/src/components/services/service-preview.tsx
+++ b/apps/backoffice/src/components/services/service-preview.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import { useEffect, useState } from "react";
-import Markdown from "react-markdown";
+import { MarkdownView } from "../markdown-view";
 
 export type ServicePreviewProps = {
   isOpen: boolean;
@@ -75,12 +75,7 @@ export const ServicePreview = ({
               }
             }}
           >
-            <Markdown
-              unwrapDisallowed
-              allowedElements={["p", "strong", "em", "ul", "ol", "li", "a"]}
-            >
-              {description}
-            </Markdown>
+            <MarkdownView>{description}</MarkdownView>
           </Grid>
         </Grid>
       </DialogContent>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Update of the drawer that displays service details data.
In particular:
- added _"Sensitive Service"_ label after the description, in case of flag `require_secure_channel = true`
- added rendering of description markdown syntax
- Added the ability to show the label/value pair on two lines

#### List of Changes
- new translations
- new reusable **MarkdownView** component
- add `renderValueOnNewLine` prop on **CardRows** component
- update service-info for service details data
<!--- Describe your changes in detail -->

#### Motivation and Context
Need to correctly show all the data of a service.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/ef909fe8-15d6-46d3-adef-2654ce7cfd44


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
