### PR TITLE
Infra ci/cd for weu infrastructure now runs only for infra/src path

### DIFF
--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
     paths:
-      - 'infra/**'
+      - 'infra/src/**'
       - '.github/workflows/infra-cd.yml'
 
 permissions:

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -10,7 +10,7 @@ on:
       - reopened
       - ready_for_review
     paths:
-      - 'infra/**'
+      - 'infra/src/**'
       - '.github/workflows/infra-ci.yml'
 
 permissions:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Changed path triggers for infrastructure ci/cd workflows to run only when terraform configuration is changed inside apps/infra/src.
<!--- Describe your changes in detail -->

#### Motivation and Context
As of now, ci/cd workflows that plan and apply terraform code for weu infrastructure, are launched also for changes in the new itn infrastructure configuration.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
