### PR TITLE
[IOPAE-914] Update deleted service table row layout in Services Page

### DIFF
--- a/.changeset/silver-avocados-arrive.md
+++ b/.changeset/silver-avocados-arrive.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Update deleted service table row layout in Services Page

--- a/apps/backoffice/src/components/__tests__/service-status.test.tsx
+++ b/apps/backoffice/src/components/__tests__/service-status.test.tsx
@@ -20,12 +20,14 @@ describe("[ServiceStatus] Component", () => {
   it("Should render an APPROVED service status", () => {
     const { container } = render(getServiceStatusComponent());
     const elements = container.getElementsByClassName("MuiChip-colorSuccess");
+    const disabledElements = container.getElementsByClassName("Mui-disabled");
 
     expect(elements.length).toBe(1);
     expect(elements[0]).toHaveAttribute(
       "aria-label",
       ServiceLifecycleStatusTypeEnum.approved
     );
+    expect(disabledElements.length).toBe(0);
     expect(document.getElementById("service-status")).toBeInTheDocument();
 
     const parent = container.parentElement?.getElementsByClassName(
@@ -37,13 +39,15 @@ describe("[ServiceStatus] Component", () => {
   it("Should render an DELETED service status", () => {
     aServiceStatus = { value: ServiceLifecycleStatusTypeEnum.deleted };
     const { container } = render(getServiceStatusComponent());
-    const elements = container.getElementsByClassName("MuiChip-colorError");
+    const elements = container.getElementsByClassName("MuiChip-colorDefault");
+    const disabledElements = container.getElementsByClassName("Mui-disabled");
 
     expect(elements.length).toBe(1);
     expect(elements[0]).toHaveAttribute(
       "aria-label",
       ServiceLifecycleStatusTypeEnum.deleted
     );
+    expect(disabledElements.length).toBe(1);
     expect(document.getElementById("service-status")).toBeInTheDocument();
 
     const parent = container.parentElement?.getElementsByClassName(
@@ -56,12 +60,14 @@ describe("[ServiceStatus] Component", () => {
     aServiceStatus = { value: ServiceLifecycleStatusTypeEnum.draft };
     const { container } = render(getServiceStatusComponent());
     const elements = container.getElementsByClassName("MuiChip-colorDefault");
+    const disabledElements = container.getElementsByClassName("Mui-disabled");
 
     expect(elements.length).toBe(1);
     expect(elements[0]).toHaveAttribute(
       "aria-label",
       ServiceLifecycleStatusTypeEnum.draft
     );
+    expect(disabledElements.length).toBe(0);
     expect(document.getElementById("service-status")).toBeInTheDocument();
 
     const parent = container.parentElement?.getElementsByClassName(
@@ -74,12 +80,14 @@ describe("[ServiceStatus] Component", () => {
     aServiceStatus = { value: ServiceLifecycleStatusTypeEnum.rejected };
     const { container } = render(getServiceStatusComponent());
     const elements = container.getElementsByClassName("MuiChip-colorError");
+    const disabledElements = container.getElementsByClassName("Mui-disabled");
 
     expect(elements.length).toBe(1);
     expect(elements[0]).toHaveAttribute(
       "aria-label",
       ServiceLifecycleStatusTypeEnum.rejected
     );
+    expect(disabledElements.length).toBe(0);
     expect(document.getElementById("service-status")).toBeInTheDocument();
 
     const parent = container.parentElement?.getElementsByClassName(
@@ -92,12 +100,14 @@ describe("[ServiceStatus] Component", () => {
     aServiceStatus = { value: ServiceLifecycleStatusTypeEnum.submitted };
     const { container } = render(getServiceStatusComponent());
     const elements = container.getElementsByClassName("MuiChip-colorWarning");
+    const disabledElements = container.getElementsByClassName("Mui-disabled");
 
     expect(elements.length).toBe(1);
     expect(elements[0]).toHaveAttribute(
       "aria-label",
       ServiceLifecycleStatusTypeEnum.submitted
     );
+    expect(disabledElements.length).toBe(0);
     expect(document.getElementById("service-status")).toBeInTheDocument();
 
     const parent = container.parentElement?.getElementsByClassName(
@@ -110,9 +120,11 @@ describe("[ServiceStatus] Component", () => {
     aServiceStatus = undefined;
     const { container } = render(getServiceStatusComponent());
     const elements = container.getElementsByClassName("MuiChip-colorDefault");
+    const disabledElements = container.getElementsByClassName("Mui-disabled");
 
     expect(elements.length).toBe(1);
     expect(elements[0]).not.toHaveAttribute("aria-label");
+    expect(disabledElements.length).toBe(0);
     expect(document.getElementById("service-status")).toBeInTheDocument();
 
     const parent = container.parentElement?.getElementsByClassName(

--- a/apps/backoffice/src/components/services/service-status.tsx
+++ b/apps/backoffice/src/components/services/service-status.tsx
@@ -13,6 +13,7 @@ export type ServiceStatusProps = {
 export const ServiceStatus = ({ status }: ServiceStatusProps) => {
   const { t } = useTranslation();
   const [color, setColor] = useState<string>("default");
+  const [disabled, setDisabled] = useState(false);
 
   useEffect(() => {
     switch (status?.value) {
@@ -20,8 +21,6 @@ export const ServiceStatus = ({ status }: ServiceStatusProps) => {
         setColor("success");
         break;
       case ServiceLifecycleStatusTypeEnum.deleted:
-        setColor("error");
-        break;
       case ServiceLifecycleStatusTypeEnum.draft:
         setColor("default");
         break;
@@ -35,6 +34,7 @@ export const ServiceStatus = ({ status }: ServiceStatusProps) => {
         setColor("default");
         break;
     }
+    setDisabled(status?.value === ServiceLifecycleStatusTypeEnum.deleted);
   }, [status]);
 
   return (
@@ -45,6 +45,7 @@ export const ServiceStatus = ({ status }: ServiceStatusProps) => {
         label={t(`service.status.${status?.value}`)}
         size="small"
         color={color as any}
+        disabled={disabled}
       />
     </LoaderSkeleton>
   );

--- a/apps/backoffice/src/pages/services/index.tsx
+++ b/apps/backoffice/src/pages/services/index.tsx
@@ -56,6 +56,20 @@ const hasTwoDifferentVersions = (service: ServiceListItem) =>
   service.status.value !== ServiceLifecycleStatusTypeEnum.deleted &&
   service.status.value !== ServiceLifecycleStatusTypeEnum.approved;
 
+/** Simply check if service status value is `deleted` */
+const isServiceStatusValueDeleted = (
+  serviceStatusValue: ServiceLifecycleStatusTypeEnum
+) => serviceStatusValue === ServiceLifecycleStatusTypeEnum.deleted;
+
+/**
+ * Returns base color for MUI `Typography` component.
+ * @param serviceStatusValue
+ * @returns `inherit` as default color, `text.disabled` if service status value is `deleted` */
+const getTypographyDefaultColor = (
+  serviceStatusValue: ServiceLifecycleStatusTypeEnum
+) =>
+  isServiceStatusValueDeleted(serviceStatusValue) ? "text.disabled" : "inherit";
+
 export default function Services() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -77,9 +91,7 @@ export default function Services() {
             ) : null
           }
           sx={{ fontWeight: 700, textAlign: "left" }}
-          disabled={
-            service.status.value === ServiceLifecycleStatusTypeEnum.deleted
-          }
+          disabled={isServiceStatusValueDeleted(service.status.value)}
           onClick={() =>
             hasTwoDifferentVersions(service)
               ? openServiceVersionSwitcher(service)
@@ -95,7 +107,10 @@ export default function Services() {
       alignment: "left",
       name: "last_update",
       cellTemplate: service => (
-        <Typography variant="body2">
+        <Typography
+          variant="body2"
+          color={getTypographyDefaultColor(service.status.value)}
+        >
           {new Date(service.last_update).toLocaleString()}
         </Typography>
       )
@@ -105,7 +120,12 @@ export default function Services() {
       alignment: "left",
       name: "id",
       cellTemplate: service => (
-        <Typography variant="monospaced">{service.id}</Typography>
+        <Typography
+          variant="monospaced"
+          color={getTypographyDefaultColor(service.status.value)}
+        >
+          {service.id}
+        </Typography>
       )
     },
     {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Change layout of _**deleted services**_ displayed in table-view of **Services** Page.
The update consists in having made the layout of all the cells that make up the row of a deleted service in a disabled style.

_Watch screenshot below to better appreciate development result._
#### List of Changes
- `services` page
- `service-status` component _(and related unit tests)_
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="1918" alt="Screenshot 2024-01-11 alle 17 23 37" src="https://github.com/pagopa/io-services-cms/assets/118166285/1ee7722c-697c-4809-b100-19e26333bdbb">

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
