### PR TITLE
[IOPAE-873] Fix responsive layout on migration overview

### DIFF
--- a/.changeset/three-eggs-behave.md
+++ b/.changeset/three-eggs-behave.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix responsive layout on migration overview

--- a/apps/backoffice/src/components/services/subscriptions-migration/migration-latest.tsx
+++ b/apps/backoffice/src/components/services/subscriptions-migration/migration-latest.tsx
@@ -7,12 +7,15 @@ import {
   Box,
   Button,
   Chip,
-  Grid,
   Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
   Typography
 } from "@mui/material";
 import { useTranslation } from "next-i18next";
-import { Fragment } from "react";
 import { MigrationChipStatus } from ".";
 
 export type MigrationLatestProps = {
@@ -43,7 +46,7 @@ export const MigrationLatest = ({
   };
 
   return (
-    <Stack direction="column" spacing={3}>
+    <Stack direction="column" spacing={3} display="contents">
       <Box>
         <Typography variant="overline">
           {t("subscriptions.migration.status.title")}
@@ -62,7 +65,7 @@ export const MigrationLatest = ({
         </Button>
       </Box>
       {isEmptyState ? (
-        <Alert severity="info">
+        <Alert severity="info" sx={{ width: "100%" }}>
           {t("subscriptions.migration.status.noData")}
         </Alert>
       ) : null}
@@ -70,36 +73,40 @@ export const MigrationLatest = ({
         loading={migrationItems === undefined}
         style={{ width: "100%", height: "50px" }}
       >
-        <Grid container direction="row" alignItems="center">
-          {migrationItems?.items
-            ?.map(item => ({
-              ...item,
-              status: computeMigrationStatus(item.status)
-            }))
-            .map((migrationItem, index) => (
-              <Fragment key={`migration-lates-${index}`}>
-                <Grid item xs={4} marginY={1}>
-                  <Typography variant="body2">
-                    {`${migrationItem.delegate.sourceSurname} ${migrationItem.delegate.sourceName}`}
-                  </Typography>
-                </Grid>
-                <Grid item xs={4} paddingLeft={1}>
-                  <Chip
-                    size="small"
-                    label={t(
-                      `subscriptions.migration.status.${migrationItem.status.label}`
-                    )}
-                    color={migrationItem.status.color}
-                  />
-                </Grid>
-                <Grid item xs paddingLeft={1}>
-                  <Typography variant="body2">
-                    {new Date(migrationItem.lastUpdate).toLocaleString()}
-                  </Typography>
-                </Grid>
-              </Fragment>
-            ))}
-        </Grid>
+        <TableContainer>
+          <Table size="small">
+            <TableBody>
+              {migrationItems?.items
+                ?.map(item => ({
+                  ...item,
+                  status: computeMigrationStatus(item.status)
+                }))
+                .map((migrationItem, index) => (
+                  <TableRow key={`migration-lates-${index}`} hover>
+                    <TableCell>
+                      <Typography variant="body2">
+                        {`${migrationItem.delegate.sourceSurname} ${migrationItem.delegate.sourceName}`}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        label={t(
+                          `subscriptions.migration.status.${migrationItem.status.label}`
+                        )}
+                        color={migrationItem.status.color}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" textAlign="right">
+                        {new Date(migrationItem.lastUpdate).toLocaleString()}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </LoaderSkeleton>
     </Stack>
   );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix responsive layout on migration overview.
_Watch screenshot and video below to better appreciate changes._

#### List of Changes
Replace **MUI Grid** with a **MUI Table**.
<!--- Describe your changes in detail -->

#### Motivation and Context
Need to fix a minor break on layout responsivity on some small screen sizes.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
**Responsivity sample issue:**
<img width="314" alt="Schermata 2023-12-06 alle 17 56 14" src="https://github.com/pagopa/io-services-cms/assets/118166285/3a2ec4ad-9045-41ed-83dc-2351258fe6a3">

**Video with new layout behaviour:**

https://github.com/pagopa/io-services-cms/assets/118166285/2ec69215-7885-4abc-93a0-2e20e2918eb3



<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
