### PR TITLE
[IOPAE-1224] Search institution default order on no searchtext provided

### DIFF
--- a/.changeset/large-hotels-speak.md
+++ b/.changeset/large-hotels-speak.md
@@ -1,0 +1,5 @@
+---
+"io-services-app-backend": patch
+---
+
+Default order on SearchInstitutions on no searchText provided

--- a/apps/app-backend/api/internal.yaml
+++ b/apps/app-backend/api/internal.yaml
@@ -5,7 +5,7 @@ info:
   contact:
     name: PagoPA S.p.A.
     url: https://pagopa.it/
-  version: 0.0.10
+  version: 0.0.11
 servers:
   - url: https://to-be-defined.it
 tags:

--- a/apps/app-backend/src/functions/search-institutions.ts
+++ b/apps/app-backend/src/functions/search-institutions.ts
@@ -31,6 +31,7 @@ type SearchInstitutionsRequestQueryParams = {
   limit: number;
   offset: O.Option<number>;
 };
+export const DEFAULT_ORDER_BY = "name asc";
 
 const calculateScopeFilter = (scope: O.Option<ScopeType>): string | undefined =>
   pipe(
@@ -92,6 +93,14 @@ const executeSearch: (
             O.toUndefined
           ),
           filter: calculateScopeFilter(requestQueryParams.scope),
+          orderBy: pipe(
+            requestQueryParams.search,
+            O.isNone,
+            B.fold(
+              () => undefined, // when search text is provided, result will be ordered by relevance(search rank)
+              () => [DEFAULT_ORDER_BY] // when no search text is provided, result will be ordered by name asc
+            )
+          ),
         })
       ),
       TE.map(({ paginationProperties, results }) => ({

--- a/apps/app-backend/src/utils/azure-search/client.ts
+++ b/apps/app-backend/src/utils/azure-search/client.ts
@@ -24,6 +24,7 @@ export type FullTextSearchParam = {
   readonly filter?: string;
   readonly scoringProfile?: string;
   readonly scoringParameters?: string[];
+  readonly orderBy?: string[];
 };
 
 export type AzureSearchClient<T> = {
@@ -33,6 +34,9 @@ export type AzureSearchClient<T> = {
     skip,
     top,
     filter,
+    scoringProfile,
+    scoringParameters,
+    orderBy,
   }: FullTextSearchParam) => TE.TaskEither<Error, SearchMappedResult<T>>;
 };
 
@@ -68,6 +72,7 @@ export const makeAzureSearchClient = <T>(
     filter,
     scoringProfile,
     scoringParameters,
+    orderBy,
   }: FullTextSearchParam): TE.TaskEither<Error, SearchMappedResult<T>> =>
     pipe(
       TE.tryCatch(
@@ -80,6 +85,7 @@ export const makeAzureSearchClient = <T>(
             scoringProfile,
             skip,
             top,
+            orderBy,
           }),
         E.toError
       ),
@@ -87,7 +93,7 @@ export const makeAzureSearchClient = <T>(
         pipe(
           response,
           O.fromPredicate((r) => r.count !== undefined && r.count > 0),
-          O.fold(
+          O.foldW(
             () => TE.right({ count: 0, resources: [] }),
             (r) =>
               pipe(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Order search Institutition based on `name` when no fullText search is involved(no search queryString param is provided when calling the API `GET /institutions`)
#### List of Changes
- Add `orderBy` parameter on Azure Search Client
- Add default `orderBy` use on no `search` queryParam is provided when calling the API `GET /institutions`

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
