### PR TITLE
Service history status unify Implementation

### DIFF
--- a/.changeset/six-shirts-destroy.md
+++ b/.changeset/six-shirts-destroy.md
@@ -1,0 +1,6 @@
+---
+"io-services-cms-webapp": patch
+"io-services-cms-backoffice": patch
+---
+
+Unify History payload status field

--- a/apps/io-services-cms-webapp/openapi.yaml
+++ b/apps/io-services-cms-webapp/openapi.yaml
@@ -673,6 +673,10 @@ components:
       $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceHistoryItem'
     ServiceHistoryItemStatus:
       $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceHistoryItemStatus'
+    ServiceHistoryStatusKind:
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceHistoryStatusKind'
+    ServiceHistoryStatusType:
+      $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceHistoryStatusType'
     ServiceLifecycle:
       $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycle'
     ServicePublication:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Unified the `status` field of the ServiceHistory API response between "service-publication" and "service-lifecycle" 
derived elements.
Prior to this modification the response Payload was:
```lang=json
// status object (history object related to lifecycle)
{
  ...params,
  "status" : {
    "value" : <String>,
    "reason": <String>
  },
  ...other params
}

// status string (history object related to publication)
{
  ...params,
  "status" : <String>,
  ...other params
}
```

After modification
```lang=json
// status object in both history object related to lifecycle and publication
{
  ...params,
  "status" : {
    "kind": "lifecycle" | "publication" // this allow to discriminate between lifecycle and publication items
    "value" : <String>,
    "reason": <String>
  },
  ...other params
}
```

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit tests(previously developed) and Local application run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

depends on https://github.com/pagopa/io-services-cms/pull/786