### PR TITLE
[IOPAE-1381] patch upsert subscription

### DIFF
--- a/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
@@ -52,14 +52,20 @@ describe("upsertManageSubscription", () => {
   `(
     "should return the new $subType Subscription",
     async ({ subType, groupId }) => {
+      const id = "id";
       const ownerId = mocks.anOwnerId;
       mocks.upsertSubscription.mockReturnValueOnce(
-        TE.right({ id: "id", name: "name", foo: "foo", bar: "bar" }),
+        TE.right({
+          id: `/full/path/${id}`,
+          name: "name",
+          foo: "foo",
+          bar: "bar",
+        }),
       );
 
       await expect(
         upsertManageSubscription(ownerId, groupId),
-      ).resolves.toStrictEqual({ id: "id", name: "name" });
+      ).resolves.toStrictEqual({ id, name: "name" });
 
       const params = groupId ? [subType, ownerId, groupId] : [subType, ownerId];
       expect(mocks.upsertSubscription).toHaveBeenCalledOnce();

--- a/apps/backoffice/src/lib/be/subscriptions/business.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/business.ts
@@ -1,4 +1,6 @@
 import { Subscription } from "@/generated/api/Subscription";
+import { ApimUtils } from "@io-services-cms/external-clients";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 
 import { upsertSubscription } from "../apim-service";
@@ -43,5 +45,10 @@ export async function upsertManageSubscription(
     );
   }
 
-  return { id: maybeSubscription.right.id, name: maybeSubscription.right.name };
+  return {
+    id: ApimUtils.parseIdFromFullPath(
+      maybeSubscription.right.id as NonEmptyString,
+    ),
+    name: maybeSubscription.right.name,
+  };
 }

--- a/apps/io-services-cms-webapp/src/utils/feature-flag-handler.ts
+++ b/apps/io-services-cms-webapp/src/utils/feature-flag-handler.ts
@@ -40,7 +40,7 @@ const isServiceOwnerIncludedInList = (
     TE.map(({ ownerId }) =>
       pipe(
         ownerId as NonEmptyString,
-        ApimUtils.parseOwnerIdFullPath,
+        ApimUtils.parseIdFromFullPath,
         isElementAllowedOnList(inclusionList),
       ),
     ),
@@ -128,6 +128,6 @@ export const isUserEnabledForRequestReviewLegacy = (
 ): boolean =>
   pipe(
     apimUserId,
-    ApimUtils.parseOwnerIdFullPath,
+    ApimUtils.parseIdFromFullPath,
     isElementAllowedOnList(config.USERID_REQUEST_REVIEW_LEGACY_INCLUSION_LIST),
   );

--- a/apps/io-services-cms-webapp/src/utils/subscription.ts
+++ b/apps/io-services-cms-webapp/src/utils/subscription.ts
@@ -33,7 +33,7 @@ const extractOwnerId = (
     O.fromNullable,
     O.foldW(
       () => E.left(ResponseErrorNotFound("Not found", "ownerId not found")),
-      (f) => E.right(pipe(f as NonEmptyString, ApimUtils.parseOwnerIdFullPath)),
+      (f) => E.right(pipe(f as NonEmptyString, ApimUtils.parseIdFromFullPath)),
     ),
   );
 

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
@@ -68,7 +68,7 @@ const aServiceList = [
 // Apim service mock *******************************
 const mockApimService = {
   getUserSubscriptions: vi.fn((_) => TE.right(aSubscriptionCollection)),
-  parseOwnerIdFullPath: vi.fn((_) => "a-user-id"),
+  parseIdFromFullPath: vi.fn((_) => "a-user-id"),
 } as unknown as ApimUtils.ApimService;
 
 const mockConfig = {
@@ -79,7 +79,7 @@ const mockConfig = {
 
 // FSM client mock *******************************
 const aBulkFetchRightValue = TE.of(
-  aServiceList.map((service) => O.fromNullable(service))
+  aServiceList.map((service) => O.fromNullable(service)),
 );
 
 let mockFsmLifecycleClient = {
@@ -113,7 +113,7 @@ const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
 const mockFetchAll = vi.fn(() =>
   Promise.resolve({
     resources: [aRetrievedSubscriptionCIDRs],
-  })
+  }),
 );
 const containerMock = {
   items: {
@@ -213,7 +213,7 @@ describe("getServices", () => {
     expect(mockContext.log.error).not.toHaveBeenCalled();
     expect(response.body.pagination).toHaveProperty(
       "limit",
-      mockConfig.PAGINATION_DEFAULT_LIMIT
+      mockConfig.PAGINATION_DEFAULT_LIMIT,
     );
   });
 

--- a/packages/external-clients/src/apim-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getApimService, parseOwnerIdFullPath } from "..";
+import { getApimService, parseIdFromFullPath } from "..";
 import { SubscriptionKeyTypeEnum } from "../../generated/api/SubscriptionKeyType";
 
 afterEach(() => {
@@ -1402,7 +1402,7 @@ describe("ApimService Test", () => {
 
   describe("Get Owner Id from Full Path", () => {
     it("should retrieve the ID", () => {
-      const res = parseOwnerIdFullPath(
+      const res = parseIdFromFullPath(
         "/subscriptions/subid/resourceGroups/{resourceGroup}/providers/Microsoft.ApiManagement/service/{apimService}/users/1234a75ae4bbd512a88c680x" as NonEmptyString,
       );
       expect(res).toBe("1234a75ae4bbd512a88c680x");

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -571,7 +571,7 @@ const getDelegateFromServiceId = (
   pipe(
     getSubscription(apimClient, apimResourceGroup, apimServiceName, serviceId),
     TE.map((subscription) =>
-      parseOwnerIdFullPath(subscription.ownerId as NonEmptyString),
+      parseIdFromFullPath(subscription.ownerId as NonEmptyString),
     ),
     TE.chain((ownerId) =>
       getUser(apimClient, apimResourceGroup, apimServiceName, ownerId),
@@ -671,14 +671,12 @@ const subscriptionsExceptManageOneApimFilter = () =>
     O.getOrElse(() => ""),
   );
 
-/*
- ** The right full path for ownerID is in this kind of format:
- ** "/subscriptions/subid/resourceGroups/{resourceGroup}/providers/Microsoft.ApiManagement/service/{apimService}/users/5931a75ae4bbd512a88c680b",
- ** resouce link: https://docs.microsoft.com/en-us/rest/api/apimanagement/current-ga/subscription/get
+/**
+ * Parse the ID from a "full path" ID format
+ * @param fullPath a full path ID in this kind of format: "/some/kind/of/prefix/id-value"
+ * @returns the parsed id value
  */
-export const parseOwnerIdFullPath = (
-  fullPath: NonEmptyString,
-): NonEmptyString =>
+export const parseIdFromFullPath = (fullPath: NonEmptyString): NonEmptyString =>
   pipe(
     fullPath,
     (f) => f.split("/"),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Currently the returned Subscription Manage Group id format is "full path"

#### List of Changes
<!--- Describe your changes in detail -->
- [refactor: rename parseOwnerIdFullPath to parseIdFromFullPath](https://github.com/pagopa/io-services-cms/commit/238baf4ad11d65076ddea96806d53e1a5960decc)
- [return id instead of full path id](https://github.com/pagopa/io-services-cms/commit/977ac052b19a5d8028fb9afcaa921d07cec208c9)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
