### PR TITLE
fix: [IOPAE-983] patch publication-lifecycle release fn

### DIFF
--- a/.changeset/curly-paws-live.md
+++ b/.changeset/curly-paws-live.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/models": patch
+"io-services-cms-webapp": patch
+---
+
+create a new release fn intead of the one that uses publication fsm

--- a/apps/io-services-cms-webapp/src/publicator/__tests__/request-publication-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/publicator/__tests__/request-publication-handler.test.ts
@@ -111,7 +111,6 @@ describe("Service Publication Handler", () => {
       mockFsmPublicationClient
     )();
     expect(mockFsmPublicationClient.release).toBeCalledTimes(1);
-    const {} = aService;
     expect(mockFsmPublicationClient.release).toBeCalledWith(
       aService.id,
       aService,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Create a new release fn intead of the one that uses publication fsm.
If this changes will pass "production tests", then we will clean codebase from useless publication FSM functions
#### List of Changes
<!--- Describe your changes in detail -->
- add new release fn to bypass publication fsm

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To fix a bug when releasing a new approved version on an "already" unpublished service. Furthermore, there is no need to use a FSM on a Publication lifecycle, because there are only two possible states (`published`, `unpublished`) and there aren't any constraints on the actions/transitions witch can change states (currently is allowed to perform any combinations of actions)

#### How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
