### PR TITLE
[EC-288] Set scheduling of indexers with 1 hour interval

### DIFF
--- a/infra/_modules/ai_search/organizations.tf
+++ b/infra/_modules/ai_search/organizations.tf
@@ -11,6 +11,10 @@ resource "restapi_object" "organizations_datasource" {
         name  = "services-publication"
         query = "SELECT c.data.organization.fiscal_code, c.data.organization.name, c.data.metadata.scope, c.fsm.state, c._ts FROM c WHERE c.fsm.state = \"published\" and c._ts >= @HighWaterMark ORDER BY c._ts"
       },
+      dataChangeDetectionPolicy = {
+        "@odata.type"           = "#Microsoft.Azure.Search.HighWaterMarkChangeDetectionPolicy",
+        highWaterMarkColumnName = "_ts"
+      }
   })
   force_new    = ["name"]
   id_attribute = "name" # The ID field on the response
@@ -170,7 +174,7 @@ resource "restapi_object" "organizations_indexer" {
       description     = null
       skillsetName    = null
       disabled        = null
-      schedule        = null
+      schedule        = { interval = var.indexers_scheduling_interval.organizations }
       parameters = {
         batchSize              = null
         maxFailedItems         = null

--- a/infra/_modules/ai_search/services.tf
+++ b/infra/_modules/ai_search/services.tf
@@ -155,7 +155,7 @@ resource "restapi_object" "services_publication_indexer" {
       description     = null
       skillsetName    = null
       disabled        = null
-      schedule        = null
+      schedule        = { interval = var.indexers_scheduling_interval.services_publication }
       parameters = {
         batchSize              = null
         maxFailedItems         = null
@@ -188,7 +188,7 @@ resource "restapi_object" "services_lifecycle_indexer" {
       description     = null
       skillsetName    = null
       disabled        = null
-      schedule        = null
+      schedule        = { interval = var.indexers_scheduling_interval.services_lifecycle }
       parameters = {
         batchSize              = null
         maxFailedItems         = null

--- a/infra/_modules/ai_search/variables.tf
+++ b/infra/_modules/ai_search/variables.tf
@@ -97,12 +97,12 @@ variable "index_aliases" {
 }
 
 variable "indexers_scheduling_interval" {
-  type = map(string)
+  type        = map(string)
   description = "The indexers scheduling intervals"
 
   default = {
-    organizations = "PT1H"
+    organizations      = "PT1H"
     services_lifecycle = "PT1H"
-    organizations = "PT1H"
+    organizations      = "PT1H"
   }
 }

--- a/infra/_modules/ai_search/variables.tf
+++ b/infra/_modules/ai_search/variables.tf
@@ -95,3 +95,14 @@ variable "index_aliases" {
     services      = "services"
   }
 }
+
+variable "indexers_scheduling_interval" {
+  type = map(string)
+  description = "The indexers scheduling intervals"
+
+  default = {
+    organizations = "PT1H"
+    services_lifecycle = "PT1H"
+    organizations = "PT1H"
+  }
+}

--- a/infra/_modules/ai_search/variables.tf
+++ b/infra/_modules/ai_search/variables.tf
@@ -101,8 +101,8 @@ variable "indexers_scheduling_interval" {
   description = "The indexers scheduling intervals"
 
   default = {
-    organizations      = "PT1H"
-    services_lifecycle = "PT1H"
-    organizations      = "PT1H"
+    organizations        = "PT1H"
+    services_lifecycle   = "PT1H"
+    services_publication = "PT1H"
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added datachange policy to the organizations datasource to allow incremental indexing
Set scheduling of the three indexers with a 1 hour interval

<!--- Describe your changes in detail -->

#### Motivation and Context
The services and organizations indexes must be updated automatically to follow the addition and/or deletion of records in cosmosdb

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
