### PR TITLE
feat: [IOPAE-816] make publish and unpublish actions idempotent

### DIFF
--- a/.changeset/tender-items-ring.md
+++ b/.changeset/tender-items-ring.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/models": minor
+"io-services-cms-webapp": minor
+---
+
+make publish and unpublish actions idempotent

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=**/__test__/*,**/__tests__/*,**/mocks/**
+sonar.cpd.exclusions=**/__test__/*,**/__tests__/*,**/mocks/**,**/service-lifecycle/**,**/service-publication/**

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/publish-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/publish-service.test.ts
@@ -153,7 +153,7 @@ describe("publishService", () => {
     expect(response.statusCode).toBe(404);
   });
 
-  it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
+  it("should allow create release when service is already published", async () => {
     await servicePublicationStore.save("s1", {
       ...aServicePub,
       id: "s1" as NonEmptyString,
@@ -168,8 +168,8 @@ describe("publishService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
-    expect(response.statusCode).toBe(409);
+    expect(mockContext.log.error).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(204);
   });
 
   it("should not allow the operation without right group", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/unpublish-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/unpublish-service.test.ts
@@ -137,7 +137,7 @@ describe("UnPublishService", () => {
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
-    blobService: mockBlobService
+    blobService: mockBlobService,
   });
 
   setAppContext(app, mockContext);
@@ -156,7 +156,7 @@ describe("UnPublishService", () => {
     expect(response.statusCode).toBe(404);
   });
 
-  it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
+  it("should allow delete release when service is already unpublished", async () => {
     await servicePublicationStore.save("s2", {
       ...aServicePub,
       fsm: { state: "unpublished" },
@@ -170,8 +170,8 @@ describe("UnPublishService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
-    expect(response.statusCode).toBe(409);
+    expect(mockContext.log.error).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(204);
   });
 
   it("should not allow the operation without right group", async () => {

--- a/packages/io-services-cms-models/src/lib/fsm/types.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/types.ts
@@ -83,7 +83,10 @@ export type Transition<
         ? { args: Action[1] }
         : { args: undefined }) &
       Record<string, never>
-  ) => E.Either<FsmTransitionExecutionError, WithState<ToState[0], ToState[1]>>;
+  ) => E.Either<
+    FsmTransitionExecutionError,
+    WithState<ToState[0], ToState[1]> & { hasChanges: boolean }
+  >;
 };
 
 export class FsmItemNotFoundError extends Error {

--- a/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
@@ -5,7 +5,7 @@ import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import { sequence } from "fp-ts/lib/Array";
 import { pipe } from "fp-ts/lib/function";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExpectStatic, beforeEach, describe, expect, it, vi } from "vitest";
 import { FSM, ItemType, getFsmClient } from "..";
 import {
   FSMStore,
@@ -67,7 +67,7 @@ const expectFailure = async ({
 }: {
   id: NonEmptyString;
   actions: RTE.ReaderTaskEither<void, unknown, unknown>[];
-  expected: Vi.ExpectStatic | undefined;
+  expected: ExpectStatic | undefined;
   errorType: unknown;
   additionalPreTestFn: Function | undefined;
   additionalPostTestFn: Function | undefined;

--- a/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
@@ -5,12 +5,11 @@ import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import { sequence } from "fp-ts/lib/Array";
 import { pipe } from "fp-ts/lib/function";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExpectStatic, beforeEach, describe, expect, it, vi } from "vitest";
 import { ItemType, getFsmClient } from "..";
 import {
   FSMStore,
   FsmItemNotFoundError,
-  FsmNoTransitionMatchedError,
   FsmStoreFetchError,
   FsmStoreSaveError,
   WithState,
@@ -66,7 +65,7 @@ const expectFailure = async ({
 }: {
   id: NonEmptyString;
   actions: RTE.ReaderTaskEither<void, unknown, unknown>[];
-  expected: Vi.ExpectStatic | undefined;
+  expected: ExpectStatic | undefined;
   errorType: unknown;
   additionalPreTestFn: Function | undefined;
   additionalPostTestFn: Function | undefined;
@@ -207,22 +206,6 @@ describe("apply", () => {
       additionalPreTestFn: undefined,
       additionalPostTestFn: undefined,
     },
-    {
-      title: "on invalid sequence of actions",
-      id: aServiceId,
-      actions: [
-        /* last ok --> */ () =>
-          fsmClient.release(aServiceId, { data: aService }),
-        /* this ko --> */ () => fsmClient.unpublish(aServiceId),
-      ],
-      expected: expect.objectContaining({
-        ...aService, // we expect the first release to have succeeded
-        fsm: expect.objectContaining({ state: "unpublished" }),
-      }),
-      errorType: FsmNoTransitionMatchedError,
-      additionalPreTestFn: undefined,
-      additionalPostTestFn: undefined,
-    },
   ])("should fail $title", expectFailure);
 
   it("should fail with FsmStoreFetchError if fetch on store return an Error", async () => {
@@ -265,6 +248,50 @@ describe("apply", () => {
     }
     const { left: value } = result;
     expect(value).toBeInstanceOf(FsmStoreSaveError);
+  });
+
+  it("should 'do nothing' when publishing an already published item", async () => {
+    const currentItem = { ...aService, fsm: { state: "published" } };
+    const mockStore = {
+      fetch: vi.fn(() => {
+        return TE.of(O.some(currentItem));
+      }),
+      save: vi.fn(() => {
+        return TE.left(new Error());
+      }),
+    } as unknown as FSMStore<ItemType>;
+    const mockFsmClient = getFsmClient(mockStore);
+
+    const result = await mockFsmClient.publish(aServiceId)();
+
+    if (E.isLeft(result)) {
+      throw new Error(`Expecting a success`);
+    }
+    const { right: value } = result;
+    expect(value).toStrictEqual(currentItem);
+    expect(mockStore.save).not.toHaveBeenCalled();
+  });
+
+  it("should 'do nothing' when unpublishing an already unpublished item", async () => {
+    const currentItem = { ...aService, fsm: { state: "unpublished" } };
+    const mockStore = {
+      fetch: vi.fn(() => {
+        return TE.of(O.some(currentItem));
+      }),
+      save: vi.fn(() => {
+        return TE.left(new Error());
+      }),
+    } as unknown as FSMStore<ItemType>;
+    const mockFsmClient = getFsmClient(mockStore);
+
+    const result = await mockFsmClient.unpublish(aServiceId)();
+
+    if (E.isLeft(result)) {
+      throw new Error(`Expecting a success`);
+    }
+    const { right: value } = result;
+    expect(value).toStrictEqual(currentItem);
+    expect(mockStore.save).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/io-services-cms-models/src/service-publication/index.ts
+++ b/packages/io-services-cms-models/src/service-publication/index.ts
@@ -196,6 +196,7 @@ const FSM: FSM = {
       action: "unpublish",
       from: "unpublished",
       to: "unpublished",
+      // eslint-disable-next-line sonarjs/no-identical-functions
       exec: ({ current }) =>
         E.right({
           ...current,

--- a/packages/io-services-cms-models/src/service-publication/index.ts
+++ b/packages/io-services-cms-models/src/service-publication/index.ts
@@ -69,7 +69,9 @@ type FSM = {
     Transition<Action<"release">, State<"published">, State<"published">>,
     Transition<Action<"publish">, void, State<"published">>,
     Transition<Action<"publish">, State<"unpublished">, State<"published">>,
-    Transition<Action<"unpublish">, State<"published">, State<"unpublished">>
+    Transition<Action<"publish">, State<"published">, State<"published">>,
+    Transition<Action<"unpublish">, State<"published">, State<"unpublished">>,
+    Transition<Action<"unpublish">, State<"unpublished">, State<"unpublished">>
   ];
 };
 
@@ -98,6 +100,7 @@ const FSM: FSM = {
             state: "unpublished",
             lastTransition: "apply release on empty",
           },
+          hasChanges: true,
         }),
     },
     {
@@ -113,6 +116,7 @@ const FSM: FSM = {
             state: "unpublished",
             lastTransition: "apply release on unpublished",
           },
+          hasChanges: true,
         }),
     },
     {
@@ -128,6 +132,7 @@ const FSM: FSM = {
             state: "published",
             lastTransition: "apply release on published",
           },
+          hasChanges: true,
         }),
     },
     {
@@ -142,6 +147,7 @@ const FSM: FSM = {
             state: "published",
             lastTransition: "apply publish on empty",
           },
+          hasChanges: true,
         }),
     },
     {
@@ -156,6 +162,18 @@ const FSM: FSM = {
             state: "published",
             lastTransition: "apply publish on unpublished",
           },
+          hasChanges: true,
+        }),
+    },
+    {
+      id: "apply publish on published",
+      action: "publish",
+      from: "published",
+      to: "published",
+      exec: ({ current }) =>
+        E.right({
+          ...current,
+          hasChanges: false,
         }),
     },
     {
@@ -170,6 +188,18 @@ const FSM: FSM = {
             state: "unpublished",
             lastTransition: "apply unpublish on published",
           },
+          hasChanges: true,
+        }),
+    },
+    {
+      id: "apply unpublish on unpublished",
+      action: "unpublish",
+      from: "unpublished",
+      to: "unpublished",
+      exec: ({ current }) =>
+        E.right({
+          ...current,
+          hasChanges: false,
         }),
     },
   ],
