### PR TITLE
[IOPAE-801] Add custom error page for next-auth errors

### DIFF
--- a/.changeset/shiny-candles-rule.md
+++ b/.changeset/shiny-candles-rule.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Add custom error page for next-auth errors

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -9,6 +9,7 @@
     "title": "IO BackOffice"
   },
   "auth": {
+    "error": "Authentication error",
     "leaving": "Exit in progress",
     "loading": "Access in progress"
   },

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -9,6 +9,7 @@
     "title": "IO BackOffice"
   },
   "auth": {
+    "error": "Errore di autenticazione",
     "leaving": "Uscita in corso",
     "loading": "Accesso in corso"
   },

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/route.ts
@@ -14,7 +14,8 @@ const authOptions: NextAuthOptions = {
   ],
   pages: {
     signIn: "/auth/login",
-    signOut: "/auth/logout"
+    signOut: "/auth/logout",
+    error: "/auth/error"
   },
   callbacks: {
     jwt({ token, user }) {

--- a/apps/backoffice/src/components/loaders/loader-fullscreen.tsx
+++ b/apps/backoffice/src/components/loaders/loader-fullscreen.tsx
@@ -11,12 +11,17 @@ import { useTranslation } from "next-i18next";
 export type LoaderFullscreenProps = {
   title: string;
   content: string;
+  loading?: boolean;
 };
 
 /**
  * This loader render a fullscreen backdrop with a centered card, with text and loader icon
  */
-export const LoaderFullscreen = ({ title, content }: LoaderFullscreenProps) => {
+export const LoaderFullscreen = ({
+  title,
+  content,
+  loading = true
+}: LoaderFullscreenProps) => {
   const { t } = useTranslation();
 
   return (
@@ -29,9 +34,11 @@ export const LoaderFullscreen = ({ title, content }: LoaderFullscreenProps) => {
           <Typography variant="body2" align="center">
             {t(content)}
           </Typography>
-          <Box textAlign="center" marginTop={2}>
-            <CircularProgress />
-          </Box>
+          {loading ? (
+            <Box textAlign="center" marginTop={2}>
+              <CircularProgress />
+            </Box>
+          ) : null}
         </CardContent>
       </Card>
     </Backdrop>

--- a/apps/backoffice/src/pages/auth/error.tsx
+++ b/apps/backoffice/src/pages/auth/error.tsx
@@ -2,7 +2,7 @@ import { LoaderFullscreen } from "@/components/loaders";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useRouter } from "next/router";
 
-export default function Error() {
+export default function ErrorPage() {
   const router = useRouter();
   const error = router.query.error as string;
 
@@ -21,4 +21,4 @@ export async function getStaticProps({ locale }: any) {
 }
 
 // No Auth required
-Error.publicRoute = true;
+ErrorPage.publicRoute = true;

--- a/apps/backoffice/src/pages/auth/error.tsx
+++ b/apps/backoffice/src/pages/auth/error.tsx
@@ -1,0 +1,24 @@
+import { LoaderFullscreen } from "@/components/loaders";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useRouter } from "next/router";
+
+export default function Error() {
+  const router = useRouter();
+  const error = router.query.error as string;
+
+  return (
+    <LoaderFullscreen title="auth.error" content={error} loading={false} />
+  );
+}
+
+export async function getStaticProps({ locale }: any) {
+  return {
+    props: {
+      // pass the translation props to the page component
+      ...(await serverSideTranslations(locale))
+    }
+  };
+}
+
+// No Auth required
+Error.publicRoute = true;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Customized next-auth error page, to display authentication/authorization error in page.

#### List of Changes
- add required **translations**
- update **LoaderFullscreen** component by adding a `loading` state prop
- update _next-auth pages options_ (add custom error page route)
- add custom _**/auth/error**_ page
<!--- Describe your changes in detail -->

#### Motivation and Context
Need to better display what kind of error is returned by next-auth.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
**Before changes _(no error detail on screen)_:**
<img width="1919" alt="Screenshot 2024-01-29 alle 13 17 11" src="https://github.com/pagopa/io-services-cms/assets/118166285/853e433e-0fbb-4fa5-9841-ce05a1ddde7f">

**After changes:**
<img width="1919" alt="Screenshot 2024-01-29 alle 13 15 58" src="https://github.com/pagopa/io-services-cms/assets/118166285/717351df-de45-4f14-aa63-db6035b5f60a">

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
