### PR TITLE
[EC-311] change AI search sku to standard

### DIFF
--- a/infra/_modules/ai_search/main.tf
+++ b/infra/_modules/ai_search/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_search_service" "srch" {
   location                      = var.location
   public_network_access_enabled = var.public_network_access_enabled
 
-  sku             = "basic"
+  sku             = var.sku
   replica_count   = var.replica_count
   partition_count = var.partition_count
 

--- a/infra/_modules/ai_search/variables.tf
+++ b/infra/_modules/ai_search/variables.tf
@@ -106,3 +106,14 @@ variable "indexers_scheduling_interval" {
     services_publication = "PT1H"
   }
 }
+
+variable "sku" {
+  type        = string
+  description = "The SKU of the Search Service"
+  default     = "standard"
+
+  validation {
+    condition     = contains(["basic", "free", "standard", "standard2", "standard3", "storage_optimized_l1", "storage_optimized_l2"], var.sku)
+    error_message = "The SKU must be one of: basic, free, standard, standard2, standard3, storage_optimized_l1, or storage_optimized_l2."
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Created sku variable in AI Search module
Changed AI Search sku to standard

⚠️ Apply will be executed locally to overcome issues caused by the restapi provider that make the plan fail.
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The current sku (basic) does not allow to scale above 3 replicas. This capacity may not be enough for production loads, hence the standard sku has been chosen.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
