### PR TITLE
fix: [IOPAE-891] patch organization name spacial characters

### DIFF
--- a/.changeset/orange-dancers-refuse.md
+++ b/.changeset/orange-dancers-refuse.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+flip apim user firstName and note values

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/__tests__/auth.test.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/__tests__/auth.test.ts
@@ -14,8 +14,6 @@ const mockConfig = ({
   AZURE_APIM_PRODUCT_NAME: faker.string.alpha()
 } as unknown) as Configuration;
 
-const first100CharsOrgName = faker.string.alpha(100);
-
 const aValidJwtPayload = {
   exp: faker.number.int(),
   iat: faker.number.int(),
@@ -33,7 +31,7 @@ const aValidJwtPayload = {
   organization: {
     id: faker.string.uuid(),
     fiscal_code: faker.helpers.fromRegExp(/[0-9]{11}/),
-    name: `${first100CharsOrgName} ${faker.company.name()}`,
+    name: faker.company.name(),
     roles: [
       {
         partyRole: faker.string.alpha(),
@@ -68,9 +66,9 @@ const getExpectedCreateUserReqParam = (
   organization: IdentityTokenPayload["organization"]
 ) => ({
   email: `org.${organization.id}@selfcare.io.pagopa.it`,
-  firstName: first100CharsOrgName,
+  firstName: organization.fiscal_code,
   lastName: organization.id,
-  note: organization.fiscal_code
+  note: organization.name
 });
 
 const getExpectedUserEmailReqParam = (

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
@@ -207,9 +207,9 @@ const createApimUser = (config: Configuration) => (
         email: formatApimAccountEmailForSelfcareOrganization(
           identityTokenPayload.organization
         ),
-        firstName: identityTokenPayload.organization.name.substring(0, 100),
+        firstName: identityTokenPayload.organization.fiscal_code,
         lastName: identityTokenPayload.organization.id,
-        note: identityTokenPayload.organization.fiscal_code
+        note: identityTokenPayload.organization.name
       }),
     TE.mapLeft(err =>
       apimErrorToManagedInternalError(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Flip `firstName` and `note` values (respectively set with `organizationName` and `organizationFiscalCode`)

#### List of Changes
<!--- Describe your changes in detail -->
- [flip apim user firstName and note values](https://github.com/pagopa/io-services-cms/commit/b3a165a8627b0f06d55a0b40760473658c8c96c5)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Organization name may have special characters that Apim User field `firstName` do not support.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
