### PR TITLE
fix:[#IOPAE-965] Fix service review checker

### DIFF
--- a/.changeset/green-knives-draw.md
+++ b/.changeset/green-knives-draw.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Fix ServiceReviewChecker pg cursor errors

--- a/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
@@ -5,7 +5,6 @@ import { sequenceT } from "fp-ts/lib/Apply";
 import * as E from "fp-ts/lib/Either";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as TE from "fp-ts/lib/TaskEither";
-import * as T from "fp-ts/lib/Task";
 import * as B from "fp-ts/lib/boolean";
 import { pipe } from "fp-ts/lib/function";
 import { JiraIssue } from "../lib/clients/jira-client";

--- a/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/review-checker-handler.ts
@@ -215,13 +215,6 @@ export const processBatchOfReviews =
       items,
       buildIssueItemPairs(context, jiraProxy),
       TE.chain(updateReview(context, dao, fsmLifecycleClient)),
-      TE.map((_) => {
-        getLogger(context, logPrefix, "processBatchOfReviews").log(
-          "info",
-          `Processed ${items.length} reviews`
-        );
-        return _;
-      }),
       TE.mapLeft((err) => {
         getLogger(context, logPrefix, "processBatchOfReviews").logError(
           err,

--- a/infra/src/webapp.tf
+++ b/infra/src/webapp.tf
@@ -104,6 +104,9 @@ locals {
 
     # Automatic service validation
     MANUAL_REVIEW_PROPERTIES = var.manual_review_properties
+
+    # Fix Service Review Checker pg module
+    APPLICATION_INSIGHTS_NO_PATCH_MODULES = "pg"
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix pg cursor by disabling Application Insight patching, according to https://github.com/microsoft/node-diagnostic-channel/issues/67
#### List of Changes
- Improve `ServiceReviewChecker` logs
- Handling cursor creation with an E.tryCatch
- Add `APPLICATION_INSIGHTS_NO_PATCH_MODULES` property in order to disabling Application insight patching module per pg.

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local Application run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
