### PR TITLE
[EC-369] Use AD authentication instead of connection string for TF state

### DIFF
--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -71,6 +71,9 @@ infra_environment_cd_roles = {
     ],
     io-p-services-cms-rg = [
       "Role Based Access Control Administrator"
+    ],
+    io-p-services-cms-rg = [
+      "Role Based Access Control Administrator"
     ]
   }
 }

--- a/infra/prod/providers.tf
+++ b/infra/prod/providers.tf
@@ -27,4 +27,5 @@ terraform {
 
 provider "azurerm" {
   features {}
+  storage_use_azuread = true
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Tell Terraform to use AD authentication rather to connect to the Storage Account which hold the state

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The connection string authentication method is disabled on a Storage Account

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
