### PR TITLE
fix:[IOPAE-960] Fix possible inconsistent data in PageBreadcrumbs

### DIFF
--- a/.changeset/late-shoes-remember.md
+++ b/.changeset/late-shoes-remember.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix inconsistent data in PageBreadcrumbs calling the app url with certain characters as query parameters

--- a/apps/backoffice/src/components/__tests__/page-breadcrumbs.test.tsx
+++ b/apps/backoffice/src/components/__tests__/page-breadcrumbs.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render } from "@testing-library/react";
+import { useRouter } from "next/router";
+import React from "react";
+import { Mock, afterEach, describe, expect, it, vi } from "vitest";
+import { PageBreadcrumbs } from "../headers/page-breadcrumbs";
+
+// mock useRouter
+vi.mock("next/router", () => ({
+  useRouter: vi.fn()
+}));
+const mockUseRouter = useRouter as Mock;
+
+// needed to clean document (react dom)
+afterEach(cleanup);
+
+describe("[PageBreadcrumbs] Component", () => {
+  it("should NOT render breadcrumbs for base App route", () => {
+    mockUseRouter.mockReturnValueOnce({
+      asPath: "/"
+    });
+
+    const { container } = render(<PageBreadcrumbs />);
+
+    expect(
+      document.getElementById("bo-io-breadcrumbs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should NOT render breadcrumbs for base App route with particular queryparams", () => {
+    mockUseRouter.mockReturnValueOnce({
+      asPath: "/?test=:/abc"
+    });
+
+    const { container } = render(<PageBreadcrumbs />);
+
+    expect(
+      document.getElementById("bo-io-breadcrumbs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should NOT render breadcrumbs for level 0 route section", () => {
+    mockUseRouter.mockReturnValueOnce({
+      asPath: "/root-section"
+    });
+
+    const { container } = render(<PageBreadcrumbs />);
+
+    expect(
+      document.getElementById("bo-io-breadcrumbs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render breadcrumbs for a nested route section", () => {
+    mockUseRouter.mockReturnValueOnce({
+      asPath: "/root-section/nested-section"
+    });
+
+    const { container } = render(<PageBreadcrumbs />);
+    const elements = container.getElementsByClassName("MuiBreadcrumbs-li");
+
+    expect(document.getElementById("bo-io-breadcrumbs")).toBeInTheDocument();
+    expect(elements.length).toBe(2);
+    expect(elements[0].textContent).toBe("root-section");
+    expect(elements[1].textContent).toBe("nested-section");
+  });
+
+  it("should render breadcrumbs without queryparams for a nested route section with queryparams", () => {
+    mockUseRouter.mockReturnValueOnce({
+      asPath: "/root-section/nested-section?key1=val1&key2=val2"
+    });
+
+    const { container } = render(<PageBreadcrumbs />);
+    const elements = container.getElementsByClassName("MuiBreadcrumbs-li");
+
+    expect(document.getElementById("bo-io-breadcrumbs")).toBeInTheDocument();
+    expect(elements.length).toBe(2);
+    expect(elements[0].textContent).toBe("root-section");
+    expect(elements[1].textContent).toBe("nested-section");
+  });
+
+  it("should render breadcrumbs without queryparams for a nested route section with particular queryparams", () => {
+    mockUseRouter.mockReturnValueOnce({
+      asPath: "/root-section/nested-section?test=:/abc"
+    });
+
+    const { container } = render(<PageBreadcrumbs />);
+    const elements = container.getElementsByClassName("MuiBreadcrumbs-li");
+
+    expect(document.getElementById("bo-io-breadcrumbs")).toBeInTheDocument();
+    expect(elements.length).toBe(2);
+    expect(elements[0].textContent).toBe("root-section");
+    expect(elements[1].textContent).toBe("nested-section");
+  });
+});

--- a/apps/backoffice/src/components/headers/page-breadcrumbs.tsx
+++ b/apps/backoffice/src/components/headers/page-breadcrumbs.tsx
@@ -8,9 +8,18 @@ export const PageBreadcrumbs = () => {
   const { t } = useTranslation();
   const router = useRouter();
 
-  /** Starting from current browser route, returns an array of route sections */
+  const removeQueryParamsIfExists = (route: string) => {
+    const queryParamsStartIndex = route.indexOf("?");
+    return queryParamsStartIndex >= 0
+      ? route.substring(0, queryParamsStartIndex)
+      : route;
+  };
+
+  /** Starting from current browser route, returns an array of route sections without query parameters _(if any)_ */
   const getRouteSections = () =>
-    router.asPath.split("/").filter(val => val !== "");
+    removeQueryParamsIfExists(router.asPath)
+      .split("/")
+      .filter(val => val !== "");
 
   const routeSectionsCount = getRouteSections().length;
 
@@ -19,13 +28,6 @@ export const PageBreadcrumbs = () => {
     const routeLocale = t(`routes.${route}.title`);
     if (routeLocale.startsWith("routes.")) return route;
     return routeLocale;
-  };
-
-  const removeQueryParamsIfExists = (route: string) => {
-    const queryParamsStartIndex = route.indexOf("?");
-    return queryParamsStartIndex >= 0
-      ? route.substring(0, queryParamsStartIndex)
-      : route;
   };
 
   /** Manage page breadcrumbs component visibility: `true` only if current route has a nesting level greater than 1. */
@@ -53,7 +55,7 @@ export const PageBreadcrumbs = () => {
         {getRouteSections().map((crumb, index) =>
           isChildRoute(index) ? (
             <Typography key={index} color={"text.disabled"}>
-              {removeQueryParamsIfExists(getRouteLocale(crumb))}
+              {getRouteLocale(crumb)}
             </Typography>
           ) : (
             <NextLink key={index} href={getRouteSectionPath(crumb)}>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix inconsistent data in **PageBreadcrumbs** calling the app url with certain characters as query parameters.

**Issue:**
There was an error on query params cleanup on PageBreadcrumbs component.

_Watch screenshots below to better appreciate developments or check added unit tests to better understand issue._

#### List of Changes
- fix _**PageBreadcrumbs**_ business logic in query params cleanup
- add basic component _**unit tests**_
<!--- Describe your changes in detail -->

#### Motivation and Context
Mitigation for VA/PT Security assessment.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
- Local `dev` mode with `msw` mock
- Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
**Before changes:**
Sample of inconsistent page breadcrumbs with unexpected query parameters.
<img width="892" alt="Screenshot 2024-02-01 alle 11 19 54" src="https://github.com/pagopa/io-services-cms/assets/118166285/7cb5eb76-828b-4c00-96a5-1cc9819ce554">

**After changes (issue fixed):**
<img width="892" alt="Screenshot 2024-02-01 alle 11 21 28" src="https://github.com/pagopa/io-services-cms/assets/118166285/e4cbcb96-0500-44e1-afdd-e5081317b8f3">


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
