### PR TITLE
fix:[IOPAE-988] Avoid start/end spaces on url fields in service create/update form

### DIFF
--- a/.changeset/fuzzy-cycles-beam.md
+++ b/.changeset/fuzzy-cycles-beam.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix url fields in service create/update form: blanks at the beginning or end of the value are not allowed and the field display error correctly

--- a/apps/backoffice/src/components/forms/schemas.ts
+++ b/apps/backoffice/src/components/forms/schemas.ts
@@ -1,6 +1,7 @@
 /**
  * Zod Validation common schemas
  */
+import { TFunction } from "i18next";
 import * as z from "zod";
 
 export const ipv4CidrSchema = z
@@ -8,3 +9,14 @@ export const ipv4CidrSchema = z
   .regex(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(\/\d{1,2})?$/);
 
 export const arrayOfIPv4CidrSchema = z.array(ipv4CidrSchema);
+
+export const getUrlSchema = (t: TFunction<"translation", undefined>) =>
+  z
+    .string()
+    .url(t("forms.errors.field.url"))
+    .refine(value => value.trim() === value, {
+      message: t("forms.errors.field.url")
+    });
+
+export const getOptionalUrlSchema = (t: TFunction<"translation", undefined>) =>
+  z.union([z.literal(""), getUrlSchema(t)]);

--- a/apps/backoffice/src/components/services/service-create-update/service-builder-step-2.tsx
+++ b/apps/backoffice/src/components/services/service-create-update/service-builder-step-2.tsx
@@ -3,9 +3,9 @@ import {
   SwitchController,
   UrlFieldController
 } from "@/components/forms/controllers";
+import { getOptionalUrlSchema, getUrlSchema } from "@/components/forms/schemas";
 import { AssistanceChannelType } from "@/types/service";
 import { SupportAgent } from "@mui/icons-material";
-import MobileScreenShareIcon from "@mui/icons-material/MobileScreenShare";
 import PrivacyTipIcon from "@mui/icons-material/PrivacyTip";
 import { TFunction } from "i18next";
 import { useTranslation } from "next-i18next";
@@ -35,7 +35,7 @@ const getSingleAssistanceChannelSchema = (
     }),
     z.object({
       type: z.literal("support_url"),
-      value: z.string().url(t("forms.errors.field.url"))
+      value: getUrlSchema(t)
     })
   ]);
 
@@ -64,36 +64,12 @@ export const getValidationSchema = (t: TFunction<"translation", undefined>) =>
     .object({
       require_secure_channel: z.boolean(),
       metadata: z.object({
-        privacy_url: z.string().url(t("forms.errors.field.url")),
-        tos_url: z.union([
-          z.literal(""),
-          z
-            .string()
-            .trim()
-            .url(t("forms.errors.field.url"))
-        ]),
+        privacy_url: getUrlSchema(t),
+        tos_url: getOptionalUrlSchema(t),
         assistanceChannels: getAssistanceChannelsSchema(t),
-        web_url: z.union([
-          z.literal(""),
-          z
-            .string()
-            .trim()
-            .url(t("forms.errors.field.url"))
-        ]),
-        app_android: z.union([
-          z.literal(""),
-          z
-            .string()
-            .trim()
-            .url(t("forms.errors.field.url"))
-        ]),
-        app_ios: z.union([
-          z.literal(""),
-          z
-            .string()
-            .trim()
-            .url(t("forms.errors.field.url"))
-        ])
+        web_url: getOptionalUrlSchema(t),
+        app_android: getOptionalUrlSchema(t),
+        app_ios: getOptionalUrlSchema(t)
       })
     })
     .refine(
@@ -147,10 +123,7 @@ export const ServiceBuilderStep2 = () => {
       >
         <ServiceAssistanceChannels />
       </FormStepSectionWrapper>
-      <FormStepSectionWrapper
-        key={2}
-        title={t("forms.service.otherChannels")}
-      >
+      <FormStepSectionWrapper key={2} title={t("forms.service.otherChannels")}>
         <UrlFieldController
           name="metadata.web_url"
           label={t("forms.service.metadata.webUrl.label")}

--- a/apps/backoffice/src/components/services/service-create-update/service-builder-step-3.tsx
+++ b/apps/backoffice/src/components/services/service-create-update/service-builder-step-3.tsx
@@ -1,6 +1,9 @@
 import { FormStepSectionWrapper } from "@/components/forms";
 import { TextFieldArrayController } from "@/components/forms/controllers";
-import { arrayOfIPv4CidrSchema } from "@/components/forms/schemas";
+import {
+  arrayOfIPv4CidrSchema,
+  getOptionalUrlSchema
+} from "@/components/forms/schemas";
 import { PinDrop } from "@mui/icons-material";
 import { TFunction } from "i18next";
 import { useTranslation } from "next-i18next";
@@ -15,13 +18,7 @@ export const getValidationSchema = (t: TFunction<"translation", undefined>) =>
     metadata: z.object({
       cta: z.object({
         text: z.string(),
-        url: z.union([
-          z.literal(""),
-          z
-            .string()
-            .trim()
-            .url(t("forms.errors.field.url"))
-        ])
+        url: getOptionalUrlSchema(t)
       })
     })
   });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix service create/update URL fields in which it was possible to insert blanks at the beginning or end of the url values.
With this fix, blanks are now correctly detected and, in this case, the field changes its status to error _(red color with error helpertext)._

_Watch video below to better appreciate fix._

#### List of Changes
- add new `getUrlSchema`, `getOptionalUrlSchema` on **schemas**
- update service create/update **url fields** schema
<!--- Describe your changes in detail -->

#### Motivation and Context
Avoid start/end spaces on url fields in service create/update form.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/93b7d8f4-f998-4725-83ff-a3a15905c967


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
