### PR TITLE
[#IOPAE-968] preserve topic_id on sync legacy

### DIFF
--- a/.changeset/shaggy-frogs-shave.md
+++ b/.changeset/shaggy-frogs-shave.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Handle topic_id on legacy -> CMS sync

--- a/apps/io-services-cms-webapp/src/config.ts
+++ b/apps/io-services-cms-webapp/src/config.ts
@@ -227,6 +227,15 @@ export const ServiceValidationConfig = t.type({
 });
 export type ServiceValidationConfig = t.TypeOf<typeof ServiceValidationConfig>;
 
+// Default Application Values
+const DefaultValues = t.type({
+  // Default Topic ID for services on legacy -> CMS sync
+  LEGACY_SYNC_DEFAULT_TOPIC_ID: withDefault(
+    NumberFromString,
+    "0" as unknown as number
+  ),
+});
+
 // Global app configuration
 export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([
@@ -256,6 +265,7 @@ export const IConfig = t.intersection([
     BackofficeInternalSubnetCIDRs,
     TopicPostgreSqlConfig,
     ServiceValidationConfig,
+    DefaultValues,
   ]),
 ]);
 

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -164,7 +164,8 @@ export const createRequestPublicationEntryPoint =
 
 export const onRequestSyncCmsEntryPoint = createRequestSyncCmsHandler(
   fsmLifecycleClient,
-  fsmPublicationClient
+  fsmPublicationClient,
+  config
 );
 
 export const onRequestSyncLegacyEntryPoint =

--- a/apps/io-services-cms-webapp/src/synchronizer/__tests__/request-sync-cms-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/synchronizer/__tests__/request-sync-cms-handler.test.ts
@@ -4,6 +4,7 @@ import {
   ServiceLifecycle,
   ServicePublication,
 } from "@io-services-cms/models";
+import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { Json } from "io-ts-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -79,10 +80,14 @@ const mockFsmLifecycleClient = {
       fsm: aRequestServiceLifecycleSync.fsm,
     } as ServiceLifecycle.ItemType)
   ),
+  fetch: vi.fn(() => TE.right(O.some(aServiceLifecycleItem))),
 } as unknown as ServiceLifecycle.FsmClient;
 
 const mockFsmPublicationClient = {
   override: vi.fn(() => TE.right(aServiceLifecycleItem)),
+  getStore: vi.fn(() => ({
+    fetch: vi.fn(() => TE.right(O.some(aServicePublicationItem))),
+  })),
 } as unknown as ServicePublication.FsmClient;
 
 describe("Sync CMS Handler", () => {
@@ -208,6 +213,9 @@ describe("Sync CMS Handler", () => {
 
     const mockFsmPublicationClientError = {
       override: vi.fn(() => TE.left(new Error("Bad Error occurs"))),
+      getStore: vi.fn(() => ({
+        fetch: vi.fn(() => TE.right(O.some(aServicePublicationItem))),
+      })),
     } as unknown as ServicePublication.FsmClient;
 
     await expect(() =>
@@ -228,6 +236,7 @@ describe("Sync CMS Handler", () => {
 
     const mockFsmLifecycleClientError = {
       override: vi.fn(() => TE.left(new Error("Bad Error occurs"))),
+      fetch: vi.fn(() => TE.right(O.some(aServiceLifecycleItem))),
     } as unknown as ServiceLifecycle.FsmClient;
 
     await expect(() =>

--- a/apps/io-services-cms-webapp/src/synchronizer/request-sync-cms-handler.ts
+++ b/apps/io-services-cms-webapp/src/synchronizer/request-sync-cms-handler.ts
@@ -28,36 +28,29 @@ const toServiceLifecycle =
   (
     state: ServiceLifecycle.ItemType["fsm"]["state"],
     { id, data }: Queue.RequestSyncCmsItem
-  ): TE.TaskEither<Error, ServiceLifecycle.ItemType> =>
+  ) =>
     pipe(
       id,
       fsmLifecycleClient.fetch,
       TE.chainW(
         O.fold(
-          // eslint-disable-next-line sonarjs/no-identical-functions
-          () =>
+          () => TE.right(data),
+          (currentServiceLifecycle) =>
             TE.right({
-              id,
-              data,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              fsm: { state: state as any, lastTransition: SYNC_FROM_LEGACY },
-            }),
-          // eslint-disable-next-line sonarjs/no-identical-functions
-          (currentItem) =>
-            TE.right({
-              id,
-              data: {
-                ...data,
-                metadata: {
-                  ...data.metadata,
-                  topic_id: currentItem.data.metadata.topic_id,
-                },
+              ...data,
+              metadata: {
+                ...data.metadata,
+                topic_id: currentServiceLifecycle.data.metadata.topic_id,
               },
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              fsm: { state: state as any, lastTransition: SYNC_FROM_LEGACY },
             })
         )
-      )
+      ),
+      TE.map((lifecycleData) => ({
+        id,
+        data: lifecycleData,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fsm: { state: state as any, lastTransition: SYNC_FROM_LEGACY },
+      }))
     );
 
 const toServicePublication =
@@ -65,37 +58,29 @@ const toServicePublication =
   (
     state: ServicePublication.ItemType["fsm"]["state"],
     { id, data }: Queue.RequestSyncCmsItem
-  ): // eslint-disable-next-line sonarjs/no-identical-functions
-  TE.TaskEither<Error, ServicePublication.ItemType> =>
+  ) =>
     pipe(
       id,
       fsmPublicationClient.getStore().fetch,
       TE.chainW(
         O.fold(
-          // eslint-disable-next-line sonarjs/no-identical-functions
-          () =>
+          () => TE.right(data),
+          (currentServicePublication) =>
             TE.right({
-              id,
-              data,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              fsm: { state: state as any, lastTransition: SYNC_FROM_LEGACY },
-            }),
-          // eslint-disable-next-line sonarjs/no-identical-functions
-          (currentItem) =>
-            TE.right({
-              id,
-              data: {
-                ...data,
-                metadata: {
-                  ...data.metadata,
-                  topic_id: currentItem.data.metadata.topic_id,
-                },
+              ...data,
+              metadata: {
+                ...data.metadata,
+                topic_id: currentServicePublication.data.metadata.topic_id,
               },
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              fsm: { state: state as any, lastTransition: SYNC_FROM_LEGACY },
             })
         )
-      )
+      ),
+      TE.map((publicationData) => ({
+        id,
+        data: publicationData,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fsm: { state: state as any, lastTransition: SYNC_FROM_LEGACY },
+      }))
     );
 
 export const handleQueueItem = (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Handle `topic_id` in Legacy -> CMS sync process.
#### List of Changes
- Preserve current topic_id both for ServiceLifecycle and ServicePublication sync items when present.
- Fallback to the ServiceLifecycle `topic_id` on ServicePublication sync and no item is found on the ServicePublication collection (this happen when the first publication is done on  legacy Developer Portal)
- Use the Default `topic_id` when this service is not found on Both ServiceLifecycle and ServicePublication collections.
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
