### PR TITLE
[IOPAE-1334]  fix get user authorized institutions

### DIFF
--- a/.changeset/four-poems-destroy.md
+++ b/.changeset/four-poems-destroy.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+filter only ACTIVE user's institutions retrieved from selfcare API

--- a/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
@@ -79,6 +79,7 @@ describe("Selfcare Client", () => {
       expect(get).toHaveBeenCalledWith("/users", {
         params: {
           userId: mocks.aSelfcareUserId,
+          states: "ACTIVE",
           size: 10000
         }
       });
@@ -112,6 +113,7 @@ describe("Selfcare Client", () => {
       expect(get).toHaveBeenCalledWith("/users", {
         params: {
           userId: mocks.aSelfcareUserId,
+          states: "ACTIVE",
           size: 10000
         }
       });
@@ -136,6 +138,7 @@ describe("Selfcare Client", () => {
       expect(get).toHaveBeenCalledWith("/users", {
         params: {
           userId: mocks.aSelfcareUserId,
+          states: "ACTIVE",
           size: 10000
         }
       });

--- a/apps/backoffice/src/lib/be/institutions/selfcare.ts
+++ b/apps/backoffice/src/lib/be/institutions/selfcare.ts
@@ -9,10 +9,10 @@ import { isAxiosError } from "axios";
 import * as E from "fp-ts/lib/Either";
 
 export const getUserAuthorizedInstitutions = async (
-  userIdForAuth: string
+  userId: string
 ): Promise<UserInstitutions> => {
   const apiResult = await getSelfcareClient().getUserAuthorizedInstitutions(
-    userIdForAuth
+    userId
   )();
 
   // errore validazione parametri chiamata

--- a/apps/backoffice/src/lib/be/selfcare-client.ts
+++ b/apps/backoffice/src/lib/be/selfcare-client.ts
@@ -85,6 +85,7 @@ const buildSelfcareClient = (): SelfcareClient => {
           axiosInstance.get(usersApi, {
             params: {
               userId,
+              states: "ACTIVE",
               size: 10000
             }
           }),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
When user is logged in to IO Backoffice, only his active institutions need to be retrieved using the Selfcare API.

#### List of Changes
<!--- Describe your changes in detail -->
- [filter only ACTIVE user's institutions retrieved from selfcare API](https://github.com/pagopa/io-services-cms/commit/1e03449372b7a14c367ad4187147da8ec957e00c)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To retrieve only active user's institutions

#### How Has This Been Tested?
unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
