### PR TITLE
[IOPAE-1338] retrieve subscriptions manage group

### DIFF
--- a/.changeset/silent-donkeys-share.md
+++ b/.changeset/silent-donkeys-share.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/external-clients": minor
+"io-services-cms-backoffice": minor
+---
+
+add Retrieve manage group subscriptions API

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -221,23 +221,8 @@ paths:
       security:
         - cookieAuth: []
       parameters:
-        - name: limit
-          in: query
-          description: The number of services to return
-          required: false
-          schema:
-            type: number
-            minimum: 1
-            maximum: 100
-            default: 20
-        - name: offset
-          in: query
-          description: The number of services to skip before starting to collect the result set
-          required: false
-          schema:
-            type: number
-            minimum: 0
-            default: 0
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Services fetched successfully
@@ -263,23 +248,8 @@ paths:
       security:
         - cookieAuth: []
       parameters:
-        - name: limit
-          in: query
-          description: The number of services to return
-          required: false
-          schema:
-            type: number
-            minimum: 1
-            maximum: 100
-            default: 20
-        - name: offset
-          in: query
-          description: The number of services to skip before starting to collect the result set
-          required: false
-          schema:
-            type: number
-            minimum: 0
-            default: 0
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
         - name: id
           in: query
           description: The serviceId to filter, when passed limit and offset will be ignored
@@ -1000,6 +970,9 @@ paths:
       operationId: getManageSubscriptions
       security:
         - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Manage keys fetched successfully
@@ -1196,6 +1169,26 @@ paths:
         '500':
           description: Internal server error
 components:
+  parameters:
+    limit:
+      name: limit
+      in: query
+      description: The number of items to return
+      required: false
+      schema:
+        type: number
+        minimum: 1
+        maximum: 100
+        default: 20
+    offset:
+      name: offset
+      in: query
+      description: The number of items to skip before starting to collect the result set
+      required: false
+      schema:
+        type: number
+        minimum: 0
+        default: 0
   schemas:
     Info:
       type: object

--- a/apps/backoffice/src/app/api/institutions/[institutionId]/groups/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/institutions/[institutionId]/groups/__tests__/route.test.ts
@@ -1,8 +1,10 @@
 import { faker } from "@faker-js/faker/locale/it";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import { NextRequest, NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BackOfficeUser } from "../../../../../../../types/next-auth";
+import { PositiveInteger } from "../../../../../../lib/be/types";
 import { SelfcareRoles } from "../../../../../../types/auth";
 import { GET } from "../route";
 
