### PR TITLE
bugfix: [IOPAE-826] FE - Get user authorized institutions from api instead of session token

### DIFF
--- a/.changeset/healthy-apricots-remember.md
+++ b/.changeset/healthy-apricots-remember.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Frontend header: get user authorized institutions from api instead of session token

--- a/apps/backoffice/mocks/data/selfcare-data.ts
+++ b/apps/backoffice/mocks/data/selfcare-data.ts
@@ -1,7 +1,4 @@
-import { SelfcareRoles } from "@/types/auth";
 import { faker } from "@faker-js/faker/locale/it";
-
-const MAX_ARRAY_LENGTH = 20;
 
 export const aMockedIdentiyToken =
   "eyJraWQiOiJkNDoxZDo4YzpkOTo4ZjowMDpiMjowNDplOTo4MDowOTo5ODplYzpmODo0Mjo3ZSIsInR5cCI6IkpXVCIsImFsZyI6IlJTMjU2In0.eyJlbWFpbCI6Im0uY3VyaWVAdGVzdC5lbWFpbC5pdCIsImZhbWlseV9uYW1lIjoiQ3VyaWUiLCJmaXNjYWxfbnVtYmVyIjoiQ1JVTVJBNzZTNThBOTQ0ViIsIm5hbWUiOiJNYXJpZSIsImZyb21fYWEiOmZhbHNlLCJ1aWQiOiIyYjEwODUyZi1hNGZkLTRhZTgtOWRmYy1hYzM1NzhmYzViMjEiLCJsZXZlbCI6IkwyIiwiaWF0IjoxNjk2NTExNDI1LCJleHAiOjE3OTY1MTE0NDAsImF1ZCI6ImxvY2FsaG9zdCIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMC9tb2Nrcy9zZWxmY2FyZSIsImp0aSI6IjUyMjE2OTkyLTY3MGEtNDUzYi1hYTVmLWU4NmI0ZGM3OGM3YSIsIm9yZ2FuaXphdGlvbiI6eyJpZCI6Ijc0ZGFlZmRhLTdlNzItNDZlMi04MTVhLWIyNmQzYmY5ODk4OCIsIm5hbWUiOiJDb211bmUgZGkgQ2lzdGVybmlubyIsInJvbGVzIjpbeyJwYXJ0eVJvbGUiOiJERUxFR0FURSIsInJvbGUiOiJhZG1pbiJ9XSwic3ViVW5pdENvZGUiOm51bGwsInN1YlVuaXRUeXBlIjoiRUMiLCJhb29QYXJlbnQiOm51bGwsInBhcmVudERlc2NyaXB0aW9uIjpudWxsLCJyb290UGFyZW50Ijp7ImlkIjpudWxsLCJkZXNjcmlwdGlvbiI6bnVsbH0sImZpc2NhbF9jb2RlIjoiODEwMDE0NzA3NDkiLCJpcGFDb2RlIjoiY19jNzQxIn0sImRlc2lyZWRfZXhwIjoxNjk2NTQzNzczfQ.raB5wxcW-GqsyvYN151qL4FvX-0se--OwDyWOFZ6qjkSvLjHdXW2VhaDLM1bt-KI2GE_ytXq-WmsMH9ZtmkAbV9BqjrtgxavnPxnWrH9PlabccFfssaUpR2pdpMExV4Lkl0qykNIvW2dUV72Hua4nMutG8I5Gb5ON24yn5ISisTe8x7R1vfDhAYKRs86Jx_vKpWAcGuyTAe1NZWN3yefxTt5_589bPvNq9htYT4DtJkLQQSxBi25Tv-O6ap_L40eMK0HHbi0r62NZ-cl_kZ5oX0Rf5WUAcLcrLuCXTxXNgqaIFlqlqoFsqxYtgXQYqJhB3vLfN6f6CiTZxeXDiA8bA";
@@ -21,6 +18,20 @@ export const aWellKnown = {
     }
   ]
 };
+
+export const aMockCurrentUserAuthorizedInstitution = {
+  id: "74daefda-7e72-46e2-815a-b26d3bf98988",
+  name: "Comune di Cisternino",
+  role: "admin",
+  logo_url: ""
+};
+
+export const getMockUserAuthorizedInstitution = () => ({
+  id: faker.string.uuid(),
+  name: faker.company.name(),
+  role: faker.helpers.arrayElement(["admin", "operator"]),
+  logo_url: ""
+});
 
 export const getMockInstitution = (institutionId?: string) => ({
   id: institutionId ?? faker.string.uuid(),

--- a/apps/backoffice/mocks/handlers/backend-handlers.ts
+++ b/apps/backoffice/mocks/handlers/backend-handlers.ts
@@ -19,7 +19,11 @@ import {
   getMockServicesMigrationStatusDetails
 } from "../data/backend-data";
 import { aMockErrorResponse } from "../data/common-data";
-import { getMockInstitution } from "../data/selfcare-data";
+import {
+  aMockCurrentUserAuthorizedInstitution,
+  getMockInstitution,
+  getMockUserAuthorizedInstitution
+} from "../data/selfcare-data";
 
 const MAX_ARRAY_LENGTH = 20;
 
@@ -318,7 +322,7 @@ export const buildHandlers = () => {
     }),
     rest.get(`${baseURL}/institutions`, (_, res, ctx) => {
       const resultArray = [
-        [ctx.status(200), ctx.json(getGetInstitutions200Response())],
+        [ctx.status(200), ctx.json(getUserAuthorizedInstitutions200Response())],
         [ctx.status(401), ctx.json(null)],
         [ctx.status(403), ctx.json(null)],
         [ctx.status(429), ctx.json(null)],
@@ -472,12 +476,15 @@ export function getGetPublishedService200Response() {
   return aMockServicePublication;
 }
 
-export function getGetInstitutions200Response() {
-  return [
-    ...Array.from(
-      Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys()
-    )
-  ].map(_ => getMockInstitution());
+export function getUserAuthorizedInstitutions200Response() {
+  return {
+    authorizedInstitutions: [
+      aMockCurrentUserAuthorizedInstitution,
+      ...Array.from(
+        Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys()
+      )
+    ].map(_ => getMockUserAuthorizedInstitution())
+  };
 }
 
 export function getGetInstitution200Response() {

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -721,9 +721,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/UserAuthorizedInstitutions'
+                $ref: '#/components/schemas/UserAuthorizedInstitutions'
         '401':
           description: Unauthorized
         '403':


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The way `UserAuthorizedInstitutions` list is retrieved has been changed.

Before this change the list was present in the session token, which caused size problems for delegates of many entities.
For this reason, the session token has been _(in another PR)_ streamlined from this list and it will be a frontend task to retrieve the list of `UserAuthorizedInstitutions` from the specific B4F api, i.e. `getUserAuthorizedInstitutions`.

_Follow commits history to better understand developments._

#### List of Changes
- fix a typo in b4f openapi
- update mocks
- change header components way of fetch UserAuthorizedInstitutions
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mock
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
