### PR TITLE
refactor: remove useless getUserByEmail calls

### DIFF
--- a/.changeset/rotten-clocks-rush.md
+++ b/.changeset/rotten-clocks-rush.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+refactor: remove useless getUserByEmail calls

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
@@ -34,7 +34,7 @@ vi.mock("../../../utils/service-topic-validator", () => ({
 const { getServiceTopicDao } = vi.hoisted(() => ({
   getServiceTopicDao: vi.fn(() => ({
     findById: vi.fn((id: number) =>
-      TE.right(O.some({ id, name: "topic name" }))
+      TE.right(O.some({ id, name: "topic name" })),
     ),
   })),
 }));
@@ -60,7 +60,7 @@ const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
 const fsmPublicationClient = ServicePublication.getFsmClient(
-  servicePublicationStore
+  servicePublicationStore,
 );
 
 const aManageSubscriptionId = "MANAGE-123";
@@ -70,13 +70,12 @@ const ownerId = `/an/owner/${anUserId}`;
 const anApimResource = { id: "any-id", name: "any-name" };
 const mockApimService = {
   getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
-  getUserByEmail: vi.fn((_) => TE.right(O.some(anApimResource))),
   upsertSubscription: vi.fn((_) => TE.right(anApimResource)),
   getSubscription: vi.fn(() =>
     TE.right({
       _etag: "_etag",
       ownerId: anUserId,
-    })
+    }),
   ),
 } as unknown as ApimUtils.ApimService;
 
@@ -103,7 +102,7 @@ const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
 const mockFetchAll = vi.fn(() =>
   Promise.resolve({
     resources: [aRetrievedSubscriptionCIDRs],
-  })
+  }),
 );
 const containerMock = {
   items: {
@@ -226,29 +225,9 @@ describe("createService", () => {
     expect(response.statusCode).toBe(403);
   });
 
-  it("should fail when cannot find apim user", async () => {
-    vi.mocked(mockApimService.getUserByEmail).mockImplementation(() =>
-      TE.left({ statusCode: 500 })
-    );
-
-    const spied = vi.spyOn(serviceLifecycleStore, "save");
-
-    const response = await request(app)
-      .post("/api/services")
-      .send(aNewService)
-      .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
-      .set("x-user-id", anUserId)
-      .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(response.statusCode).toBe(500);
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
-    expect(spied).not.toHaveBeenCalled();
-  });
-
   it("should fail when cannot find apim product", async () => {
     vi.mocked(mockApimService.getProductByName).mockImplementation(() =>
-      TE.left({ statusCode: 500 })
+      TE.left({ statusCode: 500 }),
     );
 
     const spied = vi.spyOn(serviceLifecycleStore, "save");
@@ -268,7 +247,7 @@ describe("createService", () => {
 
   it("should fail when cannot create subscription", async () => {
     vi.mocked(mockApimService.upsertSubscription).mockImplementation(() =>
-      TE.left({ statusCode: 500 })
+      TE.left({ statusCode: 500 }),
     );
 
     const spied = vi.spyOn(serviceLifecycleStore, "save");

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
@@ -24,13 +24,6 @@ const aName2 = "a-name-2";
 const aName3 = "a-name-3";
 
 // Apim resource mock *******************************
-const anApimResource = { id: "any-id", name: "any-name" };
-
-const anApimUserResource = {
-  ...anApimResource,
-  id: "/subscriptions/uuid/resourceGroups/a-rg-name/providers/Microsoft.ApiManagement/service/a-service-name/users/a-user-id",
-};
-
 const anApimSubscriptionResource1 = { id: "an-id-1", name: aName1 };
 const anApimSubscriptionResource2 = { id: "an-id-2", name: aName2 };
 const anApimSubscriptionResource3 = { id: "an-id-3", name: aName3 };
@@ -75,7 +68,6 @@ const aServiceList = [
 
 // Apim service mock *******************************
 const mockApimService = {
-  getUserByEmail: vi.fn((_) => TE.right(O.some(anApimUserResource))),
   getUserSubscriptions: vi.fn((_) => TE.right(aSubscriptionCollection)),
   parseOwnerIdFullPath: vi.fn((_) => "a-user-id"),
 } as unknown as ApimUtils.ApimService;
@@ -88,7 +80,7 @@ const mockConfig = {
 
 // FSM client mock *******************************
 const aBulkFetchRightValue = TE.of(
-  aServiceList.map((service) => O.fromNullable(service))
+  aServiceList.map((service) => O.fromNullable(service)),
 );
 
 let mockFsmLifecycleClient = {
@@ -122,7 +114,7 @@ const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
 const mockFetchAll = vi.fn(() =>
   Promise.resolve({
     resources: [aRetrievedSubscriptionCIDRs],
-  })
+  }),
 );
 const containerMock = {
   items: {
@@ -222,7 +214,7 @@ describe("getServices", () => {
     expect(mockContext.log.error).not.toHaveBeenCalled();
     expect(response.body.pagination).toHaveProperty(
       "limit",
-      mockConfig.PAGINATION_DEFAULT_LIMIT
+      mockConfig.PAGINATION_DEFAULT_LIMIT,
     );
   });
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
@@ -97,20 +97,10 @@ const pickId = (obj: unknown): TE.TaskEither<Error, NonEmptyString> =>
 
 const createSubscriptionTask = (
   apimService: ApimUtils.ApimService,
-  userEmail: EmailString,
+  userId: NonEmptyString,
   subscriptionId: NonEmptyString,
   config: IConfig,
 ): TE.TaskEither<Error, SubscriptionContract> => {
-  const getUserId = pipe(
-    apimService.getUserByEmail(userEmail),
-    TE.mapLeft(
-      (err) =>
-        new Error(`Failed to fetch user by its email, code: ${err.statusCode}`),
-    ),
-    TE.chain(TE.fromOption(() => new Error(`Cannot find user`))),
-    TE.chain(pickId),
-  );
-
   // TODO: refactor: move to common package (also used by backoffice, see auth.ts)
   const getProductId = pipe(
     apimService.getProductByName(config.AZURE_APIM_SUBSCRIPTION_PRODUCT_NAME),
@@ -142,10 +132,8 @@ const createSubscriptionTask = (
     );
 
   return pipe(
-    sequenceS(TE.ApplicativePar)({
-      productId: getProductId,
-      userId: getUserId,
-    }),
+    getProductId,
+    TE.map((productId) => ({ productId, userId })),
     TE.chain(createSubscription),
   );
 };
@@ -162,7 +150,7 @@ export const makeCreateServiceHandler =
     const serviceId = ulidGenerator();
 
     const createSubscriptionStep = pipe(
-      createSubscriptionTask(apimService, userEmail, serviceId, config),
+      createSubscriptionTask(apimService, auth.userId, serviceId, config),
       TE.mapLeft((err) => ResponseErrorInternal(err.message)),
     );
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
@@ -30,8 +30,7 @@ import {
   HttpStatusCodeEnum,
   ResponseErrorInternal,
 } from "@pagopa/ts-commons/lib/responses";
-import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { sequenceS } from "fp-ts/lib/Apply";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-services.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-services.ts
@@ -30,20 +30,17 @@ import {
   NonNegativeInteger,
   WithinRangeInteger,
 } from "@pagopa/ts-commons/lib/numbers";
-import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import {
   IResponseErrorInternal,
   IResponseSuccessJson,
   ResponseErrorInternal,
   ResponseSuccessJson,
 } from "@pagopa/ts-commons/lib/responses";
-import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import * as E from "fp-ts/lib/Either";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/lib/Option";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as TE from "fp-ts/lib/TaskEither";
 import { flow, pipe } from "fp-ts/lib/function";
-import * as t from "io-ts";
 
 import { IConfig } from "../../config";
 import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Both Backoffice and APIM set the APIM USerId as `x-user-id` header, so all request handlers already have this info

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid an APIM call to retrieve the ApimUserId....this info is already available from `x-user-id` header

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
