### PR TITLE
[CES-110] Switch Messages Cosmos secondary location to ItalyNorth

### DIFF
--- a/infra/src/99_locals.tf
+++ b/infra/src/99_locals.tf
@@ -10,4 +10,14 @@ locals {
     services_details      = "services"
   }
 }
-  
+
+# Region ITN
+locals {
+  project_itn        = "${var.prefix}-${var.env_short}-${local.itn_location_short}"
+  itn_location       = "italynorth"
+  itn_location_short = "itn"
+  common_project_itn = "${local.project}-${local.itn_location_short}"
+
+  vnet_common_name_itn                = "${local.common_project_itn}-common-vnet-01"
+  vnet_common_resource_group_name_itn = "${local.common_project_itn}-common-rg-01"
+}

--- a/infra/src/README.md
+++ b/infra/src/README.md
@@ -49,6 +49,7 @@
 | [azurerm_key_vault_secret.pgres_flex_readonly_usr_pwd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.pgres_flex_reviewer_usr_pwd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_postgresql_flexible_server_database.reviewer_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
+| [azurerm_private_endpoint.cosmos_db](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [random_password.bo_auth_session_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.postgres_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
@@ -89,6 +90,7 @@
 | [azurerm_subnet.devportal_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.github_runner_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoints_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subnet.private_endpoints_subnet_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs

--- a/infra/src/database_cms.tf
+++ b/infra/src/database_cms.tf
@@ -26,7 +26,7 @@ module "cosmosdb_account" {
   additional_geo_locations = [{
     location          = "italynorth"
     failover_priority = 1
-    zone_redundant    = false
+    zone_redundant    = true
   }]
 
   consistency_policy = {

--- a/infra/src/database_cms.tf
+++ b/infra/src/database_cms.tf
@@ -24,7 +24,7 @@ module "cosmosdb_account" {
   enable_automatic_failover        = true
 
   additional_geo_locations = [{
-    location          = "northeurope"
+    location          = "italynorth"
     failover_priority = 1
     zone_redundant    = false
   }]

--- a/infra/src/network.tf
+++ b/infra/src/network.tf
@@ -56,19 +56,19 @@ module "postgres_flexible_snet" {
 
 data "azurerm_subnet" "private_endpoints_subnet_itn" {
   name                 = "io-p-itn-pep-snet-01"
-  virtual_network_name = "io-p-itn-common-vnet-01"
-  resource_group_name  = "io-p-itn-common-rg-01"
+  virtual_network_name = local.vnet_common_name_itn
+  resource_group_name  = local.vnet_common_resource_group_name_itn
 }
 
 
 resource "azurerm_private_endpoint" "cosmos_db" {
-  name                = "${local.project}-itn-cosmos-services-cms"
+  name                = "${local.project_itn}-svc-cosno-pep-01"
   location            = "italynorth"
   resource_group_name = azurerm_resource_group.rg.name
   subnet_id           = data.azurerm_subnet.private_endpoints_subnet_itn.id
 
   private_service_connection {
-    name                           = "${local.project}-itn-cosmos-services-cms-private-endpoint"
+    name                           = "${local.project_itn}-svc-cosno-pep-01"
     private_connection_resource_id = module.cosmosdb_account.id
     is_manual_connection           = false
     subresource_names              = ["Sql"]

--- a/infra/src/network.tf
+++ b/infra/src/network.tf
@@ -49,3 +49,28 @@ module "postgres_flexible_snet" {
     }
   }
 }
+
+#
+# Cosmos Private Endpoint
+#
+
+data "azurerm_subnet" "private_endpoints_subnet_itn" {
+  name                 = "io-p-itn-pep-snet-01"
+  virtual_network_name = "io-p-itn-common-vnet-01"
+  resource_group_name  = "io-p-itn-common-rg-01"
+}
+
+
+resource "azurerm_private_endpoint" "cosmos_db" {
+  name                = "${local.project}-itn-cosmos-services-cms"
+  location            = "italynorth"
+  resource_group_name = azurerm_resource_group.rg.name
+  subnet_id           = data.azurerm_subnet.private_endpoints_subnet_itn.id
+
+  private_service_connection {
+    name                           = "${local.project}-itn-cosmos-services-cms-private-endpoint"
+    private_connection_resource_id = module.cosmosdb_account.id
+    is_manual_connection           = false
+    subresource_names              = ["Sql"]
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Replace NorthEurope with ItalyNorth region for data redundancy in read-only mode for messages namespace
Added Private endpoint for italy north.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

ItalyNorth migration. This is a first step to have data in ItalyNorth without affecting operations on the main region, WestEurope

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

### How to apply

After PR is approved
1. run deploy pipeline from Azure DevOps [io-platform-iac-projects](https://dev.azure.com/pagopaspa/io-platform-iac-projects/_build?view=folders)
2. select PR branch
3. wait for approval
