### PR TITLE
[IOPAE-1494] FSM group based authz

### DIFF
--- a/.changeset/nervous-jeans-sneeze.md
+++ b/.changeset/nervous-jeans-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/models": minor
+"io-services-cms-webapp": minor
+---
+
+add group-based authz logic to FSM

--- a/apps/io-services-cms-webapp/src/main.ts
+++ b/apps/io-services-cms-webapp/src/main.ts
@@ -134,7 +134,9 @@ const subscriptionCIDRsModel = new SubscriptionCIDRsModel(
 );
 
 // Get an instance of ServiceLifecycle client
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 // Get an instance of ServicePublication client
 const fsmPublicationClient = ServicePublication.getFsmClient(
@@ -185,7 +187,7 @@ export const httpEntryPoint = pipe(
     basePath: BASE_PATH,
     blobService,
     config,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     serviceHistoryPagedHelper,
     serviceLifecycleCosmosHelper,
@@ -202,7 +204,7 @@ export const createRequestReviewEntryPoint = createRequestReviewHandler(
   getServiceReviewDao(config),
   jiraProxy(jiraClient(config), config),
   apimService,
-  fsmLifecycleClient,
+  fsmLifecycleClientCreator(),
   fsmPublicationClient,
   config,
 );
@@ -210,7 +212,7 @@ export const createRequestReviewEntryPoint = createRequestReviewHandler(
 export const onRequestValidationEntryPoint = pipe(
   createServiceValidationHandler({
     config,
-    fsmLifecycleClient,
+    fsmLifecycleClient: fsmLifecycleClientCreator(),
     fsmPublicationClient,
     serviceLifecycleCosmosHelper,
     servicePublicationCosmosHelper,
@@ -237,7 +239,7 @@ export const createRequestDeletionEntryPoint =
   createRequestDeletionHandler(fsmPublicationClient);
 
 export const onRequestSyncCmsEntryPoint = createRequestSyncCmsHandler(
-  fsmLifecycleClient,
+  fsmLifecycleClientCreator(),
   fsmPublicationClient,
   config,
 );
@@ -255,12 +257,12 @@ export const createRequestDetailEntryPoint = createRequestDetailHandler(
 export const serviceReviewCheckerEntryPoint = createReviewCheckerHandler(
   getServiceReviewDao(config),
   jiraProxy(jiraClient(config), config),
-  fsmLifecycleClient,
+  fsmLifecycleClientCreator(),
 );
 
 export const createRequestReviewLegacyEntryPoint =
   createRequestReviewLegacyHandler(
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator(),
     getServiceReviewDao({
       ...config,
       REVIEWER_DB_TABLE: `${config.REVIEWER_DB_TABLE}_legacy` as NonEmptyString,
@@ -278,7 +280,7 @@ export const serviceReviewLegacyCheckerEntryPoint =
       jiraClient({ ...config, JIRA_PROJECT_NAME: "IES" as NonEmptyString }),
       config,
     ),
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator(),
   );
 
 export const onServiceLifecycleChangeEntryPoint = pipe(

--- a/apps/io-services-cms-webapp/src/utils/check-service.ts
+++ b/apps/io-services-cms-webapp/src/utils/check-service.ts
@@ -1,13 +1,11 @@
 import { ServiceLifecycle } from "@io-services-cms/models";
-import {
-  ResponseErrorInternal,
-  ResponseErrorNotFound,
-} from "@pagopa/ts-commons/lib/responses";
+import { ResponseErrorNotFound } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { flow, pipe } from "fp-ts/lib/function";
 
+import { fsmToApiError } from "./converters/fsm-error-converters";
 import { ErrorResponseTypes } from "./logger";
 
 export const checkService =
@@ -15,8 +13,8 @@ export const checkService =
   (serviceId: NonEmptyString): TE.TaskEither<ErrorResponseTypes, void> =>
     pipe(
       serviceId,
-      fsmLifecycleClient.getStore().fetch,
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
+      fsmLifecycleClient.fetch,
+      TE.mapLeft(fsmToApiError),
       TE.chainW(
         flow(
           O.filter((service) => service.fsm.state !== "deleted"),

--- a/apps/io-services-cms-webapp/src/utils/converters/fsm-error-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/fsm-error-converters.ts
@@ -1,4 +1,5 @@
 import {
+  FsmAuthorizationError,
   FsmItemNotFoundError,
   FsmNoApplicableTransitionError,
   FsmNoTransitionMatchedError,
@@ -13,6 +14,7 @@ import {
   ResponseErrorConflict,
   ResponseErrorInternal,
   ResponseErrorNotFound,
+  getResponseErrorForbiddenNoAuthorizationGroups,
 } from "@pagopa/ts-commons/lib/responses";
 
 /**
@@ -34,6 +36,8 @@ export const fsmToApiError = (
       return ResponseErrorInternal(err.message);
     case FsmItemNotFoundError:
       return ResponseErrorNotFound("Not Found", err.message);
+    case FsmAuthorizationError:
+      return getResponseErrorForbiddenNoAuthorizationGroups();
     default:
       return ResponseErrorInternal(err.message);
   }

--- a/apps/io-services-cms-webapp/src/utils/generic-service-retrieve.ts
+++ b/apps/io-services-cms-webapp/src/utils/generic-service-retrieve.ts
@@ -1,43 +1,39 @@
 import { Context } from "@azure/functions";
 import { ApimUtils } from "@io-services-cms/external-clients";
-import { FSMStore } from "@io-services-cms/models";
+import {
+  FsmAuthorizationError,
+  FsmStoreFetchError,
+} from "@io-services-cms/models";
 import { IAzureApiAuthorization } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import {
   IResponseErrorInternal,
   IResponseSuccessJson,
-  ResponseErrorInternal,
   ResponseErrorNotFound,
   ResponseSuccessJson,
-  getResponseErrorForbiddenNoAuthorizationGroups,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
-import { flow, identity, pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 
 import {
   EventNameEnum,
   TelemetryClient,
   trackEventOnResponseOK,
 } from "./applicationinsight";
+import { fsmToApiError } from "./converters/fsm-error-converters";
 import { ErrorResponseTypes, getLogger } from "./logger";
 import { serviceOwnerCheckManageTask } from "./subscription";
 
-export type GenericItemToResponse<T, V> = (
+type GenericItemToResponse<T, V> = (
   item: T,
 ) => TE.TaskEither<IResponseErrorInternal, V>;
 
 export const genericServiceRetrieveHandler =
-  <
-    T extends {
-      data: { metadata?: { group_id?: NonEmptyString } };
-      fsm: {
-        lastTransition?: string | undefined;
-        state: string;
-      };
-    },
-    V,
-  >(
-    store: FSMStore<T>,
+  <T, V>(
+    fetch: (
+      id: NonEmptyString,
+    ) => TE.TaskEither<FsmAuthorizationError | FsmStoreFetchError, O.Option<T>>,
     apimService: ApimUtils.ApimService,
     telemetryClient: TelemetryClient,
     itemToResponse: GenericItemToResponse<T, V>,
@@ -48,7 +44,7 @@ export const genericServiceRetrieveHandler =
     serviceId: NonEmptyString,
     logPrefix: string,
     event: EventNameEnum,
-    authzGroupIds: readonly NonEmptyString[],
+    _authzGroupIds: readonly NonEmptyString[],
   ): TE.TaskEither<ErrorResponseTypes, IResponseSuccessJson<V>> =>
     pipe(
       serviceOwnerCheckManageTask(
@@ -57,28 +53,14 @@ export const genericServiceRetrieveHandler =
         auth.subscriptionId,
         auth.userId,
       ),
+      TE.chainW(flow(fetch, TE.mapLeft(fsmToApiError))),
       TE.chainW(
-        flow(
-          store.fetch,
-          TE.mapLeft((err) => ResponseErrorInternal(err.message)),
-          TE.chain(
-            flow(
-              TE.fromOption(() =>
-                ResponseErrorNotFound("Not found", `${serviceId} not found`),
-              ),
-              flow(
-                event === EventNameEnum.GetServiceLifecycle // group authz check is applied only to ServiceLifecycle entity
-                  ? TE.filterOrElseW(isAuthorized(authzGroupIds), (_) =>
-                      getResponseErrorForbiddenNoAuthorizationGroups(),
-                    )
-                  : identity,
-              ),
-              TE.chainW(itemToResponse),
-              TE.map(ResponseSuccessJson<V>),
-            ),
-          ),
+        TE.fromOption(() =>
+          ResponseErrorNotFound("Not found", `${serviceId} not found`),
         ),
       ),
+      TE.chainW(itemToResponse),
+      TE.map(ResponseSuccessJson<V>),
       TE.map(
         trackEventOnResponseOK(telemetryClient, event, {
           serviceId,
@@ -92,10 +74,3 @@ export const genericServiceRetrieveHandler =
         }),
       ),
     );
-
-const isAuthorized =
-  (authzGroupIds: readonly NonEmptyString[]) =>
-  (service: { data: { metadata?: { group_id?: NonEmptyString } } }) =>
-    authzGroupIds.length === 0 ||
-    (!!service.data.metadata?.group_id &&
-      authzGroupIds.includes(service.data.metadata.group_id));

--- a/apps/io-services-cms-webapp/src/utils/logger.ts
+++ b/apps/io-services-cms-webapp/src/utils/logger.ts
@@ -57,11 +57,15 @@ export const getLogger = (context: Context, logPrefix: string, step = "-") => ({
     errorResponse: ErrorResponseTypes,
     addititionalInfo?: unknown,
   ) => {
-    context.log.error(
-      `${logPrefix}|${step}|${handleErrorResponseType(errorResponse)}|${
-        addititionalInfo ? JSON.stringify(addititionalInfo) : ""
-      }`,
-    );
+    const errorMessage = `${logPrefix}|${step}|${handleErrorResponseType(errorResponse)}|${addititionalInfo ? JSON.stringify(addititionalInfo) : ""}`;
+    switch (errorResponse.kind) {
+      case "IResponseErrorInternal":
+        context.log.error(errorMessage);
+        break;
+      default:
+        context.log.warn(errorMessage);
+        break;
+    }
     return errorResponse;
   },
   logErrors: (errs: Errors): void =>

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
@@ -56,7 +56,9 @@ vi.mock("../../../lib/clients/apim-client", async () => {
 
 const serviceLifecycleStore =
   stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
@@ -150,7 +152,7 @@ describe("createService", () => {
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/create-service.test.ts
@@ -1,11 +1,6 @@
 import { Container } from "@azure/cosmos";
 import { ApimUtils } from "@io-services-cms/external-clients";
 import {
-  ServiceLifecycle,
-  ServicePublication,
-  stores,
-} from "@io-services-cms/models";
-import {
   RetrievedSubscriptionCIDRs,
   SubscriptionCIDRsModel,
 } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
@@ -16,72 +11,75 @@ import {
   IPatternStringTag,
   NonEmptyString,
 } from "@pagopa/ts-commons/lib/strings";
-import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import request from "supertest";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IConfig } from "../../../config";
 import { WebServerDependencies, createWebServer } from "../../index";
-import { right } from "fp-ts/lib/Separated";
 
-const { validateServiceTopicRequest } = vi.hoisted(() => ({
-  validateServiceTopicRequest: vi.fn(),
-}));
-
-vi.mock("../../../utils/service-topic-validator", () => ({
-  validateServiceTopicRequest: validateServiceTopicRequest,
-}));
-
-const { getServiceTopicDao } = vi.hoisted(() => ({
-  getServiceTopicDao: vi.fn(() => ({
-    findById: vi.fn((id: number) =>
-      TE.right(O.some({ id, name: "topic name" })),
-    ),
-  })),
-}));
-
-vi.mock("../../../utils/service-topic-dao", () => ({
-  getDao: getServiceTopicDao,
-}));
-
-vi.mock("../../../lib/clients/apim-client", async () => {
-  const anApimResource = { id: "any-id", name: "any-name" };
-
+const {
+  validateServiceTopicRequest,
+  payloadToItemMock,
+  payloadToItemResponseMock,
+  itemToResponseWrapperMock,
+  itemToResponseMock,
+  itemToResponseResponseMock,
+  logErrorResponseMock,
+  getLoggerMock,
+} = vi.hoisted(() => {
+  const payloadToItemResponseMock = "payloadToItemResponse";
+  const itemToResponseResponseMock = "itemToResponseResponse";
+  const itemToResponseMock = vi.fn(() => TE.right(itemToResponseResponseMock));
+  const logErrorResponseMock = vi.fn((err) => err);
   return {
-    getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
-    getUser: vi.fn((_) => TE.right(anApimResource)),
-    upsertSubscription: vi.fn((_) => TE.right(anApimResource)),
+    validateServiceTopicRequest: vi.fn(() => TE.right(void 0)),
+    payloadToItemMock: vi.fn(() => payloadToItemResponseMock),
+    payloadToItemResponseMock,
+    itemToResponseWrapperMock: vi.fn(() => itemToResponseMock),
+    itemToResponseMock,
+    itemToResponseResponseMock,
+    logErrorResponseMock,
+    getLoggerMock: vi.fn(() => ({ logErrorResponse: logErrorResponseMock })),
   };
 });
 
-const serviceLifecycleStore =
-  stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
-  serviceLifecycleStore,
-);
+vi.mock("../../../utils/service-topic-validator", () => ({
+  validateServiceTopicRequest: vi.fn(() => validateServiceTopicRequest),
+}));
 
-const servicePublicationStore =
-  stores.createMemoryStore<ServicePublication.ItemType>();
-const fsmPublicationClient = ServicePublication.getFsmClient(
-  servicePublicationStore,
-);
+vi.mock("../../../utils/converters/service-lifecycle-converters", () => ({
+  itemToResponse: itemToResponseWrapperMock,
+  payloadToItem: payloadToItemMock,
+}));
+
+vi.mock("../../../utils/logger", () => ({
+  getLogger: getLoggerMock,
+}));
+
+const aNewService = {
+  name: "a service",
+  description: "a description",
+  organization: {
+    name: "org",
+    fiscal_code: "00000000000",
+  },
+  metadata: {
+    scope: "LOCAL",
+    topic_id: 1,
+  },
+  authorized_recipients: ["BBBBBB99C88D555I"],
+};
+const fsmLifecycleClientMock = { create: vi.fn(() => TE.right(aNewService)) };
+const fsmLifecycleClientCreatorMock = vi.fn(() => fsmLifecycleClientMock);
 
 const aManageSubscriptionId = "MANAGE-123";
 const anUserId = "123";
-const ownerId = `/an/owner/${anUserId}`;
 
-const anApimResource = { id: "any-id", name: "any-name" };
-const mockApimService = {
-  getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
-  getUser: vi.fn((_) => TE.right(anApimResource)),
-  upsertSubscription: vi.fn((_) => TE.right(anApimResource)),
-  getSubscription: vi.fn(() =>
-    TE.right({
-      _etag: "_etag",
-      ownerId: anUserId,
-    }),
+const apimServiceMock = {
+  upsertSubscription: vi.fn<any[], any>(() =>
+    TE.right({ id: "any-id", name: "any-name" }),
   ),
-} as unknown as ApimUtils.ApimService;
+};
 
 const mockConfig = {
   SANDBOX_FISCAL_CODE: "AAAAAA00A00A000A",
@@ -127,56 +125,31 @@ const mockAppinsights = {
   trackError: vi.fn(),
 } as any;
 
-const mockContext = {
-  log: {
-    error: vi.fn((_) => console.error(_)),
-    info: vi.fn((_) => console.info(_)),
-  },
-} as any;
+const mockContext = {} as any;
 
-const mockBlobService = {
-  createBlockBlobFromText: vi.fn((_, __, ___, cb) => cb(null, "any")),
-} as any;
-
-const mockServiceTopicDao = {
-  findAllNotDeletedTopics: vi.fn(() => TE.right([])),
-} as any;
-
-afterEach(() => {
-  vi.clearAllMocks();
+beforeEach(() => {
+  vi.restoreAllMocks();
 });
-describe("createService", () => {
-  validateServiceTopicRequest.mockReturnValue(() => TE.right(void 0));
 
+describe("createService", () => {
   const app = createWebServer({
     basePath: "api",
-    apimService: mockApimService,
+    apimService: apimServiceMock as unknown as ApimUtils.ApimService,
     config: mockConfig,
-    fsmLifecycleClientCreator,
-    fsmPublicationClient,
+    fsmLifecycleClientCreator: fsmLifecycleClientCreatorMock,
+    fsmPublicationClient: vi.fn(),
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
-    blobService: mockBlobService,
-    serviceTopicDao: mockServiceTopicDao,
+    blobService: vi.fn(),
+    serviceTopicDao: vi.fn(),
   } as unknown as WebServerDependencies);
 
   setAppContext(app, mockContext);
 
-  const aNewService = {
-    name: "a service",
-    description: "a description",
-    organization: {
-      name: "org",
-      fiscal_code: "00000000000",
-    },
-    metadata: {
-      scope: "LOCAL",
-      topic_id: 1,
-    },
-    authorized_recipients: ["BBBBBB99C88D555I"],
-  };
+  const logPrefix = "CreateServiceHandler";
 
   it("should not accept invalid payloads", async () => {
+    // when
     const response = await request(app)
       .post("/api/services")
       .send({})
@@ -185,10 +158,18 @@ describe("createService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
+    // then
     expect(response.statusCode).toBe(400);
+    expect(validateServiceTopicRequest).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientMock.create).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 
   it("should not allow the operation without right group", async () => {
+    // when
     const response = await request(app)
       .post("/api/services")
       .send({})
@@ -197,27 +178,54 @@ describe("createService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
+    // then
     expect(response.statusCode).toBe(403);
+    expect(validateServiceTopicRequest).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientMock.create).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 
   it("should create a draft service", async () => {
+    // given
+    const servicePayload = aNewService;
+
+    // when
     const response = await request(app)
       .post("/api/services")
-      .send(aNewService)
+      .send(servicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", UserGroup.ApiServiceWrite)
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
+    // then
     expect(response.statusCode).toBe(201);
-    expect(response.body.status.value).toBe("draft");
-    expect(mockContext.log.error).not.toHaveBeenCalled();
-    expect(response.body.id).toEqual(expect.any(String));
+    expect(validateServiceTopicRequest).toHaveBeenCalledOnce();
+    expect(payloadToItemMock).toHaveBeenCalledOnce();
+    expect(payloadToItemMock).toHaveBeenCalledWith(
+      expect.any(String),
+      { ...servicePayload, max_allowed_payment_amount: 0 },
+      mockConfig.SANDBOX_FISCAL_CODE,
+    );
+    expect(itemToResponseMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientMock.create).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientMock.create).toHaveBeenCalledWith(
+      expect.any(String),
+      { data: payloadToItemResponseMock },
+    );
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 
   it("should not allow the operation without manageKey", async () => {
+    // given
     const aNotManageSubscriptionId = "NOT-MANAGE-456";
 
+    // when
     const response = await request(app)
       .post("/api/services")
       .send(aNewService)
@@ -225,17 +233,23 @@ describe("createService", () => {
       .set("x-user-groups", UserGroup.ApiServiceWrite)
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aNotManageSubscriptionId);
-    expect(mockContext.log.error).not.toHaveBeenCalled();
+
+    // then
     expect(response.statusCode).toBe(403);
+    expect(validateServiceTopicRequest).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientMock.create).not.toHaveBeenCalled();
   });
 
   it("should fail when cannot create subscription", async () => {
-    vi.mocked(mockApimService.upsertSubscription).mockImplementation(() =>
-      TE.left({ statusCode: 500 }),
-    );
+    const error = { statusCode: 500 };
+    // given
+    apimServiceMock.upsertSubscription.mockReturnValueOnce(TE.left(error));
 
-    const spied = vi.spyOn(serviceLifecycleStore, "save");
-
+    // when
     const response = await request(app)
       .post("/api/services")
       .send(aNewService)
@@ -244,8 +258,14 @@ describe("createService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
+    // then
     expect(response.statusCode).toBe(500);
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
-    expect(spied).not.toHaveBeenCalled();
+    expect(validateServiceTopicRequest).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientMock.create).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/edit-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/edit-service.test.ts
@@ -45,7 +45,9 @@ vi.mock("../../../utils/service-topic-dao", () => ({
 
 const serviceLifecycleStore =
   stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
@@ -111,8 +113,9 @@ const mockAppinsights = {
 
 const mockContext = {
   log: {
-    error: vi.fn((_) => console.error(_)),
-    info: vi.fn((_) => console.info(_)),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
   },
 } as any;
 
@@ -135,7 +138,7 @@ describe("editService", () => {
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
@@ -205,7 +208,7 @@ describe("editService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(404);
   });
 
@@ -223,7 +226,7 @@ describe("editService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(409);
   });
 
@@ -270,7 +273,7 @@ describe("editService", () => {
       .set("x-user-id", aDifferentUserId)
       .set("x-subscription-id", aDifferentManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(403);
   });
   it("should not allow the operation without manageKey", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-service-keys.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-service-keys.test.ts
@@ -44,7 +44,9 @@ const anApimResource = {
 
 const serviceLifecycleStore =
   stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
@@ -128,8 +130,9 @@ const mockAppinsights = {
 
 const mockContext = {
   log: {
-    error: vi.fn((_) => console.error(_)),
-    info: vi.fn((_) => console.info(_)),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
   },
 } as any;
 
@@ -141,16 +144,16 @@ const mockServiceTopicDao = {
   findAllNotDeletedTopics: vi.fn(() => TE.right([])),
 } as any;
 
-describe("getServiceKeys", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
+describe("getServiceKeys", () => {
   const app = createWebServer({
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
@@ -170,7 +173,7 @@ describe("getServiceKeys", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(mockApimService.listSecrets).not.toHaveBeenCalled();
-    expect(mockContext.log.error).toHaveBeenCalled();
+    expect(mockContext.log.warn).toHaveBeenCalled();
     expect(response.statusCode).toBe(404);
   });
 
@@ -190,7 +193,7 @@ describe("getServiceKeys", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(mockApimService.listSecrets).not.toHaveBeenCalled();
-    expect(mockContext.log.error).toHaveBeenCalled();
+    expect(mockContext.log.warn).toHaveBeenCalled();
     expect(response.statusCode).toBe(404);
   });
 
@@ -234,7 +237,7 @@ describe("getServiceKeys", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(mockApimService.listSecrets).toHaveBeenCalled();
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(404);
   });
 
@@ -316,7 +319,7 @@ describe("getServiceKeys", () => {
       .set("x-subscription-id", aDifferentManageSubscriptionId);
 
     expect(mockApimService.listSecrets).not.toHaveBeenCalled();
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(403);
   });
 });

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-service-topics.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-service-topics.test.ts
@@ -47,7 +47,9 @@ vi.mock("../../../utils/service-topic-dao", () => ({
 
 const serviceLifecycleStore =
   stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
@@ -131,7 +133,7 @@ const mockWebServer = (mockServiceTopicDao: any) => {
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
@@ -144,11 +146,11 @@ const mockWebServer = (mockServiceTopicDao: any) => {
   return app;
 };
 
-describe("getServicePublication", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
+describe("getServiceTopics", () => {
   it("should retrieve the service topics list", async () => {
     const mockServiceTopicDao = {
       findAllNotDeletedTopics: vi.fn(() =>

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/get-services.test.ts
@@ -87,6 +87,7 @@ let mockFsmLifecycleClient = {
     bulkFetch: vi.fn(() => aBulkFetchRightValue),
   })),
 } as any;
+const mockFsmLifecycleClientCreator = vi.fn(() => mockFsmLifecycleClient);
 
 const mockFsmPublicationClient = {
   getStore: vi.fn(() => ({})),
@@ -154,7 +155,7 @@ describe("getServices", () => {
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient: mockFsmLifecycleClient,
+    fsmLifecycleClientCreator: mockFsmLifecycleClientCreator,
     fsmPublicationClient: mockFsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/regenerate-service-keys.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/regenerate-service-keys.test.ts
@@ -37,7 +37,7 @@ const anApimResource = {
 const fsmLifecycleClientMock = {};
 const fsmLifecycleClientCreatorMock = vi.fn(() => fsmLifecycleClientMock);
 
-const mockApimService = {
+const apimServiceMock = {
   regenerateSubscriptionKey: vi.fn<any[], any>((_) => TE.right(anApimResource)),
 };
 
@@ -137,7 +137,7 @@ beforeEach(() => {
 describe("regenerateSubscriptionKeys", () => {
   const app = createWebServer({
     basePath: "api",
-    apimService: mockApimService as unknown as ApimUtils.ApimService,
+    apimService: apimServiceMock as unknown as ApimUtils.ApimService,
     config: mockConfig,
     fsmLifecycleClientCreator: fsmLifecycleClientCreatorMock,
     fsmPublicationClient: vi.fn(),
@@ -170,7 +170,7 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
-      mockApimService,
+      apimServiceMock,
       serviceId,
       aManageSubscriptionId,
       userId,
@@ -183,8 +183,8 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(checkServiceMock).toHaveBeenCalledOnce();
     expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledWith(
       serviceId,
       keyType,
     );
@@ -216,7 +216,7 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
-      mockApimService,
+      apimServiceMock,
       serviceId,
       aManageSubscriptionId,
       userId,
@@ -229,8 +229,8 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(checkServiceMock).toHaveBeenCalledOnce();
     expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledWith(
       serviceId,
       keyType,
     );
@@ -261,7 +261,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(response.statusCode).toBe(404);
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
-      mockApimService,
+      apimServiceMock,
       serviceId,
       aManageSubscriptionId,
       userId,
@@ -274,7 +274,7 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(checkServiceMock).toHaveBeenCalledOnce();
     expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(apimServiceMock.regenerateSubscriptionKey).not.toHaveBeenCalled();
     expect(getLoggerMock).toHaveBeenCalledOnce();
     expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
     expect(logErrorResponseMock).toHaveBeenCalledOnce();
@@ -304,7 +304,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(fsmLifecycleClientCreatorMock).not.toHaveBeenCalled();
     expect(checkServiceDepsWrapperMock).not.toHaveBeenCalled();
     expect(checkServiceMock).not.toHaveBeenCalled();
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(apimServiceMock.regenerateSubscriptionKey).not.toHaveBeenCalled();
     expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
     expect(mapApimRestErrorMock).not.toHaveBeenCalled();
     expect(getLoggerMock).not.toHaveBeenCalled();
@@ -315,7 +315,7 @@ describe("regenerateSubscriptionKeys", () => {
     const serviceId = "aServiceId";
     const keyType = "primary";
     const apimServiceError = { statusCode: 404 };
-    mockApimService.regenerateSubscriptionKey.mockImplementationOnce(() =>
+    apimServiceMock.regenerateSubscriptionKey.mockImplementationOnce(() =>
       TE.left(apimServiceError),
     );
     const error = ResponseErrorNotFound("title", "detail");
@@ -332,7 +332,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(response.statusCode).toBe(404);
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
-      mockApimService,
+      apimServiceMock,
       serviceId,
       aManageSubscriptionId,
       userId,
@@ -345,8 +345,8 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(checkServiceMock).toHaveBeenCalledOnce();
     expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledWith(
       serviceId,
       keyType,
     );
@@ -368,7 +368,7 @@ describe("regenerateSubscriptionKeys", () => {
     const serviceId = "aServiceId";
     const keyType = "primary";
     const apimServiceError = { statusCode: 500 };
-    mockApimService.regenerateSubscriptionKey.mockImplementationOnce(() =>
+    apimServiceMock.regenerateSubscriptionKey.mockImplementationOnce(() =>
       TE.left(apimServiceError),
     );
     const error = ResponseErrorInternal("detail");
@@ -385,7 +385,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(response.statusCode).toBe(500);
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
-      mockApimService,
+      apimServiceMock,
       serviceId,
       aManageSubscriptionId,
       userId,
@@ -398,8 +398,8 @@ describe("regenerateSubscriptionKeys", () => {
     );
     expect(checkServiceMock).toHaveBeenCalledOnce();
     expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(apimServiceMock.regenerateSubscriptionKey).toHaveBeenCalledWith(
       serviceId,
       keyType,
     );
@@ -434,7 +434,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(response.statusCode).toBe(500);
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
-      mockApimService,
+      apimServiceMock,
       serviceId,
       aManageSubscriptionId,
       userId,
@@ -454,7 +454,7 @@ describe("regenerateSubscriptionKeys", () => {
       userSubscriptionId: aManageSubscriptionId,
     });
     expect(checkServiceMock).not.toHaveBeenCalled();
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(apimServiceMock.regenerateSubscriptionKey).not.toHaveBeenCalled();
     expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
     expect(mapApimRestErrorMock).not.toHaveBeenCalled();
   });
@@ -476,7 +476,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(fsmLifecycleClientCreatorMock).not.toHaveBeenCalled();
     expect(checkServiceDepsWrapperMock).not.toHaveBeenCalled();
     expect(checkServiceMock).not.toHaveBeenCalled();
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(apimServiceMock.regenerateSubscriptionKey).not.toHaveBeenCalled();
     expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
     expect(mapApimRestErrorMock).not.toHaveBeenCalled();
     expect(getLoggerMock).not.toHaveBeenCalled();
@@ -501,7 +501,7 @@ describe("regenerateSubscriptionKeys", () => {
     expect(fsmLifecycleClientCreatorMock).not.toHaveBeenCalled();
     expect(checkServiceDepsWrapperMock).not.toHaveBeenCalled();
     expect(checkServiceMock).not.toHaveBeenCalled();
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(apimServiceMock.regenerateSubscriptionKey).not.toHaveBeenCalled();
     expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
     expect(mapApimRestErrorMock).not.toHaveBeenCalled();
     expect(getLoggerMock).not.toHaveBeenCalled();

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/regenerate-service-keys.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/regenerate-service-keys.test.ts
@@ -1,33 +1,24 @@
 import { Container } from "@azure/cosmos";
 import { ApimUtils } from "@io-services-cms/external-clients";
 import {
-  ServiceLifecycle,
-  ServicePublication,
-  stores,
-} from "@io-services-cms/models";
-import {
   RetrievedSubscriptionCIDRs,
   SubscriptionCIDRsModel,
 } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
-import { UserGroup } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import {
+  ResponseErrorInternal,
+  ResponseErrorNotFound,
+} from "@pagopa/ts-commons/lib/responses";
 import {
   IPatternStringTag,
   NonEmptyString,
 } from "@pagopa/ts-commons/lib/strings";
-import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import request from "supertest";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IConfig } from "../../../config";
 import { WebServerDependencies, createWebServer } from "../../index";
-import { ResponseErrorNotFound } from "@pagopa/ts-commons/lib/responses";
 
-const apiBasePath = "/api/services/aServiceId/keys/";
-const apiDeletedServiceKeys = "/api/services/aDeletedServiceId/keys/";
-const apiFullPath = `${apiBasePath}primary`;
-const apiDeletedServiceKeysFullPath = `${apiDeletedServiceKeys}primary`;
 const aManageSubscriptionId = "MANAGE-123";
 const userId = "123";
 const ownerId = `/an/owner/${userId}`;
@@ -43,30 +34,12 @@ const anApimResource = {
   secondaryKey,
 };
 
-const serviceLifecycleStore =
-  stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
-  serviceLifecycleStore,
-);
-
-const servicePublicationStore =
-  stores.createMemoryStore<ServicePublication.ItemType>();
-const fsmPublicationClient = ServicePublication.getFsmClient(
-  servicePublicationStore,
-);
+const fsmLifecycleClientMock = {};
+const fsmLifecycleClientCreatorMock = vi.fn(() => fsmLifecycleClientMock);
 
 const mockApimService = {
-  getSubscription: vi.fn(() =>
-    TE.right({
-      _etag: "_etag",
-      ownerId,
-    }),
-  ),
-  getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
-  getUserByEmail: vi.fn((_) => TE.right(O.some(anApimResource))),
-  upsertSubscription: vi.fn((_) => TE.right(anApimResource)),
-  regenerateSubscriptionKey: vi.fn((_) => TE.right(anApimResource)),
-} as unknown as ApimUtils.ApimService;
+  regenerateSubscriptionKey: vi.fn<any[], any>((_) => TE.right(anApimResource)),
+};
 
 const mockConfig = {
   BACKOFFICE_INTERNAL_SUBNET_CIDRS: ["127.0.0.0/16"],
@@ -86,27 +59,6 @@ const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
   kind: "IRetrievedSubscriptionCIDRs",
   version: 0 as NonNegativeInteger,
 };
-
-const aServiceLifecycle = {
-  id: "aServiceId",
-  data: {
-    name: "aServiceName",
-    description: "aServiceDescription",
-    authorized_recipients: [],
-    max_allowed_payment_amount: 123,
-    metadata: {
-      address: "via tal dei tali 123",
-      email: "service@email.it",
-      pec: "service@pec.it",
-      scope: "LOCAL",
-    },
-    organization: {
-      name: "anOrganizationName",
-      fiscal_code: "12345678901",
-    },
-    require_secure_channel: false,
-  },
-} as unknown as ServiceLifecycle.ItemType;
 
 const mockFetchAll = vi.fn(() =>
   Promise.resolve({
@@ -132,67 +84,83 @@ const mockAppinsights = {
   trackError: vi.fn(),
 } as any;
 
-const mockContext = {
-  log: {
-    error: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn(),
-  },
-} as any;
+const mockContext = {} as any;
 
-const mockBlobService = {
-  createBlockBlobFromText: vi.fn((_, __, ___, cb) => cb(null, "any")),
-} as any;
+const {
+  serviceOwnerCheckManageTaskMock,
+  checkServiceMock,
+  checkServiceDepsWrapperMock,
+  mapApimRestErrorMock,
+  mapApimRestErrorWrapperMock,
+  logErrorResponseMock,
+  getLoggerMock,
+} = vi.hoisted(() => {
+  const checkServiceMock = vi.fn<any[], any>(() => TE.right(undefined));
+  const mapApimRestErrorMock = vi.fn();
+  const logErrorResponseMock = vi.fn((err) => err);
+  return {
+    serviceOwnerCheckManageTaskMock: vi.fn<any[], any>((_, serviceId) =>
+      TE.right(serviceId),
+    ),
+    checkServiceMock,
+    checkServiceDepsWrapperMock: vi.fn(() => checkServiceMock),
+    mapApimRestErrorMock,
+    mapApimRestErrorWrapperMock: vi.fn(() => mapApimRestErrorMock),
+    logErrorResponseMock,
+    getLoggerMock: vi.fn(() => ({ logErrorResponse: logErrorResponseMock })),
+  };
+});
 
-const mockServiceTopicDao = {
-  findAllNotDeletedTopics: vi.fn(() => TE.right([])),
-} as any;
-
-const { checkServiceMock } = vi.hoisted(() => ({
-  checkServiceMock: vi.fn<any[], any>(() => TE.right(undefined)),
+vi.mock("../../../utils/subscription", () => ({
+  serviceOwnerCheckManageTask: serviceOwnerCheckManageTaskMock,
 }));
 
 vi.mock("../../../utils/check-service", () => ({
-  checkService: vi.fn(() => checkServiceMock),
+  checkService: checkServiceDepsWrapperMock,
 }));
 
-afterEach(() => {
+vi.mock("../../../utils/logger", () => ({
+  getLogger: getLoggerMock,
+}));
+
+vi.mock("@io-services-cms/external-clients", async (importOriginal) => {
+  const { ApimUtils } = (await importOriginal()) as any;
+  return {
+    ApimUtils: { ...ApimUtils, mapApimRestError: mapApimRestErrorWrapperMock },
+  };
+});
+
+beforeEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("regenerateSubscriptionKeys", () => {
   const app = createWebServer({
     basePath: "api",
-    apimService: mockApimService,
+    apimService: mockApimService as unknown as ApimUtils.ApimService,
     config: mockConfig,
-    fsmLifecycleClientCreator,
-    fsmPublicationClient,
+    fsmLifecycleClientCreator: fsmLifecycleClientCreatorMock,
+    fsmPublicationClient: vi.fn(),
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
-    blobService: mockBlobService,
-    serviceTopicDao: mockServiceTopicDao,
+    blobService: vi.fn(),
+    serviceTopicDao: vi.fn(),
   } as unknown as WebServerDependencies);
-
-  setAppContext(app, mockContext);
-
+  app.set("context", mockContext);
+  const logPrefix = "RegenerateServiceKeysHandler";
   it("should regenerate primary key", async () => {
-    await serviceLifecycleStore.save("aServiceId", {
-      ...aServiceLifecycle,
-      id: "s1" as NonEmptyString,
-      fsm: { state: "draft" },
-    })();
-
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
+    // when
     const response = await request(app)
-      .put(apiFullPath)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
       .send()
       .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-groups", "ApiServiceWrite")
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalled();
-    expect(mockContext.log.error).not.toHaveBeenCalled();
-    expect(mockApimService.getSubscription).toHaveBeenCalledTimes(1);
+    // then
     expect(response.statusCode).toBe(200);
     expect(JSON.stringify(response.body)).toBe(
       JSON.stringify({
@@ -200,26 +168,45 @@ describe("regenerateSubscriptionKeys", () => {
         secondary_key: secondaryKey,
       }),
     );
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      userId,
+    );
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledWith([]);
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledOnce();
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledWith(
+      fsmLifecycleClientMock,
+    );
+    expect(checkServiceMock).toHaveBeenCalledOnce();
+    expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+      serviceId,
+      keyType,
+    );
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledOnce();
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledWith(serviceId);
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
   });
-
   it("should regenerate secondary key", async () => {
-    await serviceLifecycleStore.save("aServiceId", {
-      ...aServiceLifecycle,
-      id: "s1" as NonEmptyString,
-      fsm: { state: "draft" },
-    })();
-
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "secondary";
+    // when
     const response = await request(app)
-      .put(`${apiBasePath}secondary`)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
       .send()
       .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-groups", "ApiServiceWrite")
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalled();
-    expect(mockContext.log.error).not.toHaveBeenCalled();
-    expect(mockApimService.getSubscription).toHaveBeenCalledTimes(1);
+    // then
     expect(response.statusCode).toBe(200);
     expect(JSON.stringify(response.body)).toBe(
       JSON.stringify({
@@ -227,148 +214,297 @@ describe("regenerateSubscriptionKeys", () => {
         secondary_key: secondaryKey,
       }),
     );
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      userId,
+    );
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledWith([]);
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledOnce();
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledWith(
+      fsmLifecycleClientMock,
+    );
+    expect(checkServiceMock).toHaveBeenCalledOnce();
+    expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+      serviceId,
+      keyType,
+    );
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledOnce();
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledWith(serviceId);
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
   });
-
   it("should return 404 when service is deleted", async () => {
-    checkServiceMock.mockReturnValueOnce(
-      TE.left(
-        ResponseErrorNotFound(
-          "Not found",
-          `no item with id ${"aDeletedServiceId"} found`,
-        ),
-      ),
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
+    const error = ResponseErrorNotFound(
+      "Not found",
+      `no item with id ${serviceId} found`,
     );
-
+    checkServiceMock.mockReturnValueOnce(TE.left(error));
+    // when
     const response = await request(app)
-      .put(apiDeletedServiceKeysFullPath)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
       .send()
       .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-groups", "ApiServiceWrite")
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
-    expect(mockContext.log.warn).toHaveBeenCalled();
+    // then
     expect(response.statusCode).toBe(404);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      userId,
+    );
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledWith([]);
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledOnce();
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledWith(
+      fsmLifecycleClientMock,
+    );
+    expect(checkServiceMock).toHaveBeenCalledOnce();
+    expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
+    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(error, {
+      keyType,
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+    expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
   });
-
   it("should fail with a bad request response when use a wrong keyType path param", async () => {
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "aWrongKeyType";
+    // when
     const response = await request(app)
-      .put(`${apiBasePath}aWrongKeyType`)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
       .send()
       .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-groups", "ApiServiceWrite")
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
-    expect(mockApimService.getSubscription).not.toHaveBeenCalled();
+    // then
     expect(response.statusCode).toBe(400);
-  });
-
-  it("should fail with a not found error when cannot find requested service subscription", async () => {
-    vi.mocked(mockApimService.regenerateSubscriptionKey).mockImplementationOnce(
-      () => TE.left({ statusCode: 404 }),
-    );
-
-    const response = await request(app)
-      .put(apiFullPath)
-      .send()
-      .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
-      .set("x-user-id", userId)
-      .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.getSubscription).toHaveBeenCalledTimes(1);
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalled();
-    expect(mockContext.log.warn).toHaveBeenCalledOnce();
-    expect(response.statusCode).toBe(404);
-  });
-
-  it("should fail with a generic error if regenerate key returns an error", async () => {
-    vi.mocked(mockApimService.regenerateSubscriptionKey).mockImplementationOnce(
-      () => TE.left({ statusCode: 500 }),
-    );
-
-    const response = await request(app)
-      .put(apiFullPath)
-      .send()
-      .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
-      .set("x-user-id", userId)
-      .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.getSubscription).toHaveBeenCalledTimes(1);
-    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalled();
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
-    expect(response.statusCode).toBe(500);
-  });
-
-  it("should fail with a generic error if manage subscription returns an error", async () => {
-    // first getSubscription for manage key middleware
-    vi.mocked(mockApimService.getSubscription).mockImplementationOnce(() =>
-      TE.left({ statusCode: 500 }),
-    );
-
-    const response = await request(app)
-      .put(apiFullPath)
-      .send()
-      .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
-      .set("x-user-id", userId)
-      .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.getSubscription).toHaveBeenCalledTimes(1);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientCreatorMock).not.toHaveBeenCalled();
+    expect(checkServiceDepsWrapperMock).not.toHaveBeenCalled();
+    expect(checkServiceMock).not.toHaveBeenCalled();
     expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
-    expect(response.statusCode).toBe(500);
+    expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
-
-  it("should not allow the operation without right group", async () => {
+  it("should fail with a not found error when cannot find requested service subscription", async () => {
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
+    const apimServiceError = { statusCode: 404 };
+    mockApimService.regenerateSubscriptionKey.mockImplementationOnce(() =>
+      TE.left(apimServiceError),
+    );
+    const error = ResponseErrorNotFound("title", "detail");
+    mapApimRestErrorMock.mockReturnValueOnce(error);
+    // when
     const response = await request(app)
-      .put(apiFullPath)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
+      .send()
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", "ApiServiceWrite")
+      .set("x-user-id", userId)
+      .set("x-subscription-id", aManageSubscriptionId);
+    // then
+    expect(response.statusCode).toBe(404);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      userId,
+    );
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledWith([]);
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledOnce();
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledWith(
+      fsmLifecycleClientMock,
+    );
+    expect(checkServiceMock).toHaveBeenCalledOnce();
+    expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+      serviceId,
+      keyType,
+    );
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledOnce();
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledWith(serviceId);
+    expect(mapApimRestErrorMock).toHaveBeenCalledOnce();
+    expect(mapApimRestErrorMock).toHaveBeenCalledWith(apimServiceError);
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(error, {
+      keyType,
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+  });
+  it("should fail with a generic error if regenerate key returns an error", async () => {
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
+    const apimServiceError = { statusCode: 500 };
+    mockApimService.regenerateSubscriptionKey.mockImplementationOnce(() =>
+      TE.left(apimServiceError),
+    );
+    const error = ResponseErrorInternal("detail");
+    mapApimRestErrorMock.mockReturnValueOnce(error);
+    // when
+    const response = await request(app)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
+      .send()
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", "ApiServiceWrite")
+      .set("x-user-id", userId)
+      .set("x-subscription-id", aManageSubscriptionId);
+    // then
+    expect(response.statusCode).toBe(500);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      userId,
+    );
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledWith([]);
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledOnce();
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledWith(
+      fsmLifecycleClientMock,
+    );
+    expect(checkServiceMock).toHaveBeenCalledOnce();
+    expect(checkServiceMock).toHaveBeenCalledWith(serviceId);
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledOnce();
+    expect(mockApimService.regenerateSubscriptionKey).toHaveBeenCalledWith(
+      serviceId,
+      keyType,
+    );
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledOnce();
+    expect(mapApimRestErrorWrapperMock).toHaveBeenCalledWith(serviceId);
+    expect(mapApimRestErrorMock).toHaveBeenCalledOnce();
+    expect(mapApimRestErrorMock).toHaveBeenCalledWith(apimServiceError);
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(error, {
+      keyType,
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+  });
+  it("should fail with a generic error if manage subscription returns an error", async () => {
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
+    const error = ResponseErrorInternal("detail");
+    serviceOwnerCheckManageTaskMock.mockReturnValueOnce(TE.left(error));
+    // when
+    const response = await request(app)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
+      .send()
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", "ApiServiceWrite")
+      .set("x-user-id", userId)
+      .set("x-subscription-id", aManageSubscriptionId);
+    // then
+    expect(response.statusCode).toBe(500);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      userId,
+    );
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledOnce();
+    expect(fsmLifecycleClientCreatorMock).toHaveBeenCalledWith([]);
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledOnce();
+    expect(checkServiceDepsWrapperMock).toHaveBeenCalledWith(
+      fsmLifecycleClientMock,
+    );
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(error, {
+      keyType,
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+    expect(checkServiceMock).not.toHaveBeenCalled();
+    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
+  });
+  it("should not allow the operation without right group", async () => {
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
+    // when
+    const response = await request(app)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
       .send()
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", "OtherGroup")
       .set("x-user-id", userId)
       .set("x-subscription-id", aManageSubscriptionId);
-
-    expect(mockApimService.getSubscription).not.toHaveBeenCalled();
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    // then
     expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientCreatorMock).not.toHaveBeenCalled();
+    expect(checkServiceDepsWrapperMock).not.toHaveBeenCalled();
+    expect(checkServiceMock).not.toHaveBeenCalled();
+    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
-
   it("should not allow the operation without manageKey", async () => {
+    // given
+    const serviceId = "aServiceId";
+    const keyType = "primary";
     const aNotManageSubscriptionId = "NOT-MANAGE-123";
-
+    // when
     const response = await request(app)
-      .put(apiFullPath)
+      .put(`/api/services/${serviceId}/keys/${keyType}`)
       .send()
       .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-groups", "ApiServiceWrite")
       .set("x-user-id", userId)
       .set("x-subscription-id", aNotManageSubscriptionId);
-
-    expect(mockApimService.getSubscription).not.toHaveBeenCalled();
-    expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
+    // then
     expect(response.statusCode).toBe(403);
-  });
-
-  it("should not allow the operation without right userId", async () => {
-    const aDifferentManageSubscriptionId = "MANAGE-456";
-    const aDifferentUserId = "456";
-
-    const response = await request(app)
-      .put(apiFullPath)
-      .send()
-      .set("x-user-email", "example@email.com")
-      .set("x-user-groups", UserGroup.ApiServiceWrite)
-      .set("x-user-id", aDifferentUserId)
-      .set("x-subscription-id", aDifferentManageSubscriptionId);
-
-    expect(mockApimService.getSubscription).toHaveBeenCalledTimes(1);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientCreatorMock).not.toHaveBeenCalled();
+    expect(checkServiceDepsWrapperMock).not.toHaveBeenCalled();
+    expect(checkServiceMock).not.toHaveBeenCalled();
     expect(mockApimService.regenerateSubscriptionKey).not.toHaveBeenCalled();
-    expect(mockContext.log.warn).toHaveBeenCalledOnce();
-    expect(response.statusCode).toBe(403);
+    expect(mapApimRestErrorWrapperMock).not.toHaveBeenCalled();
+    expect(mapApimRestErrorMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/unpublish-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/unpublish-service.test.ts
@@ -25,12 +25,14 @@ import { WebServerDependencies, createWebServer } from "../../index";
 
 const serviceLifecycleStore =
   stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
 const fsmPublicationClient = ServicePublication.getFsmClient(
-  servicePublicationStore
+  servicePublicationStore,
 );
 
 const aManageSubscriptionId = "MANAGE-123";
@@ -43,7 +45,7 @@ const mockApimService = {
     TE.right({
       _etag: "_etag",
       ownerId,
-    })
+    }),
   ),
   getProductByName: vi.fn((_) => TE.right(O.some(anApimResource))),
   getUserByEmail: vi.fn((_) => TE.right(O.some(anApimResource))),
@@ -94,7 +96,7 @@ const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
 const mockFetchAll = vi.fn(() =>
   Promise.resolve({
     resources: [aRetrievedSubscriptionCIDRs],
-  })
+  }),
 );
 const containerMock = {
   items: {
@@ -117,8 +119,9 @@ const mockAppinsights = {
 
 const mockContext = {
   log: {
-    error: vi.fn((_) => console.error(_)),
-    info: vi.fn((_) => console.info(_)),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
   },
 } as any;
 
@@ -130,16 +133,24 @@ const mockServiceTopicDao = {
   findAllNotDeletedTopics: vi.fn(() => TE.right([])),
 } as any;
 
-describe("UnPublishService", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+const { checkServiceMock } = vi.hoisted(() => ({
+  checkServiceMock: vi.fn(() => TE.right(undefined)),
+}));
 
+vi.mock("../../../utils/check-service", () => ({
+  checkService: vi.fn(() => checkServiceMock),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("UnPublishService", () => {
   const app = createWebServer({
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
@@ -159,7 +170,7 @@ describe("UnPublishService", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     console.log(response.body);
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(404);
   });
 
@@ -222,7 +233,7 @@ describe("UnPublishService", () => {
       .set("x-user-id", aDifferentUserId)
       .set("x-subscription-id", aDifferentManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(403);
   });
   it("should not allow the operation without manageKey", async () => {

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/upload-service-logo.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/upload-service-logo.test.ts
@@ -16,7 +16,6 @@ import {
   IPatternStringTag,
   NonEmptyString,
 } from "@pagopa/ts-commons/lib/strings";
-import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -25,12 +24,14 @@ import { WebServerDependencies, createWebServer } from "../../index";
 
 const serviceLifecycleStore =
   stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClient = ServiceLifecycle.getFsmClient(serviceLifecycleStore);
+const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
+  serviceLifecycleStore,
+);
 
 const servicePublicationStore =
   stores.createMemoryStore<ServicePublication.ItemType>();
 const fsmPublicationClient = ServicePublication.getFsmClient(
-  servicePublicationStore
+  servicePublicationStore,
 );
 
 const aManageSubscriptionId = "MANAGE-123";
@@ -42,7 +43,7 @@ const mockApimService = {
     TE.right({
       _etag: "_etag",
       ownerId: anUserId,
-    })
+    }),
   ),
 } as unknown as ApimUtils.ApimService;
 
@@ -68,7 +69,7 @@ const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
 const mockFetchAll = vi.fn(() =>
   Promise.resolve({
     resources: [aRetrievedSubscriptionCIDRs],
-  })
+  }),
 );
 const containerMock = {
   items: {
@@ -91,8 +92,9 @@ const mockAppinsights = {
 
 const mockContext = {
   log: {
-    error: vi.fn((_) => console.error(_)),
-    info: vi.fn((_) => console.info(_)),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
   },
 } as any;
 
@@ -112,16 +114,24 @@ const anInvalidLogoPayload = {
   logo: "invalidBase64=",
 };
 
-describe("uploadServiceLogo", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+const { checkServiceMock } = vi.hoisted(() => ({
+  checkServiceMock: vi.fn(() => TE.right(undefined)),
+}));
 
+vi.mock("../../../utils/check-service", () => ({
+  checkService: vi.fn(() => checkServiceMock),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("uploadServiceLogo", () => {
   const app = createWebServer({
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     fsmPublicationClient,
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
@@ -140,10 +150,10 @@ describe("uploadServiceLogo", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalled();
     expect(response.statusCode).toBe(400);
     expect(response.body.detail).toBe(
-      "Fail decoding provided image, the reason is: The input is not a PNG file!"
+      "Fail decoding provided image, the reason is: The input is not a PNG file!",
     );
     expect(response.body.status).toBe(400);
     expect(response.body.title).toBe("Image not valid");
@@ -173,7 +183,7 @@ describe("uploadServiceLogo", () => {
       .set("x-user-id", aDifferentUserId)
       .set("x-subscription-id", aDifferentManageSubscriptionId);
 
-    expect(mockContext.log.error).toHaveBeenCalledOnce();
+    expect(mockContext.log.warn).toHaveBeenCalledOnce();
     expect(response.statusCode).toBe(403);
   });
   it("should not allow the operation without manageKey", async () => {
@@ -203,7 +213,7 @@ describe("uploadServiceLogo", () => {
     mockFetchAll.mockImplementationOnce(() =>
       Promise.resolve({
         resources: [aNewRetrievedSubscriptionCIDRs],
-      })
+      }),
     );
 
     const response = await request(app)
@@ -230,7 +240,7 @@ describe("uploadServiceLogo", () => {
     mockFetchAll.mockImplementationOnce(() =>
       Promise.resolve({
         resources: [aNewRetrievedSubscriptionCIDRs],
-      })
+      }),
     );
 
     const response = await request(app)
@@ -257,7 +267,7 @@ describe("uploadServiceLogo", () => {
     mockFetchAll.mockImplementationOnce(() =>
       Promise.resolve({
         resources: [aNewRetrievedSubscriptionCIDRs],
-      })
+      }),
     );
 
     const response = await request(app)
@@ -287,7 +297,7 @@ describe("uploadServiceLogo", () => {
     mockFetchAll.mockImplementationOnce(() =>
       Promise.resolve({
         resources: [aNewRetrievedSubscriptionCIDRs],
-      })
+      }),
     );
 
     const response = await request(app)
@@ -304,7 +314,7 @@ describe("uploadServiceLogo", () => {
 
   it("should return an internal error response if blob write fails", async () => {
     mockBlobService.createBlockBlobFromText.mockImplementationOnce(
-      (_, __, ___, cb) => cb(new Error("any"), null)
+      (_, __, ___, cb) => cb(new Error("any"), null),
     );
 
     const response = await request(app)

--- a/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
@@ -91,24 +91,6 @@ const createSubscription = (
     ),
   );
 
-const createServiceStep =
-  (config: IConfig, fsmLifecycleClient: ServiceLifecycle.FsmClient) =>
-  (serviceId: NonEmptyString, servicePayload: ServiceRequestPayload) =>
-    pipe(
-      fsmLifecycleClient.create(serviceId, {
-        data: payloadToItem(
-          serviceId,
-          servicePayload,
-          config.SANDBOX_FISCAL_CODE,
-        ),
-      }),
-      TE.mapLeft((err) => ResponseErrorInternal(err.message)),
-      TE.chain(itemToResponse(config)),
-      TE.map((result) =>
-        ResponseJsonWithStatus(result, HttpStatusCodeEnum.HTTP_STATUS_201),
-      ),
-    );
-
 export const makeCreateServiceHandler =
   ({
     apimService,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-lifecycle-internal.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-lifecycle-internal.ts
@@ -56,7 +56,7 @@ export const makeGetServiceLifecycleInternalHandler =
   (context, auth, serviceId) =>
     pipe(
       genericServiceRetrieveHandler(
-        fsmLifecycleClient.getStore(),
+        fsmLifecycleClient.fetch,
         apimService,
         telemetryClient,
         itemToResponse(config),

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-lifecycle.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-lifecycle.ts
@@ -54,7 +54,7 @@ type GetServiceLifecycleHandler = (
 interface Dependencies {
   apimService: ApimUtils.ApimService;
   config: IConfig;
-  fsmLifecycleClient: ServiceLifecycle.FsmClient;
+  fsmLifecycleClientCreator: ServiceLifecycle.FsmClientCreator;
   telemetryClient: TelemetryClient;
 }
 
@@ -62,13 +62,13 @@ export const makeGetServiceLifecycleHandler =
   ({
     apimService,
     config,
-    fsmLifecycleClient,
+    fsmLifecycleClientCreator,
     telemetryClient,
   }: Dependencies): GetServiceLifecycleHandler =>
   (context, auth, __, ___, serviceId, authzGroupIds) =>
     pipe(
       genericServiceRetrieveHandler(
-        fsmLifecycleClient.getStore(),
+        fsmLifecycleClientCreator(authzGroupIds).fetch,
         apimService,
         telemetryClient,
         itemToResponse(config),

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-publication-internal.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-publication-internal.ts
@@ -55,7 +55,7 @@ export const makeGetServicePublicationInternalHandler =
   (context, auth, serviceId) =>
     pipe(
       genericServiceRetrieveHandler(
-        fsmPublicationClient.getStore(),
+        fsmPublicationClient.fetch,
         apimService,
         telemetryClient,
         itemToResponse(config),

--- a/apps/io-services-cms-webapp/src/webservice/controllers/get-service-publication.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/get-service-publication.ts
@@ -35,7 +35,7 @@ import { AzureUserAttributesManageMiddlewareWrapper } from "../../utils/azure-us
 import { checkService } from "../../utils/check-service";
 import { itemToResponse } from "../../utils/converters/service-publication-converters";
 import { genericServiceRetrieveHandler } from "../../utils/generic-service-retrieve";
-import { ErrorResponseTypes } from "../../utils/logger";
+import { ErrorResponseTypes, getLogger } from "../../utils/logger";
 
 const logPrefix = "GetServicePublicationHandler";
 
@@ -72,6 +72,12 @@ export const makeGetServicePublicationHandler =
     pipe(
       serviceId,
       checkService(fsmLifecycleClientCreator(authzGroupIds)),
+      TE.mapLeft((err) =>
+        getLogger(context, logPrefix).logErrorResponse(err, {
+          serviceId,
+          userSubscriptionId: auth.subscriptionId,
+        }),
+      ),
       TE.chain((_) =>
         genericServiceRetrieveHandler(
           fsmPublicationClient.fetch,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/publish-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/publish-service.ts
@@ -104,7 +104,6 @@ export const makePublishServiceHandler =
         auth.subscriptionId,
         auth.userId,
       ),
-      (Z) => Z,
       TE.tap(checkService(fsmLifecycleClientCreator(authzGroupIds))),
       TE.chainW(retrieveServicePublicationTask(fsmPublicationClient)),
       TE.chainW(

--- a/apps/io-services-cms-webapp/src/webservice/index.ts
+++ b/apps/io-services-cms-webapp/src/webservice/index.ts
@@ -94,7 +94,7 @@ export interface WebServerDependencies {
   basePath: string;
   blobService: BlobService;
   config: IConfig;
-  fsmLifecycleClient: ServiceLifecycle.FsmClient;
+  fsmLifecycleClientCreator: ServiceLifecycle.FsmClientCreator;
   fsmPublicationClient: ServicePublication.FsmClient;
   serviceHistoryPagedHelper: CosmosPagedHelper<ServiceHistory>;
   serviceLifecycleCosmosHelper: CosmosHelper;
@@ -110,7 +110,7 @@ export const createWebServer = ({
   basePath,
   blobService,
   config,
-  fsmLifecycleClient,
+  fsmLifecycleClientCreator,
   fsmPublicationClient,
   serviceHistoryPagedHelper,
   serviceLifecycleCosmosHelper,
@@ -131,7 +131,7 @@ export const createWebServer = ({
       makeCreateServiceHandler({
         apimService,
         config,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyCreateServiceRequestMiddelwares(config, subscriptionCIDRsModel),
@@ -144,7 +144,7 @@ export const createWebServer = ({
       makeGetServicesHandler({
         apimService,
         config,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyGetServicesRequestMiddelwares(config, subscriptionCIDRsModel),
@@ -181,7 +181,7 @@ export const createWebServer = ({
       makeGetServiceLifecycleInternalHandler({
         apimService,
         config,
-        fsmLifecycleClient,
+        fsmLifecycleClient: fsmLifecycleClientCreator(),
         telemetryClient,
       }),
       applyGetServiceLifecycleInternalRequestMiddelwares,
@@ -194,7 +194,7 @@ export const createWebServer = ({
       makeGetServiceLifecycleHandler({
         apimService,
         config,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyGetServiceLifecycleRequestMiddelwares(
@@ -210,7 +210,7 @@ export const createWebServer = ({
       makeEditServiceHandler({
         apimService,
         config,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyEditServiceRequestMiddelwares(config, subscriptionCIDRsModel),
@@ -222,7 +222,7 @@ export const createWebServer = ({
     pipe(
       makeDeleteServiceHandler({
         apimService,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyDeleteServiceRequestMiddelwares(config, subscriptionCIDRsModel),
@@ -235,6 +235,7 @@ export const createWebServer = ({
       makeGetServiceHistoryHandler({
         apimService,
         config,
+        fsmLifecycleClientCreator,
         serviceHistoryPagedHelper,
         telemetryClient,
       }),
@@ -247,7 +248,7 @@ export const createWebServer = ({
     pipe(
       makeReviewServiceHandler({
         apimService,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyReviewServiceRequestMiddelwares(config, subscriptionCIDRsModel),
@@ -259,6 +260,7 @@ export const createWebServer = ({
     pipe(
       makePublishServiceHandler({
         apimService,
+        fsmLifecycleClientCreator,
         fsmPublicationClient,
         telemetryClient,
       }),
@@ -272,7 +274,7 @@ export const createWebServer = ({
       makeGetServicePublicationHandler({
         apimService,
         config,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         fsmPublicationClient,
         telemetryClient,
       }),
@@ -301,6 +303,7 @@ export const createWebServer = ({
     pipe(
       makeUnpublishServiceHandler({
         apimService,
+        fsmLifecycleClientCreator,
         fsmPublicationClient,
         telemetryClient,
       }),
@@ -313,7 +316,7 @@ export const createWebServer = ({
     pipe(
       makeGetServiceKeysHandler({
         apimService,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyGetServiceKeysRequestMiddelwares(config, subscriptionCIDRsModel),
@@ -325,7 +328,7 @@ export const createWebServer = ({
     pipe(
       makeRegenerateServiceKeysHandler({
         apimService,
-        fsmLifecycleClient,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyRegenerateServiceKeysRequestMiddelwares(
@@ -341,6 +344,7 @@ export const createWebServer = ({
       makeUploadServiceLogoHandler({
         apimService,
         blobService,
+        fsmLifecycleClientCreator,
         telemetryClient,
       }),
       applyUploadServiceLogoRequestMiddelwares(config, subscriptionCIDRsModel),

--- a/packages/io-services-cms-models/src/index.ts
+++ b/packages/io-services-cms-models/src/index.ts
@@ -1,5 +1,6 @@
 export {
   FSMStore,
+  FsmAuthorizationError,
   FsmItemNotFoundError,
   FsmNoApplicableTransitionError,
   FsmNoTransitionMatchedError,

--- a/packages/io-services-cms-models/src/lib/fsm/types.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/types.ts
@@ -156,3 +156,11 @@ export class FsmItemValidationError extends Error {
     this.name = "FsmItemValidationError";
   }
 }
+
+export class FsmAuthorizationError extends Error {
+  public kind = "AuthorizationError";
+  constructor() {
+    super("Unauthorized access");
+    this.name = "AuthorizationError";
+  }
+}

--- a/packages/io-services-cms-models/src/service-lifecycle/index.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/index.ts
@@ -4,6 +4,7 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/Either";
 import * as O from "fp-ts/Option";
 import * as RA from "fp-ts/ReadonlyArray";
+import * as RNEA from "fp-ts/ReadonlyNonEmptyArray";
 import * as TE from "fp-ts/TaskEither";
 import * as B from "fp-ts/boolean";
 import { flow, pipe } from "fp-ts/function";
@@ -13,6 +14,7 @@ import * as t from "io-ts";
 import {
   EmptyState,
   FSMStore,
+  FsmAuthorizationError,
   FsmItemNotFoundError,
   FsmItemValidationError,
   FsmNoApplicableTransitionError,
@@ -38,7 +40,8 @@ type ToRecord<Q> = Q extends []
 // commodity aliases
 type AllStateNames = keyof FSM["states"];
 type AllResults = States[number];
-export type AllFsmErrors =
+type AllFsmErrors =
+  | FsmAuthorizationError
   | FsmItemNotFoundError
   | FsmNoApplicableTransitionError
   | FsmNoTransitionMatchedError
@@ -88,6 +91,20 @@ interface FSM {
     Transition<Action<"edit">, State<"approved">, State<"draft">>,
   ];
 }
+
+const authorize =
+  (authzGroupIds: readonly NonEmptyString[]) =>
+  <T extends Service>(current: T): E.Either<FsmAuthorizationError, T> =>
+    pipe(
+      current,
+      E.fromPredicate(
+        (item) =>
+          RA.isEmpty(authzGroupIds) ||
+          (!!item.data.metadata.group_id &&
+            authzGroupIds.includes(item.data.metadata.group_id)),
+        () => new FsmAuthorizationError(),
+      ),
+    );
 
 // implementation
 /**
@@ -283,11 +300,13 @@ type LifecycleStore = FSMStore<States[number]>;
 function apply(
   appliedAction: "create" | "edit",
   id: ServiceId,
+  authzGroupIds: readonly NonEmptyString[],
   args: { data: Service },
 ): ReaderTaskEither<LifecycleStore, AllFsmErrors, WithState<"draft", Service>>;
 function apply(
   appliedAction: "submit",
   id: ServiceId,
+  authzGroupIds: readonly NonEmptyString[],
   args: { autoPublish: boolean },
 ): ReaderTaskEither<
   LifecycleStore,
@@ -297,6 +316,7 @@ function apply(
 function apply(
   appliedAction: "approve",
   id: ServiceId,
+  authzGroupIds: readonly NonEmptyString[],
   args: { approvalDate: string },
 ): ReaderTaskEither<
   LifecycleStore,
@@ -306,6 +326,7 @@ function apply(
 function apply(
   appliedAction: "reject",
   id: ServiceId,
+  authzGroupIds: readonly NonEmptyString[],
   args: { reason: string },
 ): ReaderTaskEither<
   LifecycleStore,
@@ -315,6 +336,7 @@ function apply(
 function apply(
   appliedAction: "delete",
   id: ServiceId,
+  authzGroupIds: readonly NonEmptyString[],
 ): ReaderTaskEither<
   LifecycleStore,
   AllFsmErrors,
@@ -323,113 +345,132 @@ function apply(
 function apply(
   appliedAction: FSM["transitions"][number]["action"],
   id: ServiceId,
+  authzGroupIds: readonly NonEmptyString[],
   args?: Parameters<FSM["transitions"][number]["exec"]>[number]["args"],
 ): ReaderTaskEither<LifecycleStore, AllFsmErrors, AllResults> {
-  return (store) => {
-    // check transitions for the action to apply
-    const applicableTransitions = FSM.transitions.filter(
-      ({ action }) => action === appliedAction,
-    );
-    if (!applicableTransitions.length) {
-      return TE.left(new FsmNoApplicableTransitionError(appliedAction));
-    }
-    return pipe(
-      // fetch the item from the store by its id
-      store.fetch(id),
-      TE.mapLeft((_) => new FsmStoreFetchError()),
-      // filter transitions that can be applied to the current item status
-      TE.chain(
-        flow(
-          // We can either find the element in the store or not
-          //   we have a O.Some(item) or a O.none respectively
-          //
-          // These two scenarios differ on how they match applicable transitions:
-          //    + on found item -> we must select transitions which have as "from" state
-          //                         the very same value of the one in the item.
-          //                       We also must decode the incoming item in order to provide
-          //                         the value to the exec() function.
-          //    + on no item    -> we must match only transitions starting from the empty state
-          O.fold(
-            () =>
-              pipe(
-                applicableTransitions,
-                // this filter is also a type guard to narrow possible from states to EmptyState only
-                RA.filter(
-                  <T extends FSM["transitions"][number]>(
-                    tr: T,
-                  ): tr is { from: "*" } & T => tr.from === EmptyState,
-                ),
-                E.fromPredicate(
-                  // we must have matched at least ONE transition
-                  (matchedTransitions) => matchedTransitions.length > 0,
-                  (_) => new FsmItemNotFoundError(id),
-                ),
-                // bind all data into a lazy implementation of exec
-                E.map(
-                  RA.map(
-                    (tr) =>
-                      (): E.Either<
-                        FsmTransitionExecutionError,
-                        { hasChanges: boolean } & AllResults
-                      > =>
-                        // FIXME: avoid this forcing
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore
-                        tr.exec({ args }),
-                  ),
-                ),
-                TE.fromEither,
-              ),
-            (item) =>
-              pipe(
-                applicableTransitions,
-                // this filter is also a type guard to narrow possible from states to any state but EmptyState
-                RA.filter(
-                  <T extends FSM["transitions"][number]>(
-                    tr: T,
-                  ): tr is { from: AllStateNames } & T =>
-                    tr.from !== EmptyState,
-                ),
-                RA.map((tr) =>
+  return (store) =>
+    pipe(
+      // check transitions for the action to apply
+      FSM.transitions.filter(({ action }) => action === appliedAction),
+      TE.fromPredicate(
+        RA.isNonEmpty,
+        (_) => new FsmNoApplicableTransitionError(appliedAction),
+      ),
+      TE.chain((applicableTransitions) =>
+        pipe(
+          // fetch the item from the store by its id
+          store.fetch(id),
+          TE.mapLeft((_) => new FsmStoreFetchError()),
+          // filter transitions that can be applied to the current item status
+          TE.chainEitherK(
+            flow(
+              // We can either find the element in the store or not
+              //   we have a O.Some(item) or a O.none respectively
+              //
+              // These two scenarios differ on how they match applicable transitions:
+              //    + on found item -> we must select transitions which have as "from" state
+              //                         the very same value of the one in the item.
+              //                       We also must decode the incoming item in order to provide
+              //                         the value to the exec() function.
+              //    + on no item    -> we must match only transitions starting from the empty state
+              O.fold(
+                () =>
                   pipe(
-                    // build the codec that will match an element in the "from" state
-                    t.intersection([
-                      FSM.states[tr.from],
-                      StateMetadata(tr.from),
-                    ]),
-                    // match&decode
-                    (codec) => codec.decode(item),
-                    // for those transitions whose from state has been matched,
-                    //  bind all data into a lazy implementation of exec
+                    applicableTransitions,
+                    // this filter is also a type guard to narrow possible from states to EmptyState only
+                    RA.filter(
+                      <T extends FSM["transitions"][number]>(
+                        tr: T,
+                      ): tr is { from: "*" } & T => tr.from === EmptyState,
+                    ),
+                    E.fromPredicate(
+                      // we must have matched at least ONE transition
+                      // (matchedTransitions) => matchedTransitions.length > 0,
+                      RA.isNonEmpty,
+                      (_) => new FsmItemNotFoundError(id),
+                    ),
+                    // bind all data into a lazy implementation of exec
                     E.map(
-                      (current) =>
-                        (): E.Either<
-                          FsmTransitionExecutionError,
-                          { hasChanges: boolean } & AllResults
-                        > =>
-                          tr.exec({
+                      RNEA.map(
+                        (tr) =>
+                          (): E.Either<
+                            FsmTransitionExecutionError,
+                            { hasChanges: boolean } & AllResults
+                          > =>
                             // FIXME: avoid this forcing
                             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                             // @ts-ignore
-                            args,
-                            // FIXME: avoid this forcing
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore
-                            current,
-                          }),
+                            tr.exec({ args, authzGroupIds }),
+                      ),
+                    ),
+                  ),
+                flow(
+                  authorize(authzGroupIds),
+                  E.chain((authzItem) =>
+                    pipe(
+                      applicableTransitions,
+                      // this filter is also a type guard to narrow possible from states to any state but EmptyState
+                      RA.filter(
+                        <T extends FSM["transitions"][number]>(
+                          tr: T,
+                        ): tr is { from: AllStateNames } & T =>
+                          tr.from !== EmptyState,
+                      ),
+                      RA.map((tr) =>
+                        pipe(
+                          // build the codec that will match an element in the "from" state
+                          t.intersection([
+                            FSM.states[tr.from],
+                            StateMetadata(tr.from),
+                          ]),
+                          // match&decode
+                          (codec) => codec.decode(authzItem),
+                          // for those transitions whose from state has been matched,
+                          //  bind all data into a lazy implementation of exec
+                          E.map(
+                            (current) =>
+                              (): E.Either<
+                                | FsmAuthorizationError
+                                | FsmTransitionExecutionError,
+                                { hasChanges: boolean } & AllResults
+                              > =>
+                                RA.isEmpty(authzGroupIds) ||
+                                (!!current.data.metadata.group_id &&
+                                  authzGroupIds.includes(
+                                    current.data.metadata.group_id,
+                                  ))
+                                  ? tr.exec({
+                                      // FIXME: avoid this forcing
+                                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                      // @ts-ignore
+                                      args,
+                                      // FIXME: avoid this forcing
+                                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                      // @ts-ignore
+                                      authzGroupIds,
+                                      // FIXME: avoid this forcing
+                                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                      // @ts-ignore
+                                      current,
+                                    })
+                                  : E.left(new FsmAuthorizationError()),
+                          ),
+                        ),
+                      ),
+                      // skip unmatched transitions
+                      RA.filter(E.isRight),
+                      RA.map((matchedTransitions) => matchedTransitions.right),
+                      E.fromPredicate(
+                        // we must have matched at least ONE transition
+                        // (matchedTransitions) => matchedTransitions.length > 0,
+                        RA.isNonEmpty,
+                        (_) => new FsmNoTransitionMatchedError(),
+                      ),
                     ),
                   ),
                 ),
-                // skip unmatched transitions
-                RA.filter(E.isRight),
-                RA.map((matchedTransitions) => matchedTransitions.right),
-                E.fromPredicate(
-                  // we must have matched at least ONE transition
-                  (matchedTransitions) => matchedTransitions.length > 0,
-                  (_) => new FsmNoTransitionMatchedError(),
-                ),
-                TE.fromEither,
               ),
+            ),
           ),
         ),
       ),
@@ -457,7 +498,6 @@ function apply(
         ),
       ),
     );
-  };
 }
 
 function override(
@@ -484,7 +524,7 @@ function override(
     );
 }
 
-export const getAutoPublish = (service: ItemType): boolean =>
+const getAutoPublish = (service: ItemType): boolean =>
   (service.fsm.autoPublish as boolean) ?? false;
 
 // method to save a "normalized" item in the store
@@ -504,23 +544,49 @@ const saveItem =
       preserveModifiedAt,
     );
 
-const getFsmClient = (store: LifecycleStore) => ({
-  approve: (id: ServiceId, args: { approvalDate: string }) =>
-    apply("approve", id, args)(store),
-  create: (id: ServiceId, args: { data: Service }) =>
-    apply("create", id, args)(store),
-  delete: (id: ServiceId) => apply("delete", id)(store),
-  edit: (id: ServiceId, args: { data: Service }) =>
-    apply("edit", id, args)(store),
-  fetch: (id: ServiceId) => store.fetch(id),
-  getStore: () => store,
-  override: (...args: Parameters<typeof override>) => override(...args)(store),
-  reject: (id: ServiceId, args: { reason: string }) =>
-    apply("reject", id, args)(store),
-  submit: (id: ServiceId, args: { autoPublish: boolean }) =>
-    apply("submit", id, args)(store),
-});
-type FsmClient = ReturnType<typeof getFsmClient>;
+/**
+ *
+ * @param store a LifecycleStore
+ * @returns A FSM Client constructor
+ */
+const getFsmClient =
+  (store: LifecycleStore) =>
+  /**
+   * A FSM Client constructor
+   * @param authzGroupIds an empty array or an undefined value means no apply authtorization
+   * @returns a FsmClient
+   */ (authzGroupIds: readonly NonEmptyString[] = []) => ({
+    approve: (id: ServiceId, args: { approvalDate: string }) =>
+      apply("approve", id, authzGroupIds, args)(store),
+    create: (id: ServiceId, args: { data: Service }) =>
+      apply("create", id, authzGroupIds, args)(store),
+    delete: (id: ServiceId) => apply("delete", id, authzGroupIds)(store),
+    edit: (id: ServiceId, args: { data: Service }) =>
+      apply("edit", id, authzGroupIds, args)(store),
+    fetch: (id: ServiceId) =>
+      pipe(
+        store.fetch(id),
+        TE.mapLeft((_) => new FsmStoreFetchError()),
+        TE.chainEitherKW(
+          flow(
+            O.fold(
+              () => E.right(O.none),
+              flow(authorize(authzGroupIds), E.map(O.some)),
+            ),
+          ),
+        ),
+      ),
+    getStore: () => store,
+    override: (...args: Parameters<typeof override>) =>
+      override(...args)(store),
+    reject: (id: ServiceId, args: { reason: string }) =>
+      apply("reject", id, authzGroupIds, args)(store),
+    submit: (id: ServiceId, args: { autoPublish: boolean }) =>
+      apply("submit", id, authzGroupIds, args)(store),
+  });
+
+type FsmClientCreator = ReturnType<typeof getFsmClient>;
+type FsmClient = ReturnType<FsmClientCreator>;
 
 type ItemType = t.TypeOf<typeof ItemType>;
 const ItemType = t.union(States.types);
@@ -532,4 +598,13 @@ const CosmosResource = t.intersection([
 ]);
 
 export * as definitions from "./definitions";
-export { CosmosResource, FSM, FsmClient, ItemType, getFsmClient };
+export {
+  AllFsmErrors,
+  CosmosResource,
+  FSM,
+  FsmClient,
+  FsmClientCreator,
+  ItemType,
+  getAutoPublish,
+  getFsmClient,
+};

--- a/packages/io-services-cms-models/src/service-publication/index.ts
+++ b/packages/io-services-cms-models/src/service-publication/index.ts
@@ -495,6 +495,11 @@ const saveItem =
     );
 
 const getFsmClient = (store: PublicationStore) => ({
+  fetch: (id: ServiceId) =>
+    pipe(
+      store.fetch(id),
+      TE.mapLeft((_) => new FsmStoreFetchError()),
+    ),
   getStore: () => store,
   override: (...args: Parameters<typeof override>) => override(...args)(store),
   publish: (id: ServiceId, args?: { data: Service }) =>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We have to check group-based authorization to all FSM actions. Currently the only one exception is related to CreateService Use Case, in which the group check is done on the upstream BO system (service-group relationship cannot be set via API).

#### List of Changes
<!--- Describe your changes in detail -->
- [add group-based authz logic to FSM](https://github.com/pagopa/io-services-cms/commit/4d9a7bc84811b941a8f09a4651a33099c4086fd1)
- [make all handlers aware to the new group-based authz FSM](https://github.com/pagopa/io-services-cms/commit/1a9d54171a48ee4069e4713b17016e9940724efb)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order "to adhere" to group-based services visibility functionality

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests and Local Run

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
