### PR TITLE
bugfix:[#IOPAE-997]Remove option from ValidSecureChannelService tos_url type

### DIFF
--- a/.changeset/shiny-birds-visit.md
+++ b/.changeset/shiny-birds-visit.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+change ValidSecureChannelService tos_url type

--- a/apps/io-services-cms-webapp/src/reviewer/__tests__/service-validation-handler.test.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/__tests__/service-validation-handler.test.ts
@@ -138,7 +138,7 @@ describe("Service Validation Handler", () => {
           },
         },
       },
-      expected: /tos_url\] is not a valid/,
+      expected: /tos_url(?=.*is not a valid)/,
     },
     {
       scenario:
@@ -324,7 +324,12 @@ describe("Service Validation Handler", () => {
           ...aValidRequestValidationItem,
           data: {
             ...aValidRequestValidationItem.data,
+            require_secure_channel: true,
             authorized_cidrs: ["0.0.0.0/0"],
+            metadata: {
+              ...aValidRequestValidationItem.data.metadata,
+              tos_url: "https://localhost",
+            },
           },
         })
       )

--- a/apps/io-services-cms-webapp/src/reviewer/service-validation-handler.ts
+++ b/apps/io-services-cms-webapp/src/reviewer/service-validation-handler.ts
@@ -11,7 +11,7 @@ import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as TE from "fp-ts/lib/TaskEither";
 import { flow, pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
-import { Json, option } from "io-ts-types";
+import { Json } from "io-ts-types";
 import lodash from "lodash";
 import { IConfig, ServiceValidationConfig } from "../config";
 import { TelemetryClient } from "../utils/applicationinsight";
@@ -53,10 +53,9 @@ const ValidSecureChannelTrueConfig = t.type({
     }),
     t.type({
       metadata: t.type({
-        tos_url: option(
+        tos_url:
           Queue.RequestReviewItemStrict.types[0].types[0].props.data.types[1]
-            .props.metadata.types[1].props.tos_url
-        ),
+            .props.metadata.types[1].props.tos_url,
       }),
     }),
   ]),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Remove option from ValidSecureChannelService tos_url type
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
even if in a service the `require_secure_channel` fiel was true adding a value to the `tos_url` field would cause the service to be automatic rejected
#### How Has This Been Tested?
unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
