### PR TITLE
fix: [#IOPAE-1358] Get service key API behaviour on deleted service invocation.

### DIFF
--- a/.changeset/dull-crews-listen.md
+++ b/.changeset/dull-crews-listen.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Get ServiceKey will now return 404 when invoked for deleted services

--- a/apps/app-backend/api/internal.yaml
+++ b/apps/app-backend/api/internal.yaml
@@ -5,7 +5,7 @@ info:
   contact:
     name: PagoPA S.p.A.
     url: https://pagopa.it/
-  version: 1.0.4
+  version: 1.0.5
 servers:
   - url: https://to-be-defined.it
 tags:

--- a/apps/io-services-cms-webapp/host.json
+++ b/apps/io-services-cms-webapp/host.json
@@ -38,5 +38,6 @@
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"
-  }
+  },
+  "functions": ["GetServiceKeys"]
 }

--- a/apps/io-services-cms-webapp/host.json
+++ b/apps/io-services-cms-webapp/host.json
@@ -38,6 +38,5 @@
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"
-  },
-  "functions": ["GetServiceKeys"]
+  }
 }

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-keys.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-keys.ts
@@ -31,7 +31,6 @@ import {
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
-import * as B from "fp-ts/lib/boolean";
 import { flow, pipe } from "fp-ts/lib/function";
 
 import { IConfig } from "../../config";

--- a/apps/io-services-cms-webapp/src/webservice/index.ts
+++ b/apps/io-services-cms-webapp/src/webservice/index.ts
@@ -312,6 +312,7 @@ export const createWebServer = ({
     pipe(
       makeGetServiceKeysHandler({
         apimService,
+        fsmLifecycleClient,
         telemetryClient,
       }),
       applyGetServiceKeysRequestMiddelwares(config, subscriptionCIDRsModel),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
`GET /service/{serviceId}/keys` will now return 404 on logically deleted services

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Test and Local Application Run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
