### PR TITLE
refactor:remove getUserByEmail calls

### DIFF
--- a/.changeset/brown-dolls-march.md
+++ b/.changeset/brown-dolls-march.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+remove getUserEmail calls

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
@@ -48,7 +48,7 @@ vi.mock("../../../lib/clients/apim-client", async () => {
 
   return {
     getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
-    getUserByEmail: vi.fn((_) => TE.right(O.some(anApimResource))),
+    getUser: vi.fn((_) => TE.right(anApimResource)),
     upsertSubscription: vi.fn((_) => TE.right(anApimResource)),
   };
 });
@@ -70,7 +70,7 @@ const ownerId = `/an/owner/${anUserId}`;
 const anApimResource = { id: "any-id", name: "any-name" };
 const mockApimService = {
   getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
-  getUserByEmail: vi.fn((_) => TE.right(O.some(anApimResource))),
+  getUser: vi.fn((_) => TE.right(anApimResource)),
   upsertSubscription: vi.fn((_) => TE.right(anApimResource)),
   getSubscription: vi.fn(() =>
     TE.right({
@@ -227,7 +227,7 @@ describe("createService", () => {
   });
 
   it("should fail when cannot find apim user", async () => {
-    vi.mocked(mockApimService.getUserByEmail).mockImplementation(() =>
+    vi.mocked(mockApimService.getUser).mockImplementation(() =>
       TE.left({ statusCode: 500 })
     );
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
@@ -23,14 +23,6 @@ const aName1 = "a-name-1";
 const aName2 = "a-name-2";
 const aName3 = "a-name-3";
 
-// Apim resource mock *******************************
-const anApimResource = { id: "any-id", name: "any-name" };
-
-const anApimUserResource = {
-  ...anApimResource,
-  id: "/subscriptions/uuid/resourceGroups/a-rg-name/providers/Microsoft.ApiManagement/service/a-service-name/users/a-user-id",
-};
-
 const anApimSubscriptionResource1 = { id: "an-id-1", name: aName1 };
 const anApimSubscriptionResource2 = { id: "an-id-2", name: aName2 };
 const anApimSubscriptionResource3 = { id: "an-id-3", name: aName3 };
@@ -75,7 +67,6 @@ const aServiceList = [
 
 // Apim service mock *******************************
 const mockApimService = {
-  getUserByEmail: vi.fn((_) => TE.right(O.some(anApimUserResource))),
   getUserSubscriptions: vi.fn((_) => TE.right(aSubscriptionCollection)),
   parseOwnerIdFullPath: vi.fn((_) => "a-user-id"),
 } as unknown as ApimUtils.ApimService;

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-services.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-services.ts
@@ -2,7 +2,6 @@ import { SubscriptionContract } from "@azure/arm-apimanagement";
 import { Context } from "@azure/functions";
 import { ApimUtils } from "@io-services-cms/external-clients";
 import { ServiceLifecycle } from "@io-services-cms/models";
-import { EmailAddress } from "@pagopa/io-functions-commons/dist/generated/definitions/EmailAddress";
 import { SubscriptionCIDRsModel } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
 import {
   AzureApiAuthMiddleware,
@@ -45,7 +44,6 @@ import { flow, pipe } from "fp-ts/lib/function";
 import { IConfig } from "../../config";
 import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";
 import { ServicePagination } from "../../generated/api/ServicePagination";
-import { UserEmailMiddleware } from "../../lib/middlewares/user-email-middleware";
 import {
   EventNameEnum,
   TelemetryClient,
@@ -66,7 +64,6 @@ type GetServicesHandler = (
   auth: IAzureApiAuthorization,
   clientIp: ClientIp,
   attrs: IAzureUserAttributesManage,
-  userEmail: EmailAddress,
   limit: O.Option<number>,
   offset: O.Option<number>,
 ) => Promise<HandlerResponseTypes>;
@@ -174,7 +171,7 @@ export const makeGetServicesHandler =
     fsmLifecycleClient,
     telemetryClient,
   }: Dependencies): GetServicesHandler =>
-  (context, auth, __, ___, userEmail, limit, offset) =>
+  (context, auth, __, ___, limit, offset) =>
     pipe(
       apimService.getUserSubscriptions(
         auth.userId,
@@ -234,8 +231,6 @@ export const applyRequestMiddelwares =
         subscriptionCIDRsModel,
         config,
       ),
-      // extract the user email from the request headers
-      UserEmailMiddleware(),
       // extract limit as number of records to return from query params
       OptionalQueryParamMiddleware(
         "limit",
@@ -256,7 +251,7 @@ export const applyRequestMiddelwares =
     return wrapRequestHandler(
       middlewaresWrap(
         // eslint-disable-next-line max-params
-        checkSourceIpForHandler(handler, (_, __, c, u, ___, ____, _____) =>
+        checkSourceIpForHandler(handler, (_, __, c, u, ___, ____) =>
           ipTuple(c, u),
         ),
       ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Optimization change for GetServices and CreateServices first one by removing a call to APIM second one using a method that uses an `Id` to search instead of an `email`
#### List of Changes
GetServices -> avoid an APIM call to retrieve the ApimUserId....this info is already available from x-user-id header
CreateServices -> using GetUsers instead of GetUserByEmail should speed up the api
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
local test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="970" alt="Screenshot 2024-09-03 alle 17 10 40" src="https://github.com/user-attachments/assets/f3b19e32-db9c-4110-9317-1c18d636834e">
<img width="967" alt="Screenshot 2024-09-03 alle 17 11 23" src="https://github.com/user-attachments/assets/6fe5afc6-c82a-4ded-b5ae-35813193f356">

<img width="747" alt="Screenshot 2024-09-03 alle 17 00 00" src="https://github.com/user-attachments/assets/cb9d11ba-1419-4aa1-b771-e63959310fa0">

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
