### PR TITLE
Use only 1 worker

### DIFF
--- a/infra/_modules/cms_function_app/locals.tf
+++ b/infra/_modules/cms_function_app/locals.tf
@@ -4,7 +4,7 @@ locals {
     tier          = "standard"
     cosmosdb_name = "db-services-cms"
     app_settings = {
-      FUNCTIONS_WORKER_PROCESS_COUNT = "4"
+      FUNCTIONS_WORKER_PROCESS_COUNT = "1"
       NODE_ENV                       = "production"
 
       // TODO: after migration, update AI implementation and use connection string


### PR DESCRIPTION
Use only 1 worker (default value) due to "App Service Plan" scale down

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- set `FUNCTIONS_WORKER_PROCESS_COUNT` config to 1

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have scaled down App Service Plan (from P1V3 to P0V3, it now uses only 1 vCPU and 4 GB of memory) but we still use 4 workers... monitoring the metrics, I noticed high memory consumption!

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
