### PR TITLE
[IOPAE-1378] change azure user attributes manage middleware

### DIFF
--- a/.changeset/bright-news-enjoy.md
+++ b/.changeset/bright-news-enjoy.md
@@ -1,0 +1,6 @@
+---
+"io-services-cms-webapp": patch
+"io-services-cms-backoffice": patch
+---
+
+set default empty cidrs when manage cidrs is not found on cosmos

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/__tests__/auth.test.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/__tests__/auth.test.ts
@@ -8,11 +8,11 @@ import { Institution } from "../../../../../generated/selfcare/Institution";
 import { IdentityTokenPayload } from "../../types";
 import { authorize } from "../auth";
 
-const mockConfig = ({
+const mockConfig = {
   SELFCARE_JWKS_URL: "http://localhost:7075/.well-known/jwks.json",
   APIM_USER_GROUPS: faker.helpers.multiple(faker.string.alpha).join(","),
-  AZURE_APIM_PRODUCT_NAME: faker.string.alpha()
-} as unknown) as Configuration;
+  AZURE_APIM_PRODUCT_NAME: faker.string.alpha(),
+} as unknown as Configuration;
 
 const aValidJwtPayload = {
   exp: faker.number.int(),
@@ -25,7 +25,7 @@ const aValidJwtPayload = {
   email: faker.internet.email(),
   uid: faker.string.uuid(),
   fiscal_number: faker.helpers.fromRegExp(
-    /[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]/
+    /[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]/,
   ),
   desired_exp: faker.number.int(),
   organization: {
@@ -35,11 +35,11 @@ const aValidJwtPayload = {
     roles: [
       {
         partyRole: faker.string.alpha(),
-        role: faker.string.alpha()
-      }
+        role: faker.string.alpha(),
+      },
     ],
-    groups: [faker.string.alpha()]
-  }
+    groups: [faker.string.alpha()],
+  },
 } as IdentityTokenPayload;
 
 const aValidApimUser = {
@@ -49,37 +49,37 @@ const aValidApimUser = {
   groups: [
     {
       type: "custom",
-      name: faker.string.alpha()
+      name: faker.string.alpha(),
     },
     {
       type: "custom",
-      name: "ApiServiceWrite"
-    }
-  ]
+      name: "ApiServiceWrite",
+    },
+  ],
 };
 
 const aValidSubscription = {
-  name: `MANAGE-${aValidApimUser.name}`
+  name: `MANAGE-${aValidApimUser.name}`,
 };
 
 const getExpectedCreateUserReqParam = (
-  organization: IdentityTokenPayload["organization"]
+  organization: IdentityTokenPayload["organization"],
 ) => ({
   email: `org.${organization.id}@selfcare.io.pagopa.it`,
   firstName: organization.fiscal_code,
   lastName: organization.id,
-  note: organization.name
+  note: organization.name,
 });
 
 const getExpectedUserEmailReqParam = (
-  organization: IdentityTokenPayload["organization"]
+  organization: IdentityTokenPayload["organization"],
 ) => `org.${organization.id}@selfcare.io.pagopa.it`;
 
 const getExpectedUser = (
   jwtPayload: IdentityTokenPayload,
   apimUser: typeof aValidApimUser,
   manageSubscription: typeof aValidSubscription,
-  institution: Institution
+  institution: Institution,
 ) => ({
   id: jwtPayload.uid,
   name: `${jwtPayload.name} ${jwtPayload.family_name}`,
@@ -89,22 +89,22 @@ const getExpectedUser = (
     name: jwtPayload.organization.name,
     fiscalCode: jwtPayload.organization.fiscal_code,
     role: jwtPayload.organization.roles[0].role,
-    logo_url: institution.logo
+    logo_url: institution.logo,
   },
   permissions: {
     apimGroups: apimUser.groups
-      .filter(group => group.type === "custom")
-      .map(group => group.name),
-    selcGroups: jwtPayload.organization.groups
+      .filter((group) => group.type === "custom")
+      .map((group) => group.name),
+    selcGroups: jwtPayload.organization.groups,
   },
   parameters: {
     userId: apimUser.name,
     userEmail: apimUser.email,
-    subscriptionId: manageSubscription.name
-  }
+    subscriptionId: manageSubscription.name,
+  },
 });
 
-const aValidInstitution = (getMockInstitution() as unknown) as Institution;
+const aValidInstitution = getMockInstitution() as unknown as Institution;
 
 const {
   getUserByEmail,
@@ -112,14 +112,14 @@ const {
   getProductByName,
   upsertSubscription,
   createOrUpdateUser,
-  createGroupUser
+  createGroupUser,
 } = vi.hoisted(() => ({
   getUserByEmail: vi.fn(),
   getSubscription: vi.fn(),
   getProductByName: vi.fn(),
   upsertSubscription: vi.fn(),
   createOrUpdateUser: vi.fn(),
-  createGroupUser: vi.fn()
+  createGroupUser: vi.fn(),
 }));
 
 const { getApimService } = vi.hoisted(() => ({
@@ -129,41 +129,33 @@ const { getApimService } = vi.hoisted(() => ({
     getProductByName,
     upsertSubscription,
     createOrUpdateUser,
-    createGroupUser
-  })
+    createGroupUser,
+  }),
 }));
 
 vi.mock("@/lib/be/apim-service", () => ({
-  getApimService
+  getApimService,
 }));
 
 const { jwtVerify } = vi.hoisted(() => ({
-  jwtVerify: vi.fn()
+  jwtVerify: vi.fn(),
 }));
 
