### PR TITLE
[#IOPAE-903]add default cidrs in sync if the service has an empty one

### DIFF
--- a/.changeset/ten-moose-worry.md
+++ b/.changeset/ten-moose-worry.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+add default cidrs in sync

--- a/apps/io-services-cms-webapp/src/synchronizer/__tests__/request-sync-legacy-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/synchronizer/__tests__/request-sync-legacy-handler.test.ts
@@ -330,4 +330,60 @@ describe("Sync Legacy Handler", () => {
       expect.objectContaining({ cmsTag: true })
     );
   });
+
+  it("should create a new legacy service with default cidrs if they are empty", async () => {
+    const context = createContext();
+
+    const aServiceWithoutCidrs = {
+      authorizedCIDRs: toAuthorizedCIDRs([]),
+      authorizedRecipients: toAuthorizedRecipients(["BBBBBB01B02C123D"]),
+      departmentName: "-",
+      isVisible: true,
+      organizationFiscalCode: "12345678901",
+      organizationName: "anOrganizationName",
+      serviceId: "sid",
+      serviceName: "aServiceName",
+      cmsTag: true,
+      serviceMetadata: {
+        category: StandardServiceCategoryEnum.STANDARD,
+        scope: ServiceScopeEnum.LOCAL,
+        customSpecialFlow: undefined,
+        description: "aDescription",
+      },
+    } as unknown as Service;
+
+    const aRequestSyncLegacyItem = {
+      cmsTag: true,
+      ...aServiceWithoutCidrs,
+    } as unknown as Queue.RequestSyncLegacyItem;
+
+    const legacyServiceModelMock = {
+      findLastVersionByModelId: vi.fn(() => {
+        return TE.right(O.none);
+      }),
+      create: vi.fn((x) => {
+        return TE.right(x);
+      }),
+      update: vi.fn(),
+    } as unknown as ServiceModel;
+
+    const res = await handleQueueItem(
+      context,
+      aRequestSyncLegacyItem as unknown as Json,
+      legacyServiceModelMock
+    )();
+
+    expect(res).toBeUndefined();
+    expect(legacyServiceModelMock.update).not.toBeCalled();
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.findLastVersionByModelId).toBeCalledWith([
+      aRequestSyncLegacyItem.serviceId,
+    ]);
+    expect(legacyServiceModelMock.create).toBeCalledTimes(1);
+    expect(legacyServiceModelMock.create).toBeCalledWith(
+      expect.objectContaining({
+        authorizedCIDRs: new Set(["0.0.0.0/0"]) as Set<CIDR>,
+      })
+    );
+  });
 });

--- a/apps/io-services-cms-webapp/src/synchronizer/request-sync-legacy-handler.ts
+++ b/apps/io-services-cms-webapp/src/synchronizer/request-sync-legacy-handler.ts
@@ -7,6 +7,7 @@ import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { flow, pipe } from "fp-ts/lib/function";
 import { Json } from "io-ts-types";
+import { CIDR } from "@pagopa/io-functions-commons/dist/generated/definitions/CIDR";
 import { withJsonInput } from "../lib/azure/misc";
 
 const parseIncomingMessage = (
@@ -55,6 +56,10 @@ export const handleQueueItem = (
                 (x) =>
                   legacyServiceModel.create({
                     ...x,
+                    authorizedCIDRs:
+                      x.authorizedCIDRs.size === 0
+                        ? (new Set(["0.0.0.0/0"]) as Set<CIDR>)
+                        : x.authorizedCIDRs,
                     isVisible: x.isVisible ?? false,
                   })
               ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
add "default" cidrs when services get synched and cidrs list is empty
#### List of Changes

<!--- Describe your changes in detail -->
add "default" cidrs when services get synched and cidrs list is empty
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
there is a check on the devportal when a service is approved/published that if the cidrs are not set it marks the service as "coming soon" in the app and with "incomplete data" on the devportal, this is because theoretically the cidrs are mandatory for the publication of a service, but in the CMS this is not the case. The CIDRS are optional so some entities do not set them and even though the service is approved they then find themselves in the app with a service "coming soon" because this does not pass the quality check due to the fact that the service has no cidrs set
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
