### PR TITLE
Allowed io-p-adgroup-services-cms group to query AI Search

### DIFF
--- a/infra/_modules/ai_search/data.tf
+++ b/infra/_modules/ai_search/data.tf
@@ -15,3 +15,7 @@ data "azurerm_subnet" "pep_snet" {
   virtual_network_name = "${var.project}-common-vnet-01"
   resource_group_name  = "${var.project}-common-rg-01"
 }
+
+data "azuread_group" "adgroup_services_cms" {
+  display_name = "${var.prefix}-${var.env_short}-adgroup-services-cms"
+}

--- a/infra/_modules/ai_search/main.tf
+++ b/infra/_modules/ai_search/main.tf
@@ -82,3 +82,9 @@ resource "azurerm_cosmosdb_sql_role_assignment" "search_to_cosmos_data_reader_db
   principal_id        = azurerm_search_service.srch.identity[0].principal_id
   scope               = "${data.azurerm_cosmosdb_account.cosmos.id}/dbs/${var.cosmos_database_name}/colls/services-publication"
 }
+
+resource "azurerm_role_assignment" "developers_group_to_ai_search_reader" {
+  scope                = var.ai_search.id
+  role_definition_name = "Search Index Data Reader"
+  principal_id         = data.azuread_group.adgroup_services_cms.object_id
+}

--- a/infra/_modules/ai_search/main.tf
+++ b/infra/_modules/ai_search/main.tf
@@ -84,7 +84,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "search_to_cosmos_data_reader_db
 }
 
 resource "azurerm_role_assignment" "developers_group_to_ai_search_reader" {
-  scope                = var.ai_search.id
+  scope                = azurerm_search_service.srch.id
   role_definition_name = "Search Index Data Reader"
   principal_id         = data.azuread_group.adgroup_services_cms.object_id
 }

--- a/infra/prod/italynorth/.terraform.lock.hcl
+++ b/infra/prod/italynorth/.terraform.lock.hcl
@@ -1,9 +1,32 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.48.0"
+  constraints = "2.48.0"
+  hashes = [
+    "h1:0R8yR32NSZvH93C1o4cdmhdRkjc1uBZD5UtiexTVcOk=",
+    "h1:0bqCK3mnamo16MVyEiyYayNAwRMCOentHqw/rPmx7/0=",
+    "h1:RR02r3H1DRVkvEWPH/PWzTXGgIZ3cXruyXvup25XTwg=",
+    "h1:ynkXYWTKilLNj+TBjlYH0jGRlJFev6GnJyEymMu1h9Q=",
+    "zh:0ec4f1ca1825f038001173c40f4b6edbdbc71d018d782b45c22d5e272ca0ec16",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:22154cd497009b5b1cb6b87131b3f31521b3de392ade1ac64dade3f29b03f8d0",
+    "zh:2723fe574d7a89242bd642b896ff7006d36f8a5d5a7c3876c7e1e2ada567d599",
+    "zh:2858abe3209fa0035419a4b2f8f155878fb6ecbc64f72c6f726dad583b1c8217",
+    "zh:3ba51d3e3ba6f12e8e12b043d7bc5f4415fc1ac08b81306ad546fe1ca2a3aa32",
+    "zh:49a39fb3713ba1a58fcb7b040bc4430ab4edb5116e8d7d33b73361f07febaead",
+    "zh:6a043d62a9cbfb805040e33e700cdcbfb5f199a74ae3867fc10c6810741ab222",
+    "zh:906c0961425d5854b22c9fed4d319248a7c88f0037547ea8472998720487ae25",
+    "zh:a1d246d8e0362afe397f0aedf0e68cf7d920fbae1adb88841f63dc98c06e5888",
+    "zh:c7df4d912c970600d9cba97a60c84b1a4ad1031feb723021c6984d99b320fd5c",
+    "zh:e8fbec893b4feb4410185126f2421ef0bdbbb102d1370ed72bb65b99d8869b98",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.97.1"
-  constraints = ">= 3.30.0, >= 3.76.0, >= 3.95.0, <= 3.97.1, <= 3.99.0, <= 3.101.0"
+  constraints = ">= 3.30.0, >= 3.76.0, >= 3.95.0, <= 3.97.1, <= 3.99.0, <= 3.100.0, <= 3.101.0"
   hashes = [
     "h1:LtwGbd4HEb5QCXmdxSvTjPSh8/Gp8eAQMYfiAKaubV4=",
     "h1:klBuN2uVZF7AVMhskbbgF8pygyhPBxsjedB1GUV79PA=",
@@ -28,6 +51,9 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.2"
   hashes = [
     "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:m467k2tZ9cdFFgHW7LPBK2GLPH43LC6wc3ppxr8yvoE=",
+    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
     "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",

--- a/infra/prod/italynorth/providers.tf
+++ b/infra/prod/italynorth/providers.tf
@@ -17,6 +17,11 @@ terraform {
       source  = "Mastercard/restapi"
       version = "<= 1.19.1"
     }
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.48.0"
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Assigned "Search Index Data Reader" role to the group of the project's developers

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Instead of using AI Search API Keys, developers will be able to locally test the application and authenticate to AI Search via their identity
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Terraform plan and pre-commit run -a

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
