### PR TITLE
ITN infra cicd should start also when editing _modules files

### DIFF
--- a/.github/workflows/infra-release-p-itn.yml
+++ b/.github/workflows/infra-release-p-itn.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths:
       - "infra/prod/italynorth/**"
+      - "infra/_modules/**"
       - ".github/workflows/infra-review-p-itn.yml"
 
 jobs:

--- a/.github/workflows/infra-review-p-itn.yml
+++ b/.github/workflows/infra-review-p-itn.yml
@@ -10,6 +10,7 @@ on:
       - ready_for_review
     paths:
       - "infra/prod/italynorth/**"
+      - "infra/_modules/**"
       - ".github/workflows/infra-review-p-itn.yml"
       - ".github/workflows/infra-release-p-itn.yml"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
The CI and CD workflows will also be triggered on changes done in the infra/_modules folder
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
If edits are done in the _modules folder (actual folder containing terraform resources configuration), the CI/CD workflows wouldn't start

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
