### PR TITLE
[IOPAE-1201] Remove unwanted continuationToken on serviceHistory first call

### DIFF
--- a/.changeset/neat-waves-hide.md
+++ b/.changeset/neat-waves-hide.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix ServiceHistory unwanted continuationToken on first call

--- a/apps/backoffice/src/pages/services/[serviceId].tsx
+++ b/apps/backoffice/src/pages/services/[serviceId].tsx
@@ -104,11 +104,6 @@ export default function ServiceDetails() {
 
   const handleHistory = (continuationToken?: string) => {
     setShowHistory(true);
-
-    console.log(
-      "Service History continuation token on handleHistory: ",
-      continuationToken
-    );
     shFetchData(
       "getServiceHistory",
       { serviceId, continuationToken },

--- a/apps/backoffice/src/pages/services/[serviceId].tsx
+++ b/apps/backoffice/src/pages/services/[serviceId].tsx
@@ -104,6 +104,11 @@ export default function ServiceDetails() {
 
   const handleHistory = (continuationToken?: string) => {
     setShowHistory(true);
+
+    console.log(
+      "Service History continuation token on handleHistory: ",
+      continuationToken
+    );
     shFetchData(
       "getServiceHistory",
       { serviceId, continuationToken },
@@ -160,7 +165,7 @@ export default function ServiceDetails() {
             onPublishClick={handlePublish}
             onUnpublishClick={handleUnpublish}
             onSubmitReviewClick={() => handleSubmitReview(true)} // TODO capire lato UX/UI come gestire l'auto_publish
-            onHistoryClick={handleHistory}
+            onHistoryClick={() => handleHistory()}
             onPreviewClick={handlePreview}
             onEditClick={() =>
               router.push(`/services/${serviceId}/edit-service`)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Currently the first call to the ServiceHistory API includes an unintended continuationToken(react passes a SyntheticBaseEvent which is mistakenly then used in the call as a continuationToken), as shown in the following screen.

![image](https://github.com/pagopa/io-services-cms/assets/7738875/014e4002-6c04-466c-9a0e-b5e9ac1a50c6)

#### List of Changes
- remove any Parameter on serviceHistory first call

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local Application Run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
