### PR TITLE
search_service_url output returning raw cname

### DIFF
--- a/infra/_modules/ai_search/outputs.tf
+++ b/infra/_modules/ai_search/outputs.tf
@@ -3,7 +3,7 @@ output "search_service_id" {
 }
 
 output "search_service_url" {
-  value = azurerm_private_endpoint.srch.private_dns_zone_configs[0].record_sets[0].fqdn
+  value = "${azurerm_private_endpoint.name}.search.windows.net"
 }
 
 output "search_service_index_aliases" {


### PR DESCRIPTION
 To allow tls handshake to work properly

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
search_service_url output returning raw cname to allow tls handshake to work properly

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The privatelink url was returned, but this caused the tls handshake to fail due to certificate validation issues.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
