### PR TITLE
bugfix: [IOPAE-829] patch apim user lastname max length

### DIFF
--- a/.changeset/young-pets-laugh.md
+++ b/.changeset/young-pets-laugh.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+truncate organization name to 100 characters before set apim user lastName fields during apim user creation

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
@@ -217,7 +217,7 @@ const createApimUser = (config: Configuration) => (
         email: formatApimAccountEmailForSelfcareOrganization(
           identityTokenPayload.organization
         ),
-        firstName: identityTokenPayload.organization.name,
+        firstName: identityTokenPayload.organization.name.substring(0, 100),
         lastName: identityTokenPayload.organization.id,
         note: identityTokenPayload.organization.fiscal_code
       }),

--- a/apps/backoffice/src/app/api/auth/types.ts
+++ b/apps/backoffice/src/app/api/auth/types.ts
@@ -1,5 +1,10 @@
 import * as t from "io-ts";
-import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import {
+  EmailString,
+  NonEmptyString,
+  OrganizationFiscalCode,
+  FiscalCode
+} from "@pagopa/ts-commons/lib/strings";
 
 export type SessionTokenInstitution = t.TypeOf<typeof SessionTokenInstitution>;
 export const SessionTokenInstitution = t.intersection([
@@ -55,21 +60,21 @@ export type IdentityTokenOrganizationRole = t.TypeOf<
   typeof IdentityTokenOrganizationRole
 >;
 export const IdentityTokenOrganizationRole = t.type({
-  partyRole: t.string,
-  role: t.string
+  partyRole: NonEmptyString,
+  role: NonEmptyString
 });
 export type IdentityTokenOrganization = t.TypeOf<
   typeof IdentityTokenOrganization
 >;
 export const IdentityTokenOrganization = t.intersection([
   t.type({
-    id: t.string,
-    fiscal_code: t.string,
-    name: t.string,
+    id: NonEmptyString,
+    fiscal_code: OrganizationFiscalCode,
+    name: NonEmptyString,
     roles: t.array(IdentityTokenOrganizationRole)
   }),
   t.partial({
-    groups: t.array(t.string)
+    groups: t.array(NonEmptyString)
   })
 ]);
 
@@ -88,16 +93,16 @@ export const IdentityTokenPayload = t.type({
   /** (JWT ID) Claim */
   jti: t.string,
   /** (Surname or last name) Claim */
-  family_name: t.string,
+  family_name: NonEmptyString,
   /** (Given name or first name) Claim */
-  name: t.string,
+  name: NonEmptyString,
   /** (Preferred e-mail address) Claim */
-  email: t.string,
+  email: EmailString,
   // Custom Claims
   /** (User ID) Claim */
-  uid: t.string,
+  uid: NonEmptyString,
   /** (Fiscal code) Custom Claim */
-  fiscal_number: t.string,
+  fiscal_number: FiscalCode,
   /** (Desired Expired Time) Claim */
   desired_exp: t.number,
   /** (Selfcare Institution) Custom Claim */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Truncate organization name to 100 characters before set apim user lastName fields during apim user creation

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
