### PR TITLE
use azurerm_monitor_scheduled_query_rules_alert_v2

### DIFF
--- a/infra/src/README.md
+++ b/infra/src/README.md
@@ -58,7 +58,7 @@
 | [azurerm_monitor_autoscale_setting.webapp_functions_app_autoscale](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.queue_diagnostic_setting](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.webapp_functions_app_health_check](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_scheduled_query_rules_alert.poison-queue-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.poison-queue-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_postgresql_flexible_server_database.reviewer_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_queue.request-deletion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |

--- a/infra/src/monitor.tf
+++ b/infra/src/monitor.tf
@@ -8,32 +8,36 @@ resource "azurerm_monitor_diagnostic_setting" "queue_diagnostic_setting" {
   }
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "poison-queue-alert" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "poison-queue-alert" {
+  enabled             = true
   name                = "[${upper(local.application_basename)}] Messages In Poison Queue"
-  location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  scopes              = [module.storage_account.id]
+  description         = "Storage Account [${module.storage_account.name}] poison queue contains messages, this happen on multiple failures in message process by the QueueTrigger Azure Functions"
   severity            = 0
-  action {
-    action_group = [data.azurerm_monitor_action_group.iopquarantineerror_action_group.id]
+
+  // check once every 5 minutes(evaluation_frequency)
+  // on the last 10 minutes of data(window_duration)
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+
+  mute_actions_after_alert_duration = "PT5M"
+
+  criteria {
+    query                   = <<-QUERY
+      StorageQueueLogs  
+      | where OperationName contains "PutMessage" 
+      | where Uri contains "-poison"
+      | distinct Uri
+      | project QueueName = split(Uri, "/")[3]
+    QUERY
+    operator                = "GreaterThan"
+    time_aggregation_method = "Count"
+    threshold               = 0
   }
 
-  data_source_id = module.storage_account.id
-
-  description = "Storage Account [${module.storage_account.name}] poison queue contains messages, this happen on multiple failures in message process by the QueueTrigger Azure Functions"
-
-  query = <<-QUERY
-    StorageQueueLogs  
-    | where OperationName contains "PutMessage" 
-    | where Uri contains "-poison"
-    | distinct Uri
-    | project QueueName = split(Uri, "/", 3)
-  QUERY
-
-  frequency   = "5" // minutes
-  time_window = "5" // minutes
-
-  trigger {
-    operator  = "GreaterThan"
-    threshold = 0
+  action {
+    action_groups = [data.azurerm_monitor_action_group.iopquarantineerror_action_group.id]
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
An `evaluation_frequency` equalsTo a `window_duration` can lead, in some edge cases, to a loss of events

#### List of Changes
<!--- Describe your changes in detail -->
- upgrade the version of query alerts terraform resource
- increment `window_duration`
- add `mute_actions_after_alert_duration` to avoid receiving alerts for the same event

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There might be a delay on audit log, so we have to increment alert time_window to manage those edge cases

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