@@ -39,7 +41,7 @@ const { retrieveInstitutionGroupsMock, withJWTAuthHandlerMock } = vi.hoisted(
   () => ({
     retrieveInstitutionGroupsMock: vi.fn().mockReturnValue(
       Promise.resolve({
-        pagination: { number: 0, size: 0, totalElements: 0, totalPages:0},
+        pagination: { number: 0, size: 0, totalElements: 0, totalPages: 0 },
         value: [],
       }),
     ),
@@ -74,15 +76,13 @@ describe("Retrieve Institutions Groups API", () => {
   it("when no size and page queryParam are provided should call with the default", async () => {
     const nextRequest = new NextRequest(new URL("http://localhost"));
     const params = { institutionId: "institutionId" };
-    const result = await GET(nextRequest, {params} );
-    
+    const result = await GET(nextRequest, { params });
+
     expect(result.status).toBe(200);
-    expect(
-      retrieveInstitutionGroupsMock
-    ).toHaveBeenCalledWith(
+    expect(retrieveInstitutionGroupsMock).toHaveBeenCalledWith(
       backofficeUserMock.institution.id,
       20,
-      0
+      0,
     );
   });
 
@@ -97,17 +97,19 @@ describe("Retrieve Institutions Groups API", () => {
 
     const nextRequest = new NextRequest(url);
 
-    const result = await GET(nextRequest, {params: { institutionId: "institutionId" }});
+    const result = await GET(nextRequest, {
+      params: { institutionId: "institutionId" },
+    });
 
     expect(result.status).toBe(200);
     expect(retrieveInstitutionGroupsMock).toHaveBeenCalledWith(
       backofficeUserMock.institution.id,
       25,
-      5
+      5,
     );
   });
 
-    it("should return a bad request if size is not number", async () => {
+  it("should return a bad request if size is not number", async () => {
     const url = new URL("http://localhost");
 
     const queryParams = new URLSearchParams(url.search);
@@ -118,12 +120,16 @@ describe("Retrieve Institutions Groups API", () => {
 
     const nextRequest = new NextRequest(url);
 
-    const result = await GET(nextRequest, {params: { institutionId: "institutionId" }});
+    const result = await GET(nextRequest, {
+      params: { institutionId: "institutionId" },
+    });
     const jsonBody = await result.json();
 
     expect(result.status).toBe(400);
     expect(retrieveInstitutionGroupsMock).not.toHaveBeenCalled();
-    expect(jsonBody.detail).toEqual("Size is not a number")
+    expect(jsonBody.detail).toEqual(
+      `Size is not a valid ${PositiveInteger.name}`,
+    );
   });
 
   it("should return a bad request if page is not number", async () => {
@@ -137,11 +143,15 @@ describe("Retrieve Institutions Groups API", () => {
 
     const nextRequest = new NextRequest(url);
 
-    const result = await GET(nextRequest, {params: { institutionId: "institutionId" }});
+    const result = await GET(nextRequest, {
+      params: { institutionId: "institutionId" },
+    });
     const jsonBody = await result.json();
 
     expect(result.status).toBe(400);
     expect(retrieveInstitutionGroupsMock).not.toHaveBeenCalled();
-    expect(jsonBody.detail).toEqual("Page is not a number")
+    expect(jsonBody.detail).toEqual(
+      `Page is not a valid ${NonNegativeInteger.name}`,
+    );
   });
 });

--- a/apps/backoffice/src/app/api/subscriptions/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/route.ts
@@ -2,13 +2,23 @@ import { HTTP_STATUS_BAD_REQUEST } from "@/config/constants";
 import { CreateManageGroupSubscription } from "@/generated/api/CreateManageGroupSubscription";
 import { isBackofficeUserAdmin } from "@/lib/be/authz";
 import {
+  handleBadRequestErrorResponse,
   handleForbiddenErrorResponse,
   handleInternalErrorResponse,
   handlerErrorLog,
 } from "@/lib/be/errors";
+import { getQueryParam } from "@/lib/be/req-res-utils";
 import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
-import { upsertManageSubscription } from "@/lib/be/subscriptions/business";
+import {
+  getManageSubscriptions,
+  upsertManageSubscription,
+} from "@/lib/be/subscriptions/business";
+import { PositiveInteger, PositiveIntegerFromString } from "@/lib/be/types";
 import { withJWTAuthHandler } from "@/lib/be/wrappers";
+import {
+  NonNegativeInteger,
+  NonNegativeIntegerFromString,
+} from "@pagopa/ts-commons/lib/numbers";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import * as E from "fp-ts/lib/Either";
 import { NextRequest, NextResponse } from "next/server";
@@ -65,6 +75,56 @@ export const PUT = withJWTAuthHandler(
         error,
       );
       return handleInternalErrorResponse("SubscriptionCreateError", error);
+    }
+  },
+);
+
+/**
+ * @description Retrieve all user authorized manage subscriptions
+ */
+export const GET = withJWTAuthHandler(
+  async (
+    request,
+    { backofficeUser }: { backofficeUser: BackOfficeUser },
+  ): Promise<NextResponse> => {
+    const maybeLimit = getQueryParam(
+      request,
+      "limit",
+      PositiveIntegerFromString,
+      20 as PositiveInteger,
+    );
+    if (E.isLeft(maybeLimit)) {
+      return handleBadRequestErrorResponse(
+        `'limit' query param is not a valid ${PositiveInteger.name}`,
+      );
+    }
+    const maybeOffset = getQueryParam(
+      request,
+      "offset",
+      NonNegativeIntegerFromString,
+      0 as NonNegativeInteger,
+    );
+    if (E.isLeft(maybeOffset)) {
+      return handleBadRequestErrorResponse(
+        `'offset' query param is not a valid ${NonNegativeInteger.name}`,
+      );
+    }
+    try {
+      const response = await getManageSubscriptions(
+        backofficeUser.parameters.userId,
+        maybeLimit.right,
+        maybeOffset.right,
+        isBackofficeUserAdmin(backofficeUser)
+          ? undefined
+          : backofficeUser.permissions.selcGroups,
+      );
+      return sanitizedNextResponseJson(response);
+    } catch (error) {
+      handlerErrorLog(
+        `An Error has occurred while retrieving manage group subscriptions for user having Selfcare userId = '${backofficeUser.id}' and institution having APIM userId = '${backofficeUser.parameters.userId}', caused by: `,
+        error,
+      );
+      return handleInternalErrorResponse("SubscriptionsRetrieveError", error);
     }
   },
 );

--- a/apps/backoffice/src/lib/be/__tests__/req-res-utils.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/req-res-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { getQueryParam } from "../req-res-utils";
+import { NextRequest } from "next/server";
+import {
+  NumberFromString,
+  NonNegativeIntegerFromString,
+  NonNegativeInteger,
+} from "@pagopa/ts-commons/lib/numbers";
+import * as E from "fp-ts/lib/Either";
+
+describe("getQueryParam", () => {
+  it("should return a validation error when value is not compliant to decoder", () => {
+    const paramName = "param";
+    const req = new NextRequest(`http://localhost?${paramName}=-1`);
+
+    const actual = getQueryParam(req, paramName, NonNegativeIntegerFromString);
+
+    expect(E.isLeft(actual)).toBeTruthy();
+  });
+
+  it("should return a validation error when no value provided and there is no default value", () => {
+    const paramName = "param";
+    const req = new NextRequest(`http://localhost`);
+
+    const actual = getQueryParam(req, paramName, NonNegativeIntegerFromString);
+
+    expect(E.isLeft(actual)).toBeTruthy();
+  });
+
+  it("should return the default value when no value provided and there is a default value", () => {
+    const paramName = "param";
+    const defaultValue = 0;
+    const req = new NextRequest(`http://localhost`);
+
+    const actual = getQueryParam(
+      req,
+      paramName,
+      NumberFromString,
+      defaultValue,
+    );
+
+    expect(E.isRight(actual)).toBeTruthy();
+    if (E.isRight(actual)) {
+      expect(actual.right).toEqual(defaultValue);
+    }
+  });
+
+  it("should return the provided query param value", () => {
+    const paramName = "param";
+    const defaultValue = 5 as NonNegativeInteger;
+    const expectedValue = 0;
+    const req = new NextRequest(
+      `http://localhost?${paramName}=${expectedValue}`,
+    );
+
+    const actual = getQueryParam(
+      req,
+      paramName,
+      NonNegativeIntegerFromString,
+      defaultValue,
+    );
+
+    expect(E.isRight(actual)).toBeTruthy();
+    if (E.isRight(actual)) {
+      expect(actual.right).toEqual(expectedValue);
+    }
+  });
+});

--- a/apps/backoffice/src/lib/be/req-res-utils.ts
+++ b/apps/backoffice/src/lib/be/req-res-utils.ts
@@ -1,0 +1,17 @@
+import * as E from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import { NextRequest } from "next/server";
+
+export const getQueryParam = <A>(
+  request: NextRequest,
+  param: string,
+  decoder: t.Decoder<unknown, A>,
+  defaultValue?: A,
+): t.Validation<A> => {
+  const rawParam = request.nextUrl.searchParams.get(param);
+  if (defaultValue !== undefined && rawParam === null) {
+    return E.right(defaultValue);
+  } else {
+    return decoder.decode(rawParam);
+  }
+};

--- a/apps/backoffice/src/lib/be/types.ts
+++ b/apps/backoffice/src/lib/be/types.ts
@@ -1,0 +1,23 @@
+import { IntegerFromString } from "@pagopa/ts-commons/lib/numbers";
+import { tag } from "@pagopa/ts-commons/lib/types";
+import * as t from "io-ts";
+
+export interface IPositiveIntegerTag {
+  readonly kind: "IPositiveIntegerTag";
+}
+
+/**
+ * A positive integer
+ */
+export const PositiveInteger = tag<IPositiveIntegerTag>()(
+  t.refinement(t.Integer, (s) => s > 0, "integer > 0"),
+);
+export type PositiveInteger = t.TypeOf<typeof PositiveInteger>;
+
+/**
+ * Parses a string into a positive integer
+ */
+export const PositiveIntegerFromString = tag<IPositiveIntegerTag>()(
+  t.refinement(IntegerFromString, (i) => i > 0, "PositiveIntegerFromString"),
+);
+type PositiveIntegerFromString = t.TypeOf<typeof PositiveIntegerFromString>;

--- a/packages/external-clients/src/apim-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/index.test.ts
@@ -3,7 +3,11 @@ import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getApimService, parseIdFromFullPath } from "..";
+import {
+  getApimService,
+  manageGroupSubscriptionsFilter,
+  parseIdFromFullPath,
+} from "..";
 import { SubscriptionKeyTypeEnum } from "../../generated/api/SubscriptionKeyType";
 
 afterEach(() => {
@@ -1406,6 +1410,40 @@ describe("ApimService Test", () => {
         "/subscriptions/subid/resourceGroups/{resourceGroup}/providers/Microsoft.ApiManagement/service/{apimService}/users/1234a75ae4bbd512a88c680x" as NonEmptyString,
       );
       expect(res).toBe("1234a75ae4bbd512a88c680x");
+    });
+  });
+
+  describe("manageGroupSubscriptionsFilter", () => {
+    it("should return a MANAGE-GROUP- filter when no groups are provided", () => {
+      const res = manageGroupSubscriptionsFilter();
+
+      expect(res).toEqual("startswith(name, 'MANAGE-GROUP-')");
+    });
+
+    it("should return an empty filter when empty array is provided", () => {
+      const res = manageGroupSubscriptionsFilter([]);
+
+      expect(res).toEqual("");
+    });
+
+    it("should return a single MANAGE-GROUP- filter when a single group id provided", () => {
+      const groupId = "g1";
+      const res = manageGroupSubscriptionsFilter([groupId]);
+
+      expect(res).toEqual(`name eq 'MANAGE-GROUP-${groupId}'`);
+    });
+
+    it("should return a concat MANAGE-GROUP- filters based on the group ids provided", () => {
+      const groupids = new Array(3);
+      for (let index = 0; index < groupids.length; index++) {
+        groupids[index] = "id" + index;
+      }
+      const res = manageGroupSubscriptionsFilter(groupids);
+
+      const expectedRes = groupids
+        .map((groupId) => `name eq 'MANAGE-GROUP-${groupId}'`)
+        .join(" or ");
+      expect(res).toEqual(expectedRes);
     });
   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Retrieving all manage subscriptions ("root" manage and "groups" manage) is required in order to allow API Keys management
User will be able to create a new type of subscription (aka "manage group") related to selfcare group, so retrieving all types of manage subscriptions ("root" manage and "groups" manage) is required in order to allow proper API Keys management

#### List of Changes
<!--- Describe your changes in detail -->
- [add PositiveInteger and PositiveIntegerFromString io-ts types](https://github.com/pagopa/io-services-cms/commit/90e647d8830d4a27ac1abe2b947360847cd54901)
- [add a common/generic getQueryParam fn](https://github.com/pagopa/io-services-cms/commit/13f48d141312e5d217af0269436e4f892396519c)
- [move out 'filter' param from getUserSubscriptions fn](https://github.com/pagopa/io-services-cms/commit/8bf8c991175081c5e09a263702765be85b6103cd)
- [add Retrieve manage subscriptions API](https://github.com/pagopa/io-services-cms/commit/fce1078f5b84aed8e44d818142453fce14b004a5)
- [fix query params type check](https://github.com/pagopa/io-services-cms/commit/2328c69310401acb81bce307897ea0176e33fffa)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Needed in order to be able to reduce services visibility to API users

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests and Run App in local environment

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
