### PR TITLE
[IOPAE-850] Fix language selector

### DIFF
--- a/.changeset/orange-poems-push.md
+++ b/.changeset/orange-poems-push.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix language selector: detect browser language and, in case of supported one, show it correctly on footer language selector

--- a/apps/backoffice/src/components/footer/index.tsx
+++ b/apps/backoffice/src/components/footer/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@pagopa/mui-italia";
 import { Trans, useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const pagoPACompanyLabel = "PagoPa S.p.A.";
 
@@ -22,6 +22,7 @@ const pagoPALink: RootLinkType = {
 
 const companyLegalInfo = <Trans i18nKey="footer.legalInfo" />;
 
+const supportedLocales = ["it", "en"];
 const languages: Languages = {
   it: {
     it: "Italiano",
@@ -91,6 +92,15 @@ export const AppFooter = ({ loggedUser, currentLanguage }: AppFooterProps) => {
     },
     [router]
   );
+
+  useEffect(() => {
+    // Detect the browser's preferred language
+    const browserLanguage = navigator.language;
+
+    if (supportedLocales.includes(browserLanguage)) {
+      setLang(browserLanguage as any);
+    }
+  }, []);
 
   return (
     <Footer


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
If the browser has configured an _english_ language preference, different from the default one _(i.e. Italian)_, the application is shown correctly in english but the language selector _(in the footer)_ remained set to Italian.
With this fix, the selector is also consistent with the language currently used in the application.

**Note:**
_At the moment the supported languages are **Italian** `it`, **English** `en`._

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
