### PR TITLE
[IOPAE-887]  Page Header: replace breadcrumbs with exit shortcut on service create/update pages

### DIFF
--- a/.changeset/calm-penguins-tease.md
+++ b/.changeset/calm-penguins-tease.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Page Header: Replace breadcrumbs with exit shortcut on service create/update pages

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -25,6 +25,7 @@
     "copyToClipboard": "Copy to clipboard",
     "delete": "Delete",
     "edit": "Edit",
+    "exit": "Exit",
     "import": "Import",
     "next": "Next",
     "save": "Save",

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -25,6 +25,7 @@
     "copyToClipboard": "Copy to clipboard",
     "delete": "Elimina",
     "edit": "Modifica",
+    "exit": "Esci",
     "import": "Importa",
     "next": "Continua",
     "save": "Salva",

--- a/apps/backoffice/src/components/buttons/button-exit.tsx
+++ b/apps/backoffice/src/components/buttons/button-exit.tsx
@@ -1,0 +1,41 @@
+import { ArrowBack } from "@mui/icons-material";
+import { ButtonNaked } from "@pagopa/mui-italia";
+import { useTranslation } from "next-i18next";
+import { useDialog } from "../dialog-provider";
+
+export type ButtonExitProps = {
+  onClick: () => void;
+};
+
+/**
+ * Implements and displays an exit button, including the logic for opening a confirmation modal.
+ *
+ * If so _(the user confirms the exit action via the modal window)_, an `onClick` event is triggered.
+ */
+export const ButtonExit = ({ onClick }: ButtonExitProps) => {
+  const { t } = useTranslation();
+  const showDialog = useDialog();
+
+  const handleExit = async () => {
+    const confirmed = await showDialog({
+      title: t("forms.cancel.title"),
+      message: t("forms.cancel.description")
+    });
+    if (confirmed) {
+      onClick();
+    } else {
+      console.log("modal cancelled");
+    }
+  };
+
+  return (
+    <ButtonNaked
+      color="primary"
+      startIcon={<ArrowBack />}
+      size="medium"
+      onClick={handleExit}
+    >
+      {t("buttons.exit")}
+    </ButtonNaked>
+  );
+};

--- a/apps/backoffice/src/components/buttons/index.ts
+++ b/apps/backoffice/src/components/buttons/index.ts
@@ -3,6 +3,7 @@ import { ReactNode } from "react";
 
 export * from "./button-back";
 export * from "./button-cancel";
+export * from "./button-exit";
 export * from "./button-next";
 export * from "./button-show-more";
 export * from "./button-with-loader";

--- a/apps/backoffice/src/components/headers/page-header.tsx
+++ b/apps/backoffice/src/components/headers/page-header.tsx
@@ -1,21 +1,38 @@
 import { Box, Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
+import { ButtonExit } from "../buttons";
+import { LoaderSkeleton } from "../loaders";
 import { PageBreadcrumbs } from "./page-breadcrumbs";
 import { PageHtmlHeadTitle } from "./page-html-head-title";
-import { LoaderSkeleton } from "../loaders";
 
 export type PageHeaderProps = {
   title?: string;
   description?: string;
+  hideBreadcrumbs?: boolean;
+  /** Displays an exit button, to abort the current page operation  */
+  showExit?: boolean;
+  /** Event triggered on exit button click */
+  onExitClick?: () => void;
 };
 
-export const PageHeader = ({ title, description }: PageHeaderProps) => {
+export const PageHeader = ({
+  title,
+  description,
+  hideBreadcrumbs,
+  showExit,
+  onExitClick
+}: PageHeaderProps) => {
   const { t } = useTranslation();
 
   return (
     <>
       <PageHtmlHeadTitle section={title ?? ""} />
-      <PageBreadcrumbs />
+      {showExit ? (
+        <Box id="bo-io-page-exit" marginBottom={2}>
+          <ButtonExit onClick={onExitClick ?? (() => null)} />
+        </Box>
+      ) : null}
+      {hideBreadcrumbs ? null : <PageBreadcrumbs />}
       <Box marginBottom={3} id="bo-io-page-title-descr">
         <Typography marginBottom={2} variant="h4">
           <LoaderSkeleton

--- a/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
+++ b/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
@@ -1,8 +1,8 @@
 import { PageHeader } from "@/components/headers";
 import { buildSnackbarItem } from "@/components/notification";
 import {
-  fromServiceLifecycleToServiceCreateUpdatePayload,
-  fromServiceCreateUpdatePayloadToApiServicePayload
+  fromServiceCreateUpdatePayloadToApiServicePayload,
+  fromServiceLifecycleToServiceCreateUpdatePayload
 } from "@/components/services";
 import { ServiceCreateUpdate } from "@/components/services/service-create-update";
 import { ServiceLifecycle } from "@/generated/api/ServiceLifecycle";
@@ -80,6 +80,9 @@ export default function EditService() {
       <PageHeader
         title={pageTitleLocaleKey}
         description={pageDescriptionLocaleKey}
+        hideBreadcrumbs
+        showExit
+        onExitClick={() => router.push(`/services/${serviceId}`)}
       />
       <ServiceCreateUpdate
         mode="update"

--- a/apps/backoffice/src/pages/services/new-service.tsx
+++ b/apps/backoffice/src/pages/services/new-service.tsx
@@ -54,6 +54,9 @@ export default function NewService() {
       <PageHeader
         title={pageTitleLocaleKey}
         description={pageDescriptionLocaleKey}
+        hideBreadcrumbs
+        showExit
+        onExitClick={() => router.push("/services")}
       />
       <ServiceCreateUpdate mode="create" onConfirm={handleConfirm} />
     </>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Replace breadcrumbs with exit shortcut on service create/update pages.

_Follow commits history to better understand developments.
Watch screenshots below to appreciate changes._

#### List of Changes
- Add translations
- Add new exit button
- Update PageHeader component with new implementations:
- Update Create/Update Service Pages replacing breadcrumbs with exit button
<!--- Describe your changes in detail -->

#### Motivation and Context
Quality Assurance activity
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
**Before changes:**
<img width="1176" alt="Screenshot 2024-01-17 alle 17 48 58" src="https://github.com/pagopa/io-services-cms/assets/118166285/2defff7d-6989-440e-9dd2-2eb53b1ac1bb">

**After changes:**
<img width="1176" alt="Screenshot 2024-01-17 alle 17 49 41" src="https://github.com/pagopa/io-services-cms/assets/118166285/1a52a764-cf31-4848-9be8-1f59b7c6818d">
**On Exit click:**
<img width="1176" alt="Screenshot 2024-01-17 alle 17 50 12" src="https://github.com/pagopa/io-services-cms/assets/118166285/59090d54-bb82-4391-8416-7815dffd0e18">


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
