### PR TITLE
fix: Itn keyvault now accessible from cicd identities

### DIFF
--- a/infra/_modules/key_vault/data.tf
+++ b/infra/_modules/key_vault/data.tf
@@ -16,3 +16,13 @@ data "azurerm_api_management" "apim_v2" {
   name                = "${var.prefix}-${var.env_short}-apim-v2-api"
   resource_group_name = "${var.prefix}-${var.env_short}-rg-internal"
 }
+
+data "azurerm_user_assigned_identity" "managed_identity_infra_ci" {
+  name                = "${var.prefix}-${var.env_short}-services-cms-github-ci-identity"
+  resource_group_name = "${var.prefix}-${var.env_short}-identity-rg"
+}
+
+data "azurerm_user_assigned_identity" "managed_identity_infra_cd" {
+  name                = "${var.prefix}-${var.env_short}-services-cms-github-cd-identity"
+  resource_group_name = "${var.prefix}-${var.env_short}-identity-rg"
+}

--- a/infra/_modules/key_vault/policy.tf
+++ b/infra/_modules/key_vault/policy.tf
@@ -43,3 +43,27 @@ resource "azurerm_key_vault_access_policy" "apim" {
   certificate_permissions = []
   key_permissions         = []
 }
+
+resource "azurerm_key_vault_access_policy" "managed_identity_infra_ci" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.managed_identity_infra_ci.principal_id
+
+  key_permissions         = ["Get", "List", ]
+  secret_permissions      = ["Get", "List", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", ]
+}
+
+resource "azurerm_key_vault_access_policy" "managed_identity_infra_cd" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.managed_identity_infra_cd.principal_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Purge", "Recover", ]
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Added read permissions on ITN keyvault to infra ci identity
Added read/write permissions on ITN keyvault to infra cd identity

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Terraform apply in actions failing

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
