### PR TITLE
fix:[IOPAE-952] Fix frontend xss vulnerability on ServiceVersionSwitcher component

### DIFF
--- a/.changeset/unlucky-maps-crash.md
+++ b/.changeset/unlucky-maps-crash.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix frontend xss vulnerability on ServiceVersionSwitcher component

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -457,7 +457,7 @@
     },
     "switcher": {
       "title": "Which version of the service do you want to view?",
-      "description": "The <strong>{{name}}</strong> service has two versions. Select the one you want to view.",
+      "description": "The <1><0>{service?.name}</0></1> service has two versions. Select the one you want to view.",
       "status": "Service status:",
       "lastApprovedVersion": "Last approved version.",
       "lastUpdate": "Last update:"

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -457,7 +457,7 @@
     },
     "switcher": {
       "title": "Quale versione del servizio vuoi visualizzare?",
-      "description": "Il servizio <strong>{{name}}</strong> ha due versioni. Seleziona quella che vuoi visualizzare.",
+      "description": "Il servizio <1><0>{service?.name}</0></1> ha due versioni. Seleziona quella che vuoi visualizzare.",
       "status": "Stato del servizio:",
       "lastApprovedVersion": "Ultima versione approvata.",
       "lastUpdate": "Ultima modifica:"

--- a/apps/backoffice/src/components/services/service-version-switcher.tsx
+++ b/apps/backoffice/src/components/services/service-version-switcher.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   Typography
 } from "@mui/material";
-import { useTranslation } from "next-i18next";
+import { Trans, useTranslation } from "next-i18next";
 import { ChangeEvent, useEffect, useState } from "react";
 import { ServiceStatus } from ".";
 
@@ -143,13 +143,10 @@ export const ServiceVersionSwitcher = ({
         sx={{ width: "425px", textAlign: "center", paddingX: 4, paddingY: 0 }}
       >
         <Box marginBottom={4}>
-          <span
-            dangerouslySetInnerHTML={{
-              __html: t(`service.switcher.description`, {
-                name: service?.name
-              })
-            }}
-          />
+          <Trans i18nKey="service.switcher.description">
+            Il servizio <strong>{service?.name}</strong> ha due versioni.
+            Seleziona quella che vuoi visualizzare.
+          </Trans>
         </Box>
         {renderServiceVersionChoice("publication", true)}
         {renderServiceVersionChoice("lifecycle")}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix frontend _xss vulnerability_ on `ServiceVersionSwitcher` component.

**Note:**
_This is a first frontend step for broader remediation of the XSS vulnerability._

#### List of Changes
- replace `dangerouslySetInnerHTML` with _next-i18next_ `Trans` function on **ServiceVersionSwitcher** component
<!--- Describe your changes in detail -->

#### Motivation and Context
**Problem description from VA/PT Security Assessment**
While selecting versions of a service, a pop-up appears showing the name of the service inserted insecurely into the html code. Any text inserted into the service name and rendered in this section, causes the exploit of an xss capable of executing javascript code.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
**Before changes:**
<img width="1458" alt="Screenshot 2024-01-26 alle 12 31 28" src="https://github.com/pagopa/io-services-cms/assets/118166285/7bbd5a13-7633-4408-945c-f4a1bede2632">

**After changes:**
<img width="1919" alt="Screenshot 2024-01-26 alle 13 02 31" src="https://github.com/pagopa/io-services-cms/assets/118166285/4901ab2d-b94f-4aa5-abfe-c52ee799c68c">

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
