### PR TITLE
[IOPAE-1123] Add organization_name to featured service

### DIFF
--- a/.changeset/twelve-scissors-wink.md
+++ b/.changeset/twelve-scissors-wink.md
@@ -1,0 +1,5 @@
+---
+"io-services-app-backend": patch
+---
+
+Add organization_name to featured service response

--- a/apps/app-backend/api/internal.yaml
+++ b/apps/app-backend/api/internal.yaml
@@ -302,8 +302,16 @@ components:
     FeaturedItem:
       x-one-of: true
       allOf:
-        - $ref: '#/components/schemas/ServiceMinified'
+        - $ref: '#/components/schemas/FeaturedService'
         - $ref: '#/components/schemas/Institution'
+    FeaturedService:
+      allOf:
+        - $ref: '#/components/schemas/ServiceMinified'
+      type: object
+      properties:
+        organization_name:
+          type: string
+          description: Organization Name
     ServiceMetadata:
       description: A set of service metadata properties
       allOf:

--- a/apps/app-backend/api/internal.yaml.template
+++ b/apps/app-backend/api/internal.yaml.template
@@ -290,8 +290,16 @@ components:
     FeaturedItem:
       x-one-of: true
       allOf:
-        - $ref: "#/components/schemas/ServiceMinified"
+        - $ref: "#/components/schemas/FeaturedService"
         - $ref: "#/components/schemas/Institution"
+    FeaturedService:
+      allOf:
+        - $ref: '#/components/schemas/ServiceMinified'
+      type: object
+      properties:
+        organization_name:
+          type: string
+          description: Organization Name
     ServiceMetadata:
       $ref: "https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceMetadata"
     Organization:

--- a/apps/app-backend/src/functions/__mocks__/featured-items.ts
+++ b/apps/app-backend/src/functions/__mocks__/featured-items.ts
@@ -12,5 +12,11 @@ export const mockFeaturedItems = {
       name: "anInstitutionName",
       fiscal_code: "12345678901",
     },
+    {
+      id: "anotherServiceId",
+      name: "aServiceName",
+      version: 1,
+      organization_name: "anOrganizationName",
+    },
   ],
 } as unknown as FeaturedItems;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add `organization_name` optional property to **FeaturedService**.

#### List of Changes
- update openapi definitions
- update FeaturedItems mocks
<!--- Describe your changes in detail -->

#### Motivation and Context
Need to have the possibility to specify Organization Name for a featured service.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