-vi.mock("jose", async importOriginal => {
+vi.mock("jose", async (importOriginal) => {
   const mod = await importOriginal();
 
   return {
     ...(mod as any),
-    jwtVerify
+    jwtVerify,
   };
 });
 
 const { getInstitutionById } = vi.hoisted(() => ({
-  getInstitutionById: vi.fn()
+  getInstitutionById: vi.fn(),
 }));
 
 vi.mock("@/lib/be/institutions/selfcare", () => ({
-  getInstitutionById
-}));
-
-const { upsertSubscriptionAuthorizedCIDRs } = vi.hoisted(() => ({
-  upsertSubscriptionAuthorizedCIDRs: vi.fn()
-}));
-
-vi.mock("@/lib/be/keys/cosmos", () => ({
-  upsertSubscriptionAuthorizedCIDRs
+  getInstitutionById,
 }));
 
 afterEach(() => {
@@ -173,7 +165,7 @@ afterEach(() => {
 describe("Authorize", () => {
   it("should fail when credentials is not valid", async () => {
     await expect(() =>
-      authorize(mockConfig)({ invalidParam: "identity_token" }, {})
+      authorize(mockConfig)({ invalidParam: "identity_token" }, {}),
     ).rejects.toThrowError(/is not a valid/);
 
     expect(jwtVerify).not.toHaveBeenCalled();
@@ -184,14 +176,13 @@ describe("Authorize", () => {
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when token is not a JWT", async () => {
     jwtVerify.mockRejectedValueOnce("Invalid Compact JWS");
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError("Invalid Compact JWS");
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -202,22 +193,21 @@ describe("Authorize", () => {
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when JWT payload is not a valid IdentityToken", async () => {
     const { uid, ...anInvalidJwtPayload } = aValidJwtPayload;
     jwtVerify.mockResolvedValueOnce({
-      payload: anInvalidJwtPayload
+      payload: anInvalidJwtPayload,
     });
 
     await expect(() =>
       authorize(mockConfig)(
         {
-          identity_token: "identity_token"
+          identity_token: "identity_token",
         },
-        {}
-      )
+        {},
+      ),
     ).rejects.toThrowError(/is not a valid/);
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -228,19 +218,18 @@ describe("Authorize", () => {
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when creating a new Apim user and creation fail", async () => {
     const statusCode = 500;
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.none));
     createOrUpdateUser.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(`Failed to create apim user, code: ${statusCode}`);
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -248,35 +237,34 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createOrUpdateUser).toHaveBeenCalledOnce();
     expect(createOrUpdateUser).toHaveBeenCalledWith(
-      getExpectedCreateUserReqParam(aValidJwtPayload.organization)
+      getExpectedCreateUserReqParam(aValidJwtPayload.organization),
     );
     expect(createGroupUser).not.toHaveBeenCalled();
     expect(getSubscription).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when adding a gruop to newly created user and user-group association fail", async () => {
     const statusCode = 500;
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.none));
     createOrUpdateUser.mockReturnValueOnce(TE.right(aValidApimUser));
     createGroupUser.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
       `Failed to create relationship between group (id = ${
         mockConfig.APIM_USER_GROUPS.split(",")[0]
-      }) and user (id = ${aValidApimUser.name}), code: ${statusCode}`
+      }) and user (id = ${aValidApimUser.name}), code: ${statusCode}`,
     );
 
     const apimUserGroupsLength = mockConfig.APIM_USER_GROUPS.split(",").length;
@@ -285,33 +273,32 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createOrUpdateUser).toHaveBeenCalledOnce();
     expect(createOrUpdateUser).toHaveBeenCalledWith(
-      getExpectedCreateUserReqParam(aValidJwtPayload.organization)
+      getExpectedCreateUserReqParam(aValidJwtPayload.organization),
     );
     expect(createGroupUser).toHaveBeenCalledTimes(
-      mockConfig.APIM_USER_GROUPS.split(",").length
+      mockConfig.APIM_USER_GROUPS.split(",").length,
     );
     mockConfig.APIM_USER_GROUPS.split(",").forEach((groupId, index) =>
       expect(createGroupUser).toHaveBeenNthCalledWith(
         index + 1, // The count starts at 1 (https://vitest.dev/api/expect.html#tohavebeennthcalledwith)
         groupId,
-        aValidApimUser.name
-      )
+        aValidApimUser.name,
+      ),
     );
     expect(getSubscription).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when fetching the newly created user and fetch fail", async () => {
     const statusCode = 500;
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.none));
     createOrUpdateUser.mockReturnValueOnce(TE.right(aValidApimUser));
@@ -319,9 +306,9 @@ describe("Authorize", () => {
     getUserByEmail.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
-      `Failed to fetch user by its email, code: ${statusCode}`
+      `Failed to fetch user by its email, code: ${statusCode}`,
     );
 
     const apimUserGroupsLength = mockConfig.APIM_USER_GROUPS.split(",").length;
@@ -330,49 +317,48 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledTimes(2);
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createOrUpdateUser).toHaveBeenCalledOnce();
     expect(createOrUpdateUser).toHaveBeenCalledWith(
-      getExpectedCreateUserReqParam(aValidJwtPayload.organization)
+      getExpectedCreateUserReqParam(aValidJwtPayload.organization),
     );
     expect(createGroupUser).toHaveBeenCalledTimes(apimUserGroupsLength);
     mockConfig.APIM_USER_GROUPS.split(",").forEach((groupId, index) =>
       expect(createGroupUser).toHaveBeenNthCalledWith(
         index + 1, // The count starts at 1 (https://vitest.dev/api/expect.html#tohavebeennthcalledwith)
         groupId,
-        aValidApimUser.name
-      )
+        aValidApimUser.name,
+      ),
     );
     expect(getSubscription).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when adding missing ApiServiceWrite group to existing user", async () => {
     const statusCode = 500;
     const missingUserGroup = "apiservicewrite";
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(
       TE.right(
         O.some({
           ...aValidApimUser,
           groups: aValidApimUser.groups.filter(
-            g => g.name !== "ApiServiceWrite"
-          )
-        })
-      )
+            (g) => g.name !== "ApiServiceWrite",
+          ),
+        }),
+      ),
     );
     createGroupUser.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
-      `Failed to create relationship between group (id = ${missingUserGroup}) and user (id = ${aValidApimUser.name}), code: ${statusCode}`
+      `Failed to create relationship between group (id = ${missingUserGroup}) and user (id = ${aValidApimUser.name}), code: ${statusCode}`,
     );
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -380,44 +366,43 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createGroupUser).toHaveBeenCalledOnce();
     expect(createGroupUser).toHaveBeenCalledWith(
       missingUserGroup,
-      aValidApimUser.name
+      aValidApimUser.name,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(getSubscription).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when fetching user after adding missing ApiServiceWrite group to existing user", async () => {
     const statusCode = 500;
     const missingUserGroup = "apiservicewrite";
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(
       TE.right(
         O.some({
           ...aValidApimUser,
           groups: aValidApimUser.groups.filter(
-            g => g.name !== "ApiServiceWrite"
-          )
-        })
-      )
+            (g) => g.name !== "ApiServiceWrite",
+          ),
+        }),
+      ),
     );
     createGroupUser.mockReturnValueOnce(TE.right(aValidApimUser));
     getUserByEmail.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
-      `Failed to fetch user by its email, code: ${statusCode}`
+      `Failed to fetch user by its email, code: ${statusCode}`,
     );
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -425,41 +410,40 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledTimes(2);
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createGroupUser).toHaveBeenCalledOnce();
     expect(createGroupUser).toHaveBeenCalledWith(
       missingUserGroup,
-      aValidApimUser.name
+      aValidApimUser.name,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(getSubscription).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail if no user is retrieved after adding missing ApiServiceWrite group to existing user", async () => {
     const missingUserGroup = "apiservicewrite";
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(
       TE.right(
         O.some({
           ...aValidApimUser,
           groups: aValidApimUser.groups.filter(
-            g => g.name !== "ApiServiceWrite"
-          )
-        })
-      )
+            (g) => g.name !== "ApiServiceWrite",
+          ),
+        }),
+      ),
     );
     createGroupUser.mockReturnValueOnce(TE.right(aValidApimUser));
     getUserByEmail.mockReturnValueOnce(TE.right(O.none));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError("Cannot find user");
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -467,31 +451,30 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledTimes(2);
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createGroupUser).toHaveBeenCalledOnce();
     expect(createGroupUser).toHaveBeenCalledWith(
       missingUserGroup,
-      aValidApimUser.name
+      aValidApimUser.name,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(getSubscription).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when retrieved Apim user is not valid", async () => {
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(
-      TE.right(O.some({ ...aValidApimUser, name: undefined }))
+      TE.right(O.some({ ...aValidApimUser, name: undefined })),
     );
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(/is not a valid/);
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -499,7 +482,7 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
@@ -507,25 +490,24 @@ describe("Authorize", () => {
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when retrieving user manage subscription fail", async () => {
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.some(aValidApimUser)));
     const statusCode = 500;
     const apimErrorName = "APIM Failure";
     const apimErrorCode = 500;
     getSubscription.mockReturnValueOnce(
-      TE.left({ statusCode, name: apimErrorName, code: apimErrorCode })
+      TE.left({ statusCode, name: apimErrorName, code: apimErrorCode }),
     );
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
-      `Failed to fetch user subscription manage (MANAGE-${aValidApimUser.name}), apimStatuscode: ${statusCode}, apimErrorName: ${apimErrorName}, apimErrorCode: ${apimErrorCode}`
+      `Failed to fetch user subscription manage (MANAGE-${aValidApimUser.name}), apimStatuscode: ${statusCode}, apimErrorName: ${apimErrorName}, apimErrorCode: ${apimErrorCode}`,
     );
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -533,23 +515,22 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when manage subscription is not found and and fail to fetch APIM product", async () => {
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.some(aValidApimUser)));
     const statusCode = 500;
@@ -557,9 +538,9 @@ describe("Authorize", () => {
     getProductByName.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
-      `Failed to fetch product by its name, code: ${statusCode}`
+      `Failed to fetch product by its name, code: ${statusCode}`,
     );
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -567,28 +548,27 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getProductByName).toHaveBeenCalledOnce();
     expect(getProductByName).toHaveBeenCalledWith(
-      mockConfig.AZURE_APIM_PRODUCT_NAME
+      mockConfig.AZURE_APIM_PRODUCT_NAME,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
     expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should fail when manage subscription is not found and fail to create it", async () => {
     const statusCode = 500;
     const productId = faker.string.uuid();
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.some(aValidApimUser)));
     getSubscription.mockReturnValueOnce(TE.left({ statusCode: 404 }));
@@ -596,9 +576,9 @@ describe("Authorize", () => {
     upsertSubscription.mockReturnValueOnce(TE.left({ statusCode }));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(
-      `Failed to create subscription manage, code: ${statusCode}`
+      `Failed to create subscription manage, code: ${statusCode}`,
     );
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -606,71 +586,21 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getProductByName).toHaveBeenCalledOnce();
     expect(getProductByName).toHaveBeenCalledWith(
-      mockConfig.AZURE_APIM_PRODUCT_NAME
+      mockConfig.AZURE_APIM_PRODUCT_NAME,
     );
     expect(upsertSubscription).toHaveBeenCalledOnce();
     expect(upsertSubscription).toHaveBeenCalledWith(
       productId,
       aValidApimUser.id,
-      `MANAGE-${aValidApimUser.name}`
-    );
-    expect(createOrUpdateUser).not.toHaveBeenCalled();
-    expect(createGroupUser).not.toHaveBeenCalled();
-    expect(getInstitutionById).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
-  });
-
-  it("should fail when creation of default manage subscription cidrs return error", async () => {
-    const productId = faker.string.uuid();
-    const errorMessage = "rejected";
-    jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
-    });
-    getUserByEmail.mockReturnValueOnce(TE.right(O.some(aValidApimUser)));
-    getSubscription.mockReturnValueOnce(TE.left({ statusCode: 404 }));
-    getProductByName.mockReturnValueOnce(TE.right(O.some({ id: productId })));
-    upsertSubscription.mockReturnValueOnce(TE.right(aValidSubscription));
-    upsertSubscriptionAuthorizedCIDRs.mockRejectedValueOnce(
-      new Error(errorMessage)
-    );
-
-    await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
-    ).rejects.toThrowError(errorMessage);
-
-    expect(jwtVerify).toHaveBeenCalledOnce();
-    expect(getApimService).toHaveBeenCalledTimes(4);
-    expect(getUserByEmail).toHaveBeenCalledOnce();
-    expect(getUserByEmail).toHaveBeenCalledWith(
-      getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
-    );
-    expect(getSubscription).toHaveBeenCalledOnce();
-    expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
-    );
-    expect(getProductByName).toHaveBeenCalledOnce();
-    expect(getProductByName).toHaveBeenCalledWith(
-      mockConfig.AZURE_APIM_PRODUCT_NAME
-    );
-    expect(upsertSubscription).toHaveBeenCalledOnce();
-    expect(upsertSubscription).toHaveBeenCalledWith(
-      productId,
-      aValidApimUser.id,
-      `MANAGE-${aValidApimUser.name}`
-    );
-    expect(upsertSubscriptionAuthorizedCIDRs).toHaveBeenCalledOnce();
-    expect(upsertSubscriptionAuthorizedCIDRs).toHaveBeenCalledWith(
-      aValidSubscription.name,
-      []
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
@@ -681,18 +611,17 @@ describe("Authorize", () => {
     const productId = faker.string.uuid();
     const invalidSubscriptionName = undefined;
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.some(aValidApimUser)));
     getSubscription.mockReturnValueOnce(TE.left({ statusCode: 404 }));
     getProductByName.mockReturnValueOnce(TE.right(O.some({ id: productId })));
     upsertSubscription.mockReturnValueOnce(
-      TE.right({ ...aValidSubscription, name: invalidSubscriptionName })
+      TE.right({ ...aValidSubscription, name: invalidSubscriptionName }),
     );
-    upsertSubscriptionAuthorizedCIDRs.mockResolvedValueOnce(void 0);
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(/is not a valid/);
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -700,26 +629,21 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getProductByName).toHaveBeenCalledOnce();
     expect(getProductByName).toHaveBeenCalledWith(
-      mockConfig.AZURE_APIM_PRODUCT_NAME
+      mockConfig.AZURE_APIM_PRODUCT_NAME,
     );
     expect(upsertSubscription).toHaveBeenCalledOnce();
     expect(upsertSubscription).toHaveBeenCalledWith(
       productId,
       aValidApimUser.id,
-      `MANAGE-${aValidApimUser.name}`
-    );
-    expect(upsertSubscriptionAuthorizedCIDRs).toHaveBeenCalledOnce();
-    expect(upsertSubscriptionAuthorizedCIDRs).toHaveBeenCalledWith(
-      invalidSubscriptionName,
-      []
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
@@ -729,14 +653,14 @@ describe("Authorize", () => {
   it("should fail when retrieve logged institution details", async () => {
     const errorMessage = "Rejected getInstitutionById";
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockImplementation(() => TE.right(O.some(aValidApimUser)));
     getSubscription.mockReturnValueOnce(TE.right(aValidSubscription));
     getInstitutionById.mockRejectedValueOnce(new Error(errorMessage));
 
     await expect(() =>
-      authorize(mockConfig)({ identity_token: "identity_token" }, {})
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
     ).rejects.toThrowError(errorMessage);
 
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -744,26 +668,25 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledOnce();
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getInstitutionById).toHaveBeenCalledOnce();
     expect(getInstitutionById).toHaveBeenCalledWith(
-      aValidJwtPayload.organization.id
+      aValidJwtPayload.organization.id,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should return a valid backoffice User when both APIM users and its manage subscription exists", async () => {
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockImplementation(() => TE.right(O.some(aValidApimUser)));
     getSubscription.mockReturnValueOnce(TE.right(aValidSubscription));
@@ -771,7 +694,7 @@ describe("Authorize", () => {
 
     const user = await authorize(mockConfig)(
       { identity_token: "identity_token" },
-      {}
+      {},
     );
 
     expect(user).toEqual(
@@ -779,8 +702,8 @@ describe("Authorize", () => {
         aValidJwtPayload,
         aValidApimUser,
         aValidSubscription,
-        aValidInstitution
-      )
+        aValidInstitution,
+      ),
     );
     expect(jwtVerify).toHaveBeenCalledOnce();
     expect(getApimService).toHaveBeenCalledTimes(2);
@@ -788,23 +711,22 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledWith(aValidApimUser.email, true);
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getInstitutionById).toHaveBeenCalledOnce();
     expect(getInstitutionById).toHaveBeenCalledWith(
-      aValidJwtPayload.organization.id
+      aValidJwtPayload.organization.id,
     );
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
     expect(getProductByName).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();
-    expect(upsertSubscriptionAuthorizedCIDRs).not.toHaveBeenCalled();
   });
 
   it("should return a valid backoffice User when both APIM users and its manage subscription does not exists", async () => {
     const productId = faker.string.uuid();
     jwtVerify.mockResolvedValueOnce({
-      payload: aValidJwtPayload
+      payload: aValidJwtPayload,
     });
     getUserByEmail.mockReturnValueOnce(TE.right(O.none));
     createOrUpdateUser.mockReturnValueOnce(TE.right(aValidApimUser));
@@ -813,12 +735,11 @@ describe("Authorize", () => {
     getSubscription.mockReturnValueOnce(TE.left({ statusCode: 404 }));
     getProductByName.mockReturnValueOnce(TE.right(O.some({ id: productId })));
     upsertSubscription.mockReturnValueOnce(TE.right(aValidSubscription));
-    upsertSubscriptionAuthorizedCIDRs.mockResolvedValueOnce(void 0);
     getInstitutionById.mockResolvedValueOnce(aValidInstitution);
 
     const user = await authorize(mockConfig)(
       { identity_token: "identity_token" },
-      {}
+      {},
     );
 
     expect(user).toEqual(
@@ -826,8 +747,8 @@ describe("Authorize", () => {
         aValidJwtPayload,
         aValidApimUser,
         aValidSubscription,
-        aValidInstitution
-      )
+        aValidInstitution,
+      ),
     );
 
     const apimUserGroupsLength = mockConfig.APIM_USER_GROUPS.split(",").length;
@@ -836,42 +757,37 @@ describe("Authorize", () => {
     expect(getUserByEmail).toHaveBeenCalledTimes(2);
     expect(getUserByEmail).toHaveBeenCalledWith(
       getExpectedUserEmailReqParam(aValidJwtPayload.organization),
-      true
+      true,
     );
     expect(createOrUpdateUser).toHaveBeenCalledOnce();
     expect(createOrUpdateUser).toHaveBeenCalledWith(
-      getExpectedCreateUserReqParam(aValidJwtPayload.organization)
+      getExpectedCreateUserReqParam(aValidJwtPayload.organization),
     );
     expect(createGroupUser).toHaveBeenCalledTimes(apimUserGroupsLength);
     mockConfig.APIM_USER_GROUPS.split(",").forEach((groupId, index) =>
       expect(createGroupUser).toHaveBeenNthCalledWith(
         index + 1, // The count starts at 1 (https://vitest.dev/api/expect.html#tohavebeennthcalledwith)
         groupId,
-        aValidApimUser.name
-      )
+        aValidApimUser.name,
+      ),
     );
     expect(getSubscription).toHaveBeenCalledOnce();
     expect(getSubscription).toHaveBeenCalledWith(
-      `MANAGE-${aValidApimUser.name}`
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getProductByName).toHaveBeenCalledOnce();
     expect(getProductByName).toHaveBeenCalledWith(
-      mockConfig.AZURE_APIM_PRODUCT_NAME
+      mockConfig.AZURE_APIM_PRODUCT_NAME,
     );
     expect(upsertSubscription).toHaveBeenCalledOnce();
     expect(upsertSubscription).toHaveBeenCalledWith(
       productId,
       aValidApimUser.id,
-      `MANAGE-${aValidApimUser.name}`
-    );
-    expect(upsertSubscriptionAuthorizedCIDRs).toHaveBeenCalledOnce();
-    expect(upsertSubscriptionAuthorizedCIDRs).toHaveBeenCalledWith(
-      aValidSubscription.name,
-      []
+      `MANAGE-${aValidApimUser.name}`,
     );
     expect(getInstitutionById).toHaveBeenCalledOnce();
     expect(getInstitutionById).toHaveBeenCalledWith(
-      aValidJwtPayload.organization.id
+      aValidJwtPayload.organization.id,
     );
   });
 });

--- a/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
+++ b/apps/backoffice/src/app/api/auth/[...nextauth]/auth.ts
@@ -9,7 +9,6 @@ import {
   extractTryCatchError,
 } from "@/lib/be/errors";
 import { getInstitutionById } from "@/lib/be/institutions/selfcare";
-import { upsertSubscriptionAuthorizedCIDRs } from "@/lib/be/keys/cosmos";
 import { ApimUtils } from "@io-services-cms/external-clients";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
@@ -267,18 +266,7 @@ const retrieveOrCreateUserSubscriptionManage =
       TE.chain(
         flow(
           O.fold(
-            () =>
-              pipe(
-                apimUser,
-                createSubscriptionManage(config),
-                TE.chain((manageSub) =>
-                  pipe(
-                    manageSub.name as NonEmptyString,
-                    createEmptyManageCidrs,
-                    TE.map((_) => manageSub),
-                  ),
-                ),
-              ),
+            () => pipe(apimUser, createSubscriptionManage(config)),
             TE.right,
           ),
         ),
@@ -291,17 +279,6 @@ const retrieveOrCreateUserSubscriptionManage =
         ),
       ),
     );
-
-const createEmptyManageCidrs = (
-  subscriptionId: NonEmptyString,
-): TE.TaskEither<Error | ManagedInternalError, void> =>
-  pipe(
-    TE.tryCatch(
-      () => upsertSubscriptionAuthorizedCIDRs(subscriptionId, []),
-      extractTryCatchError,
-    ),
-    TE.map((_) => void 0),
-  );
 
 const getUserSubscriptionManage = (
   apimUser: ApimUser,

--- a/apps/io-services-cms-webapp/src/lib/middlewares/__tests__/azure_user_attributes_manage-middleware.test.ts
+++ b/apps/io-services-cms-webapp/src/lib/middlewares/__tests__/azure_user_attributes_manage-middleware.test.ts
@@ -1,0 +1,277 @@
+import * as TE from "fp-ts/lib/TaskEither";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { AzureUserAttributesManageMiddleware } from "../azure_user_attributes_manage-middleware";
+import { SubscriptionCIDRs } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
+import { CIDR } from "@pagopa/io-functions-commons/dist/generated/definitions/CIDR";
+import {
+  CosmosErrors,
+  toCosmosErrorResponse,
+} from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("winston");
+
+interface IHeaders {
+  readonly [key: string]: string | undefined;
+}
+
+function lookup(h: IHeaders): (k: string) => string | undefined {
+  return (k: string) => h[k];
+}
+
+const anUserEmail = "test@example.com" as EmailString;
+const aSubscriptionId = "MySubscriptionId" as NonEmptyString;
+const aManageSubscriptionId = "MANAGE-MySubscriptionId" as NonEmptyString;
+const aSubscriptionCIDRs: SubscriptionCIDRs = {
+  subscriptionId: "MANAGE-123" as NonEmptyString,
+  cidrs: new Set(["0.0.0.0/0"] as unknown as CIDR[]),
+};
+
+describe("AzureUserAttributesManageMiddleware", () => {
+  it("should fail on empty user email", async () => {
+    const subscriptionCIDRsModel = vi.fn();
+
+    const headers: IHeaders = {
+      "x-user-email": "",
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header).toHaveBeenCalledTimes(1);
+    expect(mockRequest.header).toHaveBeenCalledWith("x-user-email");
+    expect(E.isLeft(result)).toBeTruthy();
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toEqual("IResponseErrorInternal");
+    }
+  });
+
+  it("should fail on invalid user email", async () => {
+    const subscriptionCIDRsModel = vi.fn();
+
+    const headers: IHeaders = {
+      "x-user-email": "xyz",
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header).toHaveBeenCalledTimes(1);
+    expect(mockRequest.header).toHaveBeenCalledWith("x-user-email");
+    expect(E.isLeft(result)).toBeTruthy();
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toEqual("IResponseErrorInternal");
+    }
+  });
+
+  it("should fail on invalid key", async () => {
+    const subscriptionCIDRsModel = vi.fn();
+
+    const headers: IHeaders = {
+      "x-subscription-id": undefined,
+      "x-user-email": anUserEmail,
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header.mock.calls[0][0]).toBe("x-user-email");
+    expect(mockRequest.header.mock.calls[1][0]).toBe("x-subscription-id");
+    expect(E.isLeft(result)).toBeTruthy();
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toEqual("IResponseErrorInternal");
+    }
+  });
+
+  it("should fail and return an ErrorForbiddenNotAuthorized if the subscription is not a MANAGE subscription", async () => {
+    const subscriptionCIDRsModel = {
+      findLastVersionByModelId: vi.fn(),
+    };
+
+    const headers: IHeaders = {
+      "x-subscription-id": aSubscriptionId,
+      "x-user-email": anUserEmail,
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header.mock.calls[0][0]).toBe("x-user-email");
+    expect(mockRequest.header.mock.calls[1][0]).toBe("x-subscription-id");
+    expect(subscriptionCIDRsModel.findLastVersionByModelId).not.toBeCalled();
+
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toEqual("IResponseErrorForbiddenNotAuthorized");
+    }
+  });
+
+  it("should fail on a subscription cidrs find error", async () => {
+    const subscriptionCIDRsModel = {
+      findLastVersionByModelId: vi.fn(() =>
+        TE.left(toCosmosErrorResponse("") as CosmosErrors),
+      ),
+    };
+
+    const headers: IHeaders = {
+      "x-subscription-id": aManageSubscriptionId,
+      "x-user-email": anUserEmail,
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header.mock.calls[0][0]).toBe("x-user-email");
+    expect(mockRequest.header.mock.calls[1][0]).toBe("x-subscription-id");
+    expect(
+      subscriptionCIDRsModel.findLastVersionByModelId,
+    ).toHaveBeenCalledWith([mockRequest.header("x-subscription-id")]);
+    expect(E.isLeft(result)).toBeTruthy();
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toEqual("IResponseErrorQuery");
+    }
+  });
+
+  it("should return the user custom attributes if the MANAGE subscription not exists on CosmosDB", async () => {
+    const subscriptionCIDRsModel = {
+      findLastVersionByModelId: vi.fn(() => TE.fromEither(E.right(O.none))),
+    };
+
+    const headers: IHeaders = {
+      "x-subscription-id": aManageSubscriptionId,
+      "x-user-email": anUserEmail,
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header.mock.calls[0][0]).toBe("x-user-email");
+    expect(mockRequest.header.mock.calls[1][0]).toBe("x-subscription-id");
+    expect(
+      subscriptionCIDRsModel.findLastVersionByModelId,
+    ).toHaveBeenCalledWith([mockRequest.header("x-subscription-id")]);
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(result.right.kind).toEqual("IAzureUserAttributesManage");
+      expect(result.right.authorizedCIDRs).toEqual(
+        new Set([] as unknown as CIDR[]),
+      );
+    }
+  });
+
+  it("should return the user custom attributes if the subscription is a MANAGE subscription and cidrs is an empty array", async () => {
+    const subscriptionCIDRsModel = {
+      findLastVersionByModelId: vi.fn(() =>
+        TE.fromEither(
+          E.right(
+            O.some({
+              ...aSubscriptionCIDRs,
+              cidrs: new Set([] as unknown as CIDR[]),
+            }),
+          ),
+        ),
+      ),
+    };
+
+    const headers: IHeaders = {
+      "x-subscription-id": aManageSubscriptionId,
+      "x-user-email": anUserEmail,
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header.mock.calls[0][0]).toBe("x-user-email");
+    expect(mockRequest.header.mock.calls[1][0]).toBe("x-subscription-id");
+    expect(
+      subscriptionCIDRsModel.findLastVersionByModelId,
+    ).toHaveBeenCalledWith([mockRequest.header("x-subscription-id")]);
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(result.right.kind).toEqual("IAzureUserAttributesManage");
+      expect(result.right.authorizedCIDRs).toEqual(
+        new Set([] as unknown as CIDR[]),
+      );
+    }
+  });
+
+  it("should return the user custom attributes if the subscription is a MANAGE subscription", async () => {
+    const subscriptionCIDRsModel = {
+      findLastVersionByModelId: vi.fn(() =>
+        TE.fromEither(E.right(O.some(aSubscriptionCIDRs))),
+      ),
+    };
+
+    const headers: IHeaders = {
+      "x-subscription-id": aManageSubscriptionId,
+      "x-user-email": anUserEmail,
+    };
+
+    const mockRequest = {
+      header: vi.fn(lookup(headers)),
+    };
+
+    const middleware = AzureUserAttributesManageMiddleware(
+      subscriptionCIDRsModel as any,
+    );
+
+    const result = await middleware(mockRequest as any);
+    expect(mockRequest.header.mock.calls[0][0]).toBe("x-user-email");
+    expect(mockRequest.header.mock.calls[1][0]).toBe("x-subscription-id");
+    expect(
+      subscriptionCIDRsModel.findLastVersionByModelId,
+    ).toHaveBeenCalledWith([mockRequest.header("x-subscription-id")]);
+    expect(E.isRight(result));
+    if (E.isRight(result)) {
+      const attributes = result.right;
+      expect(attributes.email).toBe(anUserEmail);
+      expect(attributes.kind).toBe("IAzureUserAttributesManage");
+      expect(attributes.authorizedCIDRs).toBe(aSubscriptionCIDRs.cidrs);
+    }
+  });
+});

--- a/apps/io-services-cms-webapp/src/lib/middlewares/azure_user_attributes_manage-middleware.ts
+++ b/apps/io-services-cms-webapp/src/lib/middlewares/azure_user_attributes_manage-middleware.ts
@@ -1,0 +1,149 @@
+/*
+ * A middleware that extracts custom user attributes from the request, that supports MANAGE flow.
+ */
+import { CIDR } from "@pagopa/io-functions-commons/dist/generated/definitions/CIDR";
+import { SubscriptionCIDRsModel } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
+import { IAzureUserAttributes } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
+import { ResponseErrorQuery } from "@pagopa/io-functions-commons/dist/src/utils/response";
+import { IRequestMiddleware } from "@pagopa/ts-commons/lib/request_middleware";
+import {
+  IResponse,
+  ResponseErrorForbiddenNotAuthorized,
+  ResponseErrorInternal,
+} from "@pagopa/ts-commons/lib/responses";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+
+import winston = require("winston");
+
+// The user email will be passed in this header by the API Gateway
+const HEADER_USER_EMAIL = "x-user-email";
+
+const HEADER_USER_SUBSCRIPTION_KEY = "x-subscription-id";
+
+/**
+ * The attributes extracted from the user's "Note"
+ */
+export type IAzureUserAttributesManage = {
+  // authorized source CIDRs
+  readonly authorizedCIDRs: ReadonlySet<CIDR>;
+  readonly kind: "IAzureUserAttributesManage";
+} & Omit<IAzureUserAttributes, "kind" | "service">;
+
+/**
+ * A middleware that will extract custom user attributes from the request, that supports **MANAGE** flow.
+ *
+ * The middleware expects the following header:
+ *
+ * *x-subscription-id*: The user's subscription id.
+ *
+ * Used to check if its name starts with *'MANAGE-'*.
+ *
+ * On success, the middleware provides an *IAzureUserAttributesManage*.
+ */
+export const AzureUserAttributesManageMiddleware =
+  (
+    subscriptionCIDRsModel: SubscriptionCIDRsModel,
+  ): IRequestMiddleware<
+    | "IResponseErrorForbiddenNotAuthorized"
+    | "IResponseErrorInternal"
+    | "IResponseErrorQuery",
+    IAzureUserAttributesManage
+  > =>
+  async (
+    request,
+  ): Promise<
+    E.Either<
+      IResponse<
+        | "IResponseErrorForbiddenNotAuthorized"
+        | "IResponseErrorInternal"
+        | "IResponseErrorQuery"
+      >,
+      IAzureUserAttributesManage
+    >
+  > => {
+    const errorOrUserEmail = EmailString.decode(
+      request.header(HEADER_USER_EMAIL),
+    );
+
+    if (E.isLeft(errorOrUserEmail)) {
+      return E.left<
+        IResponse<"IResponseErrorInternal">,
+        IAzureUserAttributesManage
+      >(
+        ResponseErrorInternal(
+          `Missing, empty or invalid ${HEADER_USER_EMAIL} header`,
+        ),
+      );
+    }
+
+    const userEmail = errorOrUserEmail.right;
+
+    const errorOrUserSubscriptionId = NonEmptyString.decode(
+      request.header(HEADER_USER_SUBSCRIPTION_KEY),
+    );
+
+    if (E.isLeft(errorOrUserSubscriptionId)) {
+      return E.left<
+        IResponse<"IResponseErrorInternal">,
+        IAzureUserAttributesManage
+      >(
+        ResponseErrorInternal(
+          `Missing or empty ${HEADER_USER_SUBSCRIPTION_KEY} header`,
+        ),
+      );
+    }
+
+    const subscriptionId = errorOrUserSubscriptionId.right;
+
+    if (subscriptionId.startsWith("MANAGE-")) {
+      // MANAGE Flow
+      const errorOrMaybeAuthorizedCIDRs =
+        await subscriptionCIDRsModel.findLastVersionByModelId([
+          subscriptionId,
+        ])();
+
+      if (E.isLeft(errorOrMaybeAuthorizedCIDRs)) {
+        winston.error(
+          `No CIDRs found for subscription|${subscriptionId}|${JSON.stringify(
+            errorOrMaybeAuthorizedCIDRs.left,
+          )}`,
+        );
+        return E.left<
+          IResponse<"IResponseErrorQuery">,
+          IAzureUserAttributesManage
+        >(
+          ResponseErrorQuery(
+            `Error while retrieving CIDRs tied to the provided subscription id`,
+            errorOrMaybeAuthorizedCIDRs.left,
+          ),
+        );
+      }
+
+      const maybeAuthorizedCIDRs = errorOrMaybeAuthorizedCIDRs.right;
+
+      const authInfo: IAzureUserAttributesManage = {
+        authorizedCIDRs: pipe(
+          maybeAuthorizedCIDRs,
+          O.map((authorizedCIDRs) => authorizedCIDRs.cidrs),
+          O.getOrElse<ReadonlySet<CIDR>>(() => new Set<CIDR>()),
+        ),
+        email: userEmail,
+        kind: "IAzureUserAttributesManage",
+      };
+
+      return E.right<
+        IResponse<
+          "IResponseErrorForbiddenNotAuthorized" | "IResponseErrorInternal"
+        >,
+        IAzureUserAttributesManage
+      >(authInfo);
+    } else {
+      return E.left<
+        IResponse<"IResponseErrorForbiddenNotAuthorized">,
+        IAzureUserAttributesManage
+      >(ResponseErrorForbiddenNotAuthorized);
+    }
+  };

--- a/apps/io-services-cms-webapp/src/utils/__tests__/azure-user-attributes-manage-middleware-wrapper.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/azure-user-attributes-manage-middleware-wrapper.test.ts
@@ -17,22 +17,22 @@ const { AzureUserAttributesManageMiddleware } = vi.hoisted(() => ({
           authorizedCIDRs: mocks.authorizedCIDRs,
           email: "" as any,
           kind: "IAzureUserAttributesManage",
-        })
-      )
+        }),
+      ),
   ),
 }));
 
 vi.mock(
-  "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes_manage",
+  "../../lib/middlewares/azure_user_attributes_manage-middleware",
   async () => {
     const actual = await vi.importActual(
-      "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes_manage"
+      "../../lib/middlewares/azure_user_attributes_manage-middleware",
     );
     return {
       ...(actual as any),
       AzureUserAttributesManageMiddleware,
     };
-  }
+  },
 );
 
 const subscriptionCIDRsModelMock = {
@@ -40,14 +40,14 @@ const subscriptionCIDRsModelMock = {
     Promise.resolve(
       E.right({
         authorizedCIDRs: new Set(),
-      })
-    )
+      }),
+    ),
   ),
 } as unknown as SubscriptionCIDRsModel;
 
 const BackofficeInternalSubnetCIDRMock = {
   BACKOFFICE_INTERNAL_SUBNET_CIDRS: ["127.0.0.0/16"],
-} as BackofficeInternalSubnetCIDRs;
+} as unknown as BackofficeInternalSubnetCIDRs;
 
 describe("AzureUserAttributesManageMiddlewareWrapper", () => {
   it("should return an empty CIDRs list when no authorized CIDRs was set by the user", async () => {
@@ -55,7 +55,7 @@ describe("AzureUserAttributesManageMiddlewareWrapper", () => {
 
     const result = await AzureUserAttributesManageMiddlewareWrapper(
       subscriptionCIDRsModelMock,
-      BackofficeInternalSubnetCIDRMock
+      BackofficeInternalSubnetCIDRMock,
     )(requestMock);
 
     expect(E.isRight(result)).toBeTruthy();
@@ -80,13 +80,13 @@ describe("AzureUserAttributesManageMiddlewareWrapper", () => {
           authorizedCIDRs: new Set(returningCIDRs),
           email: "" as any,
           kind: "IAzureUserAttributesManage",
-        })
-      )
+        }),
+      ),
     );
 
     const result = await AzureUserAttributesManageMiddlewareWrapper(
       subscriptionCIDRsModelMock,
-      BackofficeInternalSubnetCIDRMock
+      BackofficeInternalSubnetCIDRMock,
     )(requestMock);
 
     expect(E.isRight(result)).toBeTruthy();

--- a/apps/io-services-cms-webapp/src/utils/azure-user-attributes-manage-middleware-wrapper.ts
+++ b/apps/io-services-cms-webapp/src/utils/azure-user-attributes-manage-middleware-wrapper.ts
@@ -1,13 +1,11 @@
 import { SubscriptionCIDRsModel } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
-import {
-  AzureUserAttributesManageMiddleware,
-  IAzureUserAttributesManage,
-} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes_manage";
+import { IAzureUserAttributesManage } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes_manage";
 import { IRequestMiddleware } from "@pagopa/ts-commons/lib/request_middleware";
 import { IResponse } from "@pagopa/ts-commons/lib/responses";
 import * as E from "fp-ts/lib/Either";
 
 import { BackofficeInternalSubnetCIDRs } from "../config";
+import { AzureUserAttributesManageMiddleware } from "../lib/middlewares/azure_user_attributes_manage-middleware";
 
 export const AzureUserAttributesManageMiddlewareWrapper =
   (
@@ -35,16 +33,6 @@ export const AzureUserAttributesManageMiddlewareWrapper =
     const originalMiddelwareResult = await AzureUserAttributesManageMiddleware(
       subscriptionCIDRsModel,
     )(request);
-
-    // eslint-disable-next-line no-console
-    console.log(
-      "AzureUserAttributesManageMiddlewareWrapper | IP: ",
-      request.ip,
-      " | headers.forwarded: ",
-      request.headers?.forwarded,
-      " | X-Forwarded-For: ",
-      request.header ? request.header("X-Forwarded-For") : undefined,
-    );
 
     // If the middleware fails or the request comes outside the Backoffice subnet
     // return the originale middleware result


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
If we handle a "not found" query result as a default (empty) cirds, then we can avoid to create a new item inside `manage-subscription-cidrs` CosmosDB container every time a new manage subscription is created.

#### List of Changes
<!--- Describe your changes in detail -->
- [set default empty cidrs when manage cidrs is not found on cosmos](https://github.com/pagopa/io-services-cms/commit/d5aad2e2c1f5727d17e9959016e61d7261a774bc)
- [remove no longer necessary default cidrs creation](https://github.com/pagopa/io-services-cms/commit/629097c0620cef8ef77da9508422c6a4686efc60)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will unlock "Subscription MANAGE Group" functionality needed to correctly handle Selfcare Groups

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
