### PR TITLE
chore:[IOPAE-1043] Trim Service Name before save

### DIFF
--- a/.changeset/five-bugs-dress.md
+++ b/.changeset/five-bugs-dress.md
@@ -1,0 +1,5 @@
+---
+"@io-services-cms/models": patch
+---
+
+Trim service name before saving in FSM store

--- a/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
@@ -305,4 +305,24 @@ describe("override", () => {
       expect(result.right.fsm.autoPublish).toBeTruthy();
     }
   });
+
+  it("should trim before save an item", async () => {
+    const aServiceWithSpaces = changeName(aService, "  a new name  ");
+    store
+      .inspect()
+      .set(aServiceId, { ...aServiceWithSpaces, fsm: { state: "draft" } });
+
+    const item = {
+      ...aServiceWithSpaces,
+      fsm: { state: "approved", autoPublish: true },
+    } as WithState<"approved", Service>;
+    const result = await fsmClient.override(aServiceId, item)();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(store.inspect().get(aServiceId)).eq(result.right);
+      expect(result.right.fsm.state).eq("approved");
+      expect(result.right.fsm.autoPublish).toBeTruthy();
+      expect(result.right.data.name).eq("a new name");
+    }
+  });
 });

--- a/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-publication/__tests__/index.test.ts
@@ -422,6 +422,28 @@ describe("override", () => {
       expect(result.right.fsm.state).eq("published");
     }
   });
+
+  it("should trim the name before save", async () => {
+    const aServiceWithSpaces = {
+      ...aService,
+      data: { ...aService.data, name: " a name with spaces " },
+    };
+    store
+      .inspect()
+      .set(aServiceId, { ...aServiceWithSpaces, fsm: { state: "unpublished" } });
+
+    const item = {
+      ...aServiceWithSpaces,
+      fsm: { state: "published" },
+    } as WithState<"published", Service>;
+    const result = await fsmClient.override(aServiceId, item)();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(store.inspect().get(aServiceId)).eq(result.right);
+      expect(result.right.fsm.state).eq("published");
+      expect(result.right.data.name).eq("a name with spaces");
+    }
+  });
 });
 
 describe("release", () => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Trim Service Name before save FSM store.
This will help in Pure duplicates identification implemented here https://github.com/pagopa/io-services-cms/pull/767
#### List of Changes
- trim service name before saving in FSM store
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