@@ -267,7 +297,10 @@ function apply(
                 E.map(
                   RA.map(
                     (tr) =>
-                      (): E.Either<FsmTransitionExecutionError, AllResults> =>
+                      (): E.Either<
+                        FsmTransitionExecutionError,
+                        AllResults & { hasChanges: boolean }
+                      > =>
                         // FIXME: avoid this forcing
                         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                         // @ts-ignore
@@ -298,7 +331,10 @@ function apply(
                     //  bind all data into a lazy implementation of exec
                     E.map(
                       (current) =>
-                        (): E.Either<FsmTransitionExecutionError, AllResults> =>
+                        (): E.Either<
+                          FsmTransitionExecutionError,
+                          AllResults & { hasChanges: boolean }
+                        > =>
                           tr.exec({
                             // FIXME: avoid this forcing
                             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -336,10 +372,13 @@ function apply(
       TE.map((exec) => exec()),
       TE.map(TE.fromEither),
       TE.flattenW,
-      // save new status in the store
-      TE.chain((newItem) =>
+      TE.chain(({ hasChanges, ...newItem }) =>
         pipe(
-          store.save(id, newItem),
+          hasChanges
+            ? // save new status in the store
+              store.save(id, newItem)
+            : // no changes to save
+              TE.right(newItem),
           TE.mapLeft((_) => new FsmStoreSaveError())
         )
       )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Make publish and unpublish actions (Publication FSM) idempotent

#### List of Changes
<!--- Describe your changes in detail -->
- add action publish: published -> published
- add action unpublish: unpublished -> unpublished

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid errors (and, thus, log entropy) when the requested action makes no change to the current state of the item

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
