### PR TITLE
[IOPAE-992] Fix serviceId and continuationToken in serviceHistory response fields

### DIFF
--- a/.changeset/blue-tools-cover.md
+++ b/.changeset/blue-tools-cover.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Fix serviceId and continuationToken in serviceHistory response fields

--- a/apps/io-services-cms-webapp/src/utils/converters/service-history-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-history-converters.ts
@@ -28,13 +28,13 @@ export const itemToResponse =
       metadata: { scope, category, custom_special_flow, topic_id, ...metadata },
       ...data
     },
-    id,
+    serviceId,
     last_update,
   }: ServiceHistoryCosmosItem): TE.TaskEither<Error, ServiceResponsePayload> =>
     pipe(
-      toServiceTopic(dbConfig)(id, topic_id),
+      toServiceTopic(dbConfig)(serviceId, topic_id),
       TE.bimap(E.toError, (topic) => ({
-        id,
+        id: serviceId,
         status: buildStatus(fsm),
         last_update: last_update ?? new Date().getTime().toString(),
         ...data,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-history.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-history.ts
@@ -123,9 +123,7 @@ export const makeGetServiceHistoryHandler =
                   itemsToResponse(config),
                   TE.map((mapped) =>
                     ResponseSuccessJson({
-                      continuationToken: continuationToken
-                        ? encodeURIComponent(continuationToken)
-                        : undefined,
+                      continuationToken,
                       items: mapped,
                     })
                   )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fix serviceId and continuationToken in serviceHistory response fields
#### List of Changes
- Set the right serviceId in serviceHistory response
- Remove urlEnconding in continuationToken

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
local application ruin
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
