### PR TITLE
[IOPAE-1065] BackOffice IO: Topic is now required on service create/update form

### DIFF
--- a/.changeset/cool-actors-sing.md
+++ b/.changeset/cool-actors-sing.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+Topic is now required on Service Creation/Edit

--- a/apps/backoffice/src/components/forms/controllers/autocomplete-controller.tsx
+++ b/apps/backoffice/src/components/forms/controllers/autocomplete-controller.tsx
@@ -6,7 +6,7 @@ import {
 } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import { ReactNode } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { Controller, get, useFormContext } from "react-hook-form";
 
 export type AutocompleteControllerProps = {
   name: string;
@@ -31,7 +31,8 @@ export function AutocompleteController({
   helperText
 }: AutocompleteControllerProps) {
   const { t } = useTranslation();
-  const { register, control } = useFormContext();
+  const { register, control, formState } = useFormContext();
+  const error = get(formState.errors, name);
 
   if (items.length === 0) return; // avoid mui out-of-range error
   return (
@@ -60,10 +61,17 @@ export function AutocompleteController({
               typeof v === "number" ? o.id === v : false
             }
             renderInput={params => (
-              <TextField {...params} label={label} placeholder={placeholder} />
+              <TextField
+                {...params}
+                label={label}
+                placeholder={placeholder}
+                error={!!error}
+              />
             )}
           />
-          <FormHelperText>{helperText}</FormHelperText>
+          <FormHelperText error={!!error}>
+            {error ? error.message : helperText ?? null}
+          </FormHelperText>
         </FormControl>
       )}
     />

--- a/apps/backoffice/src/components/services/service-create-update/service-builder-step-1.tsx
+++ b/apps/backoffice/src/components/services/service-create-update/service-builder-step-1.tsx
@@ -32,6 +32,10 @@ export const getValidationSchema = (t: TFunction<"translation", undefined>) =>
       .max(1000, { message: t("forms.errors.field.max", { max: 1000 }) }),
     metadata: z.object({
       scope: z.string(),
+      topic_id: z.union([
+        z.string().min(1, { message: t("forms.errors.field.required") }),
+        z.number().min(0, { message: t("forms.errors.field.required") })
+      ]),
       address: z
         .string()
         .max(100, { message: t("forms.errors.field.max", { max: 100 }) })


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Make topic required on service create/update form.

_Watch video below to better appreciate development._

#### List of Changes
- add required property for topic schema validation
- update AutocompleteController component in order to manage validation error
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/pagopa/io-services-cms/assets/118166285/35fb9e10-1bec-4739-a93f-a511081cf46b


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
