### PR TITLE
[IOPAE-1262] use custom offset limit only when requested a full text search

### DIFF
--- a/.changeset/wet-horses-suffer.md
+++ b/.changeset/wet-horses-suffer.md
@@ -1,0 +1,5 @@
+---
+"io-services-app-backend": patch
+---
+
+use custom offset limit only when requested a full text search

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -47,12 +47,14 @@ jobs:
 
       - name: 'Report App Backend Coverage'
         uses: davelosert/vitest-coverage-report-action@9fd25c0d0394bfd0ffa632777316402c2e5fb81f # v2.0.4
+        if: ${{ hashFiles('./apps/app-backend/coverage/*.json') != '' }}
         with:
           name: 'App Backend'
           working-directory: './apps/app-backend'
 
       - name: 'Report Backoffice Frontend Coverage'
         uses: davelosert/vitest-coverage-report-action@9fd25c0d0394bfd0ffa632777316402c2e5fb81f # v2.0.4
+        if: ${{ hashFiles('./apps/backoffice/frontend/coverage/*.json') != '' }}
         with:
           name: 'Backoffice Frontend'
           working-directory: './apps/backoffice'
@@ -62,6 +64,7 @@ jobs:
 
       - name: 'Report Backoffice Backend Coverage'
         uses: davelosert/vitest-coverage-report-action@9fd25c0d0394bfd0ffa632777316402c2e5fb81f # v2.0.4
+        if: ${{ hashFiles('./apps/backoffice/backend/coverage/*.json') != '' }}
         with:
           name: 'Backoffice Backend'
           working-directory: './apps/backoffice'
@@ -71,18 +74,21 @@ jobs:
 
       - name: 'Report Webapp Coverage'
         uses: davelosert/vitest-coverage-report-action@9fd25c0d0394bfd0ffa632777316402c2e5fb81f # v2.0.4
+        if: ${{ hashFiles('./apps/io-services-cms-webapp/coverage/*.json') != '' }}
         with:
           name: 'Webapp'
           working-directory: './apps/io-services-cms-webapp'
 
       - name: 'Report External Clients Coverage'
         uses: davelosert/vitest-coverage-report-action@9fd25c0d0394bfd0ffa632777316402c2e5fb81f # v2.0.4
+        if: ${{ hashFiles('./apps/external-clients/coverage/*.json') != '' }}
         with:
           name: 'External Clients'
           working-directory: './packages/external-clients'
 
       - name: 'Report Models Coverage'
         uses: davelosert/vitest-coverage-report-action@9fd25c0d0394bfd0ffa632777316402c2e5fb81f # v2.0.4
+        if: ${{ hashFiles('./apps/io-services-cms-models/coverage/*.json') != '' }}
         with:
           name: 'Models'
           working-directory: './packages/io-services-cms-models'

--- a/apps/app-backend/src/config.ts
+++ b/apps/app-backend/src/config.ts
@@ -70,6 +70,10 @@ export const PaginationConfig = t.type({
     IntegerFromString.pipe(NonNegativeInteger),
     "500" as unknown as NonNegativeInteger
   ),
+  PAGINATION_MAX_OFFSET_AI_SEARCH: withDefault(
+    IntegerFromString.pipe(NonNegativeInteger),
+    "100000" as unknown as NonNegativeInteger
+  ),
 });
 
 // global app configuration


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We have introduced a custom offset limit to avoid performance issue when paging a large response

#### List of Changes
<!--- Describe your changes in detail -->
- use custom offset limit only when requested a full text search

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By using custom offset limit when requested either national institutions list or institution's services list, may return partial data

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
