### PR TITLE
[IOPAE-1001] topic_id is now required in service payload Metadada schema

### DIFF
--- a/packages/io-services-cms-models/openapi/services-cms-schemas.yaml
+++ b/packages/io-services-cms-models/openapi/services-cms-schemas.yaml
@@ -191,6 +191,8 @@ ServicePayloadMetadata:
           type: number
           description: The topic id
           example: 3
+      required:
+        - topic_id
 ServiceLifecycleStatus:
   type: object
   properties:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Set `topic_id` field required on ServicePayloadMetadata Schema
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
