### PR TITLE
[IOPAE-870] Change sidenav bottom menu icon for opening/collapsing sidenav

### DIFF
--- a/.changeset/modern-spies-help.md
+++ b/.changeset/modern-spies-help.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Change sidenav bottom menu icon for opening/collapsing sidenav

--- a/apps/backoffice/src/components/sidenav/index.tsx
+++ b/apps/backoffice/src/components/sidenav/index.tsx
@@ -1,7 +1,7 @@
 import useScreenSize from "@/hooks/use-screen-size";
 import { RequiredAuthorizations } from "@/types/auth";
 import { hasRequiredAuthorizations } from "@/utils/auth-util";
-import { ExitToAppRounded, MenuOpen } from "@mui/icons-material";
+import { ExitToAppRounded, Menu } from "@mui/icons-material";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
@@ -41,14 +41,6 @@ export const Sidenav = ({ items, onWidthChange }: SidenavProps) => {
 
   const [settings, setSettings] = useState({ width: 300, collapse: false });
   const prevWidthRef = useRef<number | null>(null);
-
-  // styles used to rotate the open/close button icon
-  const menuOpenStyle = {
-    transform: "rotate(0deg)"
-  };
-  const menuCloseStyle = {
-    transform: "rotate(-180deg)"
-  };
 
   /** Render a tooltip wrapper on menu item text when menu is closed _(collapse=true)_ */
   const renderTooltipOnCollapse = (text: string, children: ReactElement) =>
@@ -181,19 +173,16 @@ export const Sidenav = ({ items, onWidthChange }: SidenavProps) => {
         </List>
       </Box>
 
-      <Box id="open-close" textAlign="right">
+      <Box id="open-close">
         <Divider />
         <IconButton
           aria-label="open-close"
-          sx={{ margin: 1 }}
+          sx={{ margin: 2.75 }}
           onClick={_ =>
             settings.collapse ? manageMenuOpen(true) : setMenuCollapsed()
           }
         >
-          <MenuOpen
-            fontSize="inherit"
-            style={settings.collapse ? menuCloseStyle : menuOpenStyle}
-          />
+          <Menu />
         </IconButton>
       </Box>
     </Box>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Change **sidenav** bottom menu icon for opening/collapsing sidenav
_Watch screenshot to better appreciate result._
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="342" alt="Screenshot 2024-01-12 alle 15 27 35" src="https://github.com/pagopa/io-services-cms/assets/118166285/81aa454f-5dad-41de-bb7d-b38cf995d820">
<img width="323" alt="Screenshot 2024-01-12 alle 15 28 12" src="https://github.com/pagopa/io-services-cms/assets/118166285/f11e2268-5a22-475f-a9f6-5445f9c07dcc">

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
