### PR TITLE
fix: [#IOPAE-912] replace findOneByServiceId method call with findLastVersionByModelId

### DIFF
--- a/.changeset/tricky-cherries-sniff.md
+++ b/.changeset/tricky-cherries-sniff.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Replace findOneByServiceId with findLastVersionByModelId in request-sync-legacy-handler

--- a/apps/io-services-cms-webapp/src/synchronizer/__tests__/request-sync-legacy-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/synchronizer/__tests__/request-sync-legacy-handler.test.ts
@@ -129,7 +129,7 @@ describe("Sync Legacy Handler", () => {
   it("should return an error if find legacy service fails", async () => {
     const context = createContext();
     const legacyServiceModelMock = {
-      findOneByServiceId: vi.fn(() => {
+      findLastVersionByModelId: vi.fn(() => {
         return TE.left(CosmosEmptyResponse);
       }),
       create: vi.fn(),
@@ -146,16 +146,16 @@ describe("Sync Legacy Handler", () => {
 
     expect(legacyServiceModelMock.create).not.toBeCalled();
     expect(legacyServiceModelMock.update).not.toBeCalled();
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledTimes(1);
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledWith(
-      aRequestSyncLegacyItem.serviceId
-    );
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
   });
 
   it("should return an error if legacy service creation fails", async () => {
     const context = createContext();
     const legacyServiceModelMock = {
-      findOneByServiceId: vi.fn(() => {
+      findLastVersionByModelId: vi.fn(() => {
         return TE.right(O.none);
       }),
       create: vi.fn(() => {
@@ -173,17 +173,17 @@ describe("Sync Legacy Handler", () => {
     ).rejects.toThrowError(CosmosConflictResponse.kind);
 
     expect(legacyServiceModelMock.update).not.toBeCalled();
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledTimes(1);
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledWith(
-      aRequestSyncLegacyItem.serviceId
-    );
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
     expect(legacyServiceModelMock.create).toBeCalledTimes(1);
   });
 
   it("should return an error if legacy service update fails", async () => {
     const context = createContext();
     const legacyServiceModelMock = {
-      findOneByServiceId: vi.fn(() => {
+      findLastVersionByModelId: vi.fn(() => {
         return TE.right(O.some(aRetrievedService));
       }),
       create: vi.fn(),
@@ -201,17 +201,17 @@ describe("Sync Legacy Handler", () => {
     ).rejects.toThrowError(CosmosConflictResponse.kind);
 
     expect(legacyServiceModelMock.create).not.toBeCalled();
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledTimes(1);
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledWith(
-      aRequestSyncLegacyItem.serviceId
-    );
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
     expect(legacyServiceModelMock.update).toBeCalledTimes(1);
   });
 
   it("should create a new legacy service with CMS tag", async () => {
     const context = createContext();
     const legacyServiceModelMock = {
-      findOneByServiceId: vi.fn(() => {
+      findLastVersionByModelId: vi.fn(() => {
         return TE.right(O.none);
       }),
       create: vi.fn(() => {
@@ -228,10 +228,10 @@ describe("Sync Legacy Handler", () => {
 
     expect(res).toBeUndefined();
     expect(legacyServiceModelMock.update).not.toBeCalled();
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledTimes(1);
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledWith(
-      aRequestSyncLegacyItem.serviceId
-    );
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
     expect(legacyServiceModelMock.create).toBeCalledTimes(1);
     expect(legacyServiceModelMock.create).toBeCalledWith(
       expect.objectContaining({ cmsTag: true })
@@ -264,7 +264,7 @@ describe("Sync Legacy Handler", () => {
     } as unknown as Queue.RequestSyncLegacyItem;
 
     const legacyServiceModelMock = {
-      findOneByServiceId: vi.fn(() => {
+      findLastVersionByModelId: vi.fn(() => {
         return TE.right(O.none);
       }),
       create: vi.fn(() => {
@@ -281,10 +281,10 @@ describe("Sync Legacy Handler", () => {
 
     expect(res).toBeUndefined();
     expect(legacyServiceModelMock.update).not.toBeCalled();
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledTimes(1);
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledWith(
-      aRequestSyncLegacyItem.serviceId
-    );
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
     expect(legacyServiceModelMock.create).toBeCalledTimes(1);
     expect(legacyServiceModelMock.create).toBeCalledWith(
       expect.objectContaining({ cmsTag: true })
@@ -294,7 +294,7 @@ describe("Sync Legacy Handler", () => {
   it("should update a new legacy service with CMS tag", async () => {
     const context = createContext();
     const legacyServiceModelMock = {
-      findOneByServiceId: vi.fn(() => {
+      findLastVersionByModelId: vi.fn(() => {
         return TE.right(O.some(aRetrievedService));
       }),
       create: vi.fn(),
@@ -314,10 +314,10 @@ describe("Sync Legacy Handler", () => {
 
     expect(res).toBeUndefined();
     expect(legacyServiceModelMock.create).not.toBeCalled();
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledTimes(1);
-    expect(legacyServiceModelMock.findOneByServiceId).toBeCalledWith(
-      aRequestSyncLegacyItem.serviceId
-    );
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
     expect(legacyServiceModelMock.update).toBeCalledTimes(1);
     const expected = JSON.parse(
       JSON.stringify({

--- a/apps/io-services-cms-webapp/src/synchronizer/request-sync-legacy-handler.ts
+++ b/apps/io-services-cms-webapp/src/synchronizer/request-sync-legacy-handler.ts
@@ -42,7 +42,7 @@ export const handleQueueItem = (
     TE.fromEither,
     TE.chainW((item) =>
       pipe(
-        legacyServiceModel.findOneByServiceId(item.serviceId),
+        legacyServiceModel.findLastVersionByModelId([item.serviceId]),
         TE.chainW(
           O.fold(
             () =>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
- call `findLastVersionByModelId` instead of deprecated `findOneByServiceId` method
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
