### PR TITLE
[IOPAE-1477] operator with group edit service

### DIFF
--- a/.changeset/honest-pets-begin.md
+++ b/.changeset/honest-pets-begin.md
@@ -1,0 +1,7 @@
+---
+"@io-services-cms/models": minor
+"io-services-cms-webapp": minor
+"io-services-cms-backoffice": minor
+---
+
+allow operator to edit service without overriding group

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -193,7 +193,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServicePayload'
+              $ref: '#/components/schemas/CreateServicePayload'
         required: true
       responses:
         '201':
@@ -349,6 +349,47 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ServicePayload'
+        required: true
+      responses:
+        '200':
+          description: Service updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceLifecycle'
+        '400':
+          description: Invalid payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '429':
+          description: Too many requests
+        '500':
+          description: Internal server error
+    patch:
+      tags:
+        - services
+      summary: Patch service
+      description: Update a subset of properties of an existing service
+      operationId: patchService
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: serviceId
+          in: path
+          description: ID of the service
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Patch service payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchServicePayload'
         required: true
       responses:
         '200':
@@ -1239,6 +1280,8 @@ components:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceHistoryStatusType'
     ServicePublication:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublication'
+    PatchServicePayload:
+      $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/PatchServicePayload'
     ServicePayload:
       type: object
       description: Service basic data
@@ -1275,6 +1318,42 @@ components:
         - name
         - description
         - metadata
+    CreateServicePayload:
+      type: object
+      description: Create Service data
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          minLength: 1
+        require_secure_channel:
+          type: boolean
+        authorized_recipients:
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/FiscalCode'
+        authorized_cidrs:
+          description: >-
+            Allowed source IPs or CIDRs for this service.
+            When empty, every IP address it's authorized to call the IO API on
+            behalf of the service.
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/pagopa/io-services-cms/master/packages/io-services-cms-models/openapi/commons-schemas.yaml#/Cidr'
+        max_allowed_payment_amount:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 9999999999
+          default: 0
+        metadata:
+          $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/CreateServicePayloadMetadata'
+      required:
+        - name
+        - description
+        - metadata
     ServiceData:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceData'
     ServiceBaseMetadata:
@@ -1283,6 +1362,8 @@ components:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceMetadata'
     ServicePayloadMetadata:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePayloadMetadata'
+    CreateServicePayloadMetadata:
+      $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/CreateServicePayloadMetadata'
     ServiceLifecycleStatus:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycleStatus'
     ServiceLifecycleStatusType:

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -18,12 +18,9 @@
     "coverage": "yarn coverage:b4f && yarn coverage:fe",
     "coverage:b4f": "vitest run --config ./vitest.config.node.ts --coverage",
     "coverage:fe": "vitest run --config ./vitest.config.react.ts --coverage",
-    "clean:api-definitions": "rm -rf ./src/generated/api",
-    "clean:services-cms": "rm -rf ./src/generated/services-cms",
-    "clean:selfcare-api-models": "rm -rf ./src/generated/selfcare",
-    "generate:api-definitions": "gen-api-models --api-spec ./openapi.yaml --out-dir ./src/generated/api --request-types --response-decoders --client",
-    "generate:services-cms": "gen-api-models --api-spec ../io-services-cms-webapp/openapi.yaml --out-dir ./src/generated/services-cms --request-types --response-decoders --client",
-    "generate:selfcare-api-models": "gen-api-models --api-spec https://selfcare.pagopa.it/developer/external/v2/ms-external-api.yaml --out-dir ./src/generated/selfcare --response-decoders"
+    "generate:api-definitions": "rm -rf ./src/generated/api && gen-api-models --api-spec ./openapi.yaml --out-dir ./src/generated/api --request-types --response-decoders --client",
+    "generate:services-cms": "rm -rf ./src/generated/services-cms && gen-api-models --api-spec ../io-services-cms-webapp/openapi.yaml --out-dir ./src/generated/services-cms --request-types --response-decoders --client",
+    "generate:selfcare-api-models": "rm -rf ./src/generated/selfcare && gen-api-models --api-spec https://selfcare.pagopa.it/developer/external/v2/ms-external-api.yaml --out-dir ./src/generated/selfcare --response-decoders"
   },
   "dependencies": {
     "@azure/arm-apimanagement": "8.1.2",

--- a/apps/backoffice/src/app/api/services/[serviceId]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/services/[serviceId]/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { BackOfficeUser } from "../../../../../../types/next-auth";
 import { ScopeEnum } from "../../../../../generated/api/ServiceBaseMetadata";
 import { ServicePayload } from "../../../../../generated/api/ServicePayload";
-import { ManagedInternalError } from "../../../../../lib/be/errors";
 import { SelfcareRoles } from "../../../../../types/auth";
 import { PUT } from "../route";
 
@@ -37,15 +36,6 @@ const aValidServicePayload: ServicePayload = {
   },
   max_allowed_payment_amount: 0 as any,
 };
-const aGroup = { id: "group_id", name: "group name" };
-
-vi.hoisted(() => {
-  const originalEnv = process.env;
-  process.env = {
-    ...originalEnv,
-    GROUP_AUTHZ_ENABLED: "true",
-  };
-});
 
 const { forwardIoServicesCmsRequestMock, withJWTAuthHandlerMock } = vi.hoisted(
   () => ({
@@ -67,9 +57,8 @@ const { forwardIoServicesCmsRequestMock, withJWTAuthHandlerMock } = vi.hoisted(
   }),
 );
 
-const { parseBody, groupExists } = vi.hoisted(() => ({
+const { parseBody } = vi.hoisted(() => ({
   parseBody: vi.fn(),
-  groupExists: vi.fn(),
 }));
 
 vi.mock("@/lib/be/services/business", () => ({
@@ -78,10 +67,6 @@ vi.mock("@/lib/be/services/business", () => ({
 
 vi.mock("@/lib/be/wrappers", () => ({
   withJWTAuthHandler: withJWTAuthHandlerMock,
-}));
-
-vi.mock("@/lib/be/institutions/business", () => ({
-  groupExists,
 }));
 
 vi.mock("@/lib/be/req-res-utils", () => ({
@@ -106,176 +91,47 @@ describe("Services API", () => {
       parseBody.mockRejectedValueOnce(new Error(errorMessage));
       const request = new NextRequest(new URL("http://localhost"));
 
+      // when
       const result = await PUT(request, {});
 
+      // then
       expect(result.status).toBe(400);
       const responseBody = await result.json();
       expect(responseBody.detail).toStrictEqual(errorMessage);
       expect(parseBody).toHaveBeenCalledOnce();
       expect(parseBody).toHaveBeenCalledWith(request, ServicePayload);
-      expect(groupExists).not.toHaveBeenCalled();
       expect(forwardIoServicesCmsRequestMock).not.toHaveBeenCalled();
     });
 
-    it.each`
-      scenario           | selcGroups
-      ${"has no groups"} | ${undefined}
-      ${"has groups"}    | ${faker.helpers.multiple(faker.string.uuid)}
-    `(
-      "should return a forbidden response when group_id is set and user is not admin and $scenario",
-      async ({ selcGroups }) => {
-        // given
-        const jsonBodyMock = {
-          ...aValidServicePayload,
-          metadata: {
-            ...aValidServicePayload.metadata,
-            group_id: `different-${faker.string.uuid()}`,
-          },
-        };
-        parseBody.mockResolvedValueOnce(jsonBodyMock);
-        backofficeUserMock.institution.role = SelfcareRoles.operator;
-        backofficeUserMock.permissions.selcGroups = selcGroups;
-        const request = new NextRequest(new URL("http://localhost"));
-
-        // when
-        const result = await PUT(request, {});
-
-        // then
-        expect(result.status).toBe(403);
-        const responseBody = await result.json();
-        expect(responseBody.detail).toEqual(
-          "Cannot set service group relationship",
-        );
-        expect(parseBody).toHaveBeenCalledOnce();
-        expect(parseBody).toHaveBeenCalledWith(request, ServicePayload);
-        expect(groupExists).not.toHaveBeenCalled();
-        expect(forwardIoServicesCmsRequestMock).not.toHaveBeenCalled();
-      },
-    );
-
-    it("should return an internal error when group is set but checking group fn fails ", async () => {
+    it("should forward request", async () => {
       // given
-      const jsonBodyMock = {
-        ...aValidServicePayload,
-        metadata: {
-          ...aValidServicePayload.metadata,
-          group_id: "nonExistingGroupId",
-        },
-      };
-      parseBody.mockResolvedValueOnce(jsonBodyMock);
-      const errorMessage = "errorMessage";
-      groupExists.mockRejectedValueOnce(new ManagedInternalError(errorMessage));
+      const jsonBodyMock = aValidServicePayload;
+      parseBody.mockResolvedValueOnce(aValidServicePayload);
       backofficeUserMock.institution.role = SelfcareRoles.admin;
+      const params = { serviceId: faker.string.uuid() };
       const request = new NextRequest(new URL("http://localhost"));
 
-      const result = await PUT(request, { params: { serviceId: "serviceId" } });
+      // when
+      const result = await PUT(request, { params });
 
-      expect(result.status).toBe(500);
-      const responseBody = await result.json();
-      expect(responseBody.detail).toEqual("errorMessage");
-      expect(groupExists).toHaveBeenCalledOnce();
-      expect(groupExists).toHaveBeenCalledWith(
-        backofficeUserMock.institution.id,
-        jsonBodyMock.metadata.group_id,
-      );
-      expect(forwardIoServicesCmsRequestMock).not.toHaveBeenCalled();
-    });
-
-    it.each`
-      scenario        | selcGroups
-      ${"has groups"} | ${undefined}
-      ${"has groups"} | ${["aGroupId"]}
-    `(
-      "should return a bad request when group is set but doesn't exists and user is admin and $scenario",
-      async ({ selcGroups }) => {
-        // given
-        const jsonBodyMock = {
-          ...aValidServicePayload,
-          metadata: {
-            ...aValidServicePayload.metadata,
-            group_id: "nonExistingGroupId",
-          },
-        };
-        parseBody.mockResolvedValueOnce(jsonBodyMock);
-        groupExists.mockResolvedValueOnce(false);
-        backofficeUserMock.institution.role = SelfcareRoles.admin;
-        backofficeUserMock.permissions.selcGroups = selcGroups;
-        const request = new NextRequest(new URL("http://localhost"));
-
-        const result = await PUT(request, {});
-
-        expect(result.status).toBe(400);
-        const responseBody = await result.json();
-        expect(responseBody.detail).toEqual(
-          "Provided group_id does not exists",
-        );
-        expect(groupExists).toHaveBeenCalledOnce();
-        expect(groupExists).toHaveBeenCalledWith(
-          backofficeUserMock.institution.id,
-          jsonBodyMock.metadata.group_id,
-        );
-        expect(forwardIoServicesCmsRequestMock).not.toHaveBeenCalled();
-      },
-    );
-
-    it.each`
-      scenario                                      | selcGroups      | group_id     | mockGroupExists
-      ${"has no groups and group is not set"}       | ${undefined}    | ${undefined} | ${undefined}
-      ${"has groups and group is not set"}          | ${["aGroupId"]} | ${undefined} | ${undefined}
-      ${"has groups and group is set and valid"}    | ${["aGroupId"]} | ${aGroup.id} | ${true}
-      ${"has no groups and group is not set"}       | ${undefined}    | ${undefined} | ${undefined}
-      ${"has no groups and group is set and valid"} | ${undefined}    | ${aGroup.id} | ${true}
-    `(
-      "should forward request when user is admin and $scenario",
-      async ({ selcGroups, group_id, mockGroupExists }) => {
-        // given
-        const jsonBodyMock = {
-          ...aValidServicePayload,
-          metadata: {
-            ...aValidServicePayload.metadata,
-            group_id,
-          },
-        };
-        parseBody.mockResolvedValueOnce(jsonBodyMock);
-        if (mockGroupExists !== undefined) {
-          groupExists.mockResolvedValueOnce(mockGroupExists);
-        }
-        backofficeUserMock.institution.role = SelfcareRoles.admin;
-        backofficeUserMock.permissions.selcGroups = selcGroups;
-        const params = { serviceId: faker.string.uuid() };
-        const request = new NextRequest(new URL("http://localhost"));
-
-        // when
-        const result = await PUT(request, { params });
-
-        // then
-        expect(result.status).toBe(200);
-        if (mockGroupExists !== undefined) {
-          expect(groupExists).toHaveBeenCalledOnce();
-          expect(groupExists).toHaveBeenCalledWith(
-            backofficeUserMock.institution.id,
-            jsonBodyMock.metadata.group_id,
-          );
-        } else {
-          expect(groupExists).not.toHaveBeenCalled();
-        }
-        expect(forwardIoServicesCmsRequestMock).toHaveBeenCalledOnce();
-        expect(forwardIoServicesCmsRequestMock).toHaveBeenCalledWith(
-          "updateService",
-          {
-            nextRequest: request,
-            backofficeUser: backofficeUserMock,
-            jsonBody: {
-              ...jsonBodyMock,
-              organization: {
-                name: backofficeUserMock.institution.name,
-                fiscal_code: backofficeUserMock.institution.fiscalCode,
-              },
+      // then
+      expect(result.status).toBe(200);
+      expect(forwardIoServicesCmsRequestMock).toHaveBeenCalledOnce();
+      expect(forwardIoServicesCmsRequestMock).toHaveBeenCalledWith(
+        "updateService",
+        {
+          nextRequest: request,
+          backofficeUser: backofficeUserMock,
+          jsonBody: {
+            ...jsonBodyMock,
+            organization: {
+              name: backofficeUserMock.institution.name,
+              fiscal_code: backofficeUserMock.institution.fiscalCode,
             },
-            pathParams: params,
           },
-        );
-      },
-    );
+          pathParams: params,
+        },
+      );
+    });
   });
 });

--- a/apps/backoffice/turbo.json
+++ b/apps/backoffice/turbo.json
@@ -1,33 +1,33 @@
 {
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "tasks": {
-    "clean:api-definitions": {
-      "inputs": ["openapi.yaml"]
-    },
-    "clean:services-cms": {
-      "inputs": ["../io-services-cms-webapp/openapi.yaml"]
-    },
-    "clean:selfcare-api-models": {
+    "generate:api-definitions": {
       "inputs": [
-        "https://selfcare.pagopa.it/developer/external/v2/ms-external-api.yaml"
+        "openapi.yaml",
+        "../../packages/io-services-cms-models/openapi/*.yaml"
+      ],
+      "outputs": [
+        "src/generated/api/**"
       ]
     },
-    "generate:api-definitions": {
-      "inputs": ["openapi.yaml"],
-      "outputs": ["src/generated/api/**"],
-      "dependsOn": ["clean:api-definitions"]
-    },
     "generate:services-cms": {
-      "inputs": ["../io-services-cms-webapp/openapi.yaml"],
-      "outputs": ["src/generated/services-cms/**"],
-      "dependsOn": ["clean:services-cms"]
+      "inputs": [
+        "../io-services-cms-webapp/openapi.yaml",
+        "../../packages/io-services-cms-models/openapi/*.yaml"
+      ],
+      "outputs": [
+        "src/generated/services-cms/**"
+      ]
     },
     "generate:selfcare-api-models": {
       "inputs": [
         "https://selfcare.pagopa.it/developer/external/v2/ms-external-api.yaml"
       ],
-      "outputs": ["src/generated/selfcare/*"],
-      "dependsOn": ["clean:selfcare-api-models"]
+      "outputs": [
+        "src/generated/selfcare/*"
+      ]
     },
     "generate": {
       "dependsOn": [
@@ -47,11 +47,20 @@
         "!README.md",
         "!vitest.config.*"
       ],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "typecheck": {
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig.json"],
-      "dependsOn": ["build"]
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "tsconfig.json"
+      ],
+      "dependsOn": [
+        "build"
+      ]
     }
   }
 }

--- a/apps/io-services-cms-webapp/PatchService/function.json
+++ b/apps/io-services-cms-webapp/PatchService/function.json
@@ -1,0 +1,21 @@
+{
+    "bindings": [
+        {
+            "authLevel": "anonymous",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "route": "services/{serviceId}",
+            "methods": [
+                "patch"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "res"
+        }
+    ],
+    "scriptFile": "../dist/main.js",
+    "entryPoint": "httpEntryPoint"
+}

--- a/apps/io-services-cms-webapp/openapi.yaml
+++ b/apps/io-services-cms-webapp/openapi.yaml
@@ -66,7 +66,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServicePayload'
+              $ref: '#/components/schemas/CreateServicePayload'
         required: true
       responses:
         '201':
@@ -219,6 +219,52 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ServicePayload'
+        required: true
+      responses:
+        '200':
+          description: Service updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceLifecycle'
+        '400':
+          description: Invalid payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+        '429':
+          description: Too many requests
+        '500':
+          description: Internal server error
+    patch:
+      tags:
+        - services
+      summary: Patch service
+      description: Update a subset of properties of an existing service
+      operationId: patchService
+      parameters:
+        - $ref: '#/components/parameters/UserEmail'
+        - $ref: '#/components/parameters/UserGroups'
+        - $ref: '#/components/parameters/UserID'
+        - $ref: '#/components/parameters/SubscriptionID'
+        - $ref: '#/components/parameters/XForwardedFor'
+        - $ref: '#/components/parameters/UserGroupsSelc'
+        - $ref: '#/components/parameters/Channel'
+        - name: serviceId
+          in: path
+          description: ID of the service
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Patch service payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchServicePayload'
         required: true
       responses:
         '200':
@@ -723,6 +769,10 @@ components:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePublication'
     ServicePayload:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePayload'
+    CreateServicePayload:
+      $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/CreateServicePayload'
+    PatchServicePayload:
+      $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/PatchServicePayload'
     ServiceData:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceData'
     ServiceBaseMetadata:
@@ -731,6 +781,8 @@ components:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceMetadata'
     ServicePayloadMetadata:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServicePayloadMetadata'
+    CreateServicePayloadMetadata:
+      $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/CreateServicePayloadMetadata'
     ServiceLifecycleStatus:
       $ref: '../../packages/io-services-cms-models/openapi/services-cms-schemas.yaml#/ServiceLifecycleStatus'
     ServiceLifecycleStatusType:

--- a/apps/io-services-cms-webapp/package.json
+++ b/apps/io-services-cms-webapp/package.json
@@ -20,8 +20,7 @@
     "lint:fix": "eslint --fix \"src/**\"",
     "start": "dotenv -e .env func start -- --javascript",
     "generate:avro": "rm -rf ./src/generated/avro && mkdir -p ./src/generated/avro && avro-to-typescript --compile ./avro ./src/generated/avro",
-    "generate:definitions": "rm -rf ./src/generated/api & gen-api-models --api-spec ./openapi.yaml --out-dir ./src/generated/api --request-types --response-decoders",
-    "generate": "yarn generate:definitions && yarn generate:avro"
+    "generate:definitions": "rm -rf ./src/generated/api & gen-api-models --api-spec ./openapi.yaml --out-dir ./src/generated/api --request-types --response-decoders"
   },
   "devDependencies": {
     "@pagopa/eslint-config": "^4.0.1",

--- a/apps/io-services-cms-webapp/src/lib/middlewares/__tests__/channel-middleware.test.ts
+++ b/apps/io-services-cms-webapp/src/lib/middlewares/__tests__/channel-middleware.test.ts
@@ -1,0 +1,47 @@
+import * as express from "express";
+import * as E from "fp-ts/lib/Either";
+import { describe, expect, it } from "vitest";
+import { ChannelMiddleware } from "../channel-middleware";
+
+describe("ChannelMiddleware", () => {
+  it.each`
+    scenario             | value
+    ${"is not provided"} | ${undefined}
+    ${"is not valid"}    | ${"invalid_value"}
+  `(
+    "should return an error response when expected header $scenario",
+    async ({ value }) => {
+      const request = express.request;
+      if (value) {
+        request.headers["x-channel"] = value;
+      }
+
+      const res = await ChannelMiddleware(request);
+
+      expect(E.isLeft(res));
+      if (E.isLeft(res)) {
+        expect(res.left.kind).toStrictEqual("IResponseErrorInternal");
+        expect(res.left.detail).toMatch(/Failed to decode provided channel$/);
+      }
+    },
+  );
+
+  it.each`
+    channel
+    ${"BO"}
+    ${"APIM"}
+  `(
+    "should return the channel when expected header is $channel",
+    async ({ channel }) => {
+      const request = express.request;
+      request.headers["x-channel"] = channel;
+
+      const res = await ChannelMiddleware(request);
+
+      expect(E.isRight(res));
+      if (E.isRight(res)) {
+        expect(res.right).toStrictEqual(channel);
+      }
+    },
+  );
+});

--- a/apps/io-services-cms-webapp/src/lib/middlewares/channel-middleware.ts
+++ b/apps/io-services-cms-webapp/src/lib/middlewares/channel-middleware.ts
@@ -1,0 +1,25 @@
+import { IRequestMiddleware } from "@pagopa/ts-commons/lib/request_middleware";
+import { ResponseErrorInternal } from "@pagopa/ts-commons/lib/responses";
+import * as E from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
+import * as t from "io-ts";
+
+const Channel = t.union([t.literal("APIM"), t.literal("BO")]);
+type Channel = t.TypeOf<typeof Channel>;
+
+/**
+ * Extracts the channel from the provided header.
+ * Block the request if the value is not valid
+ *
+ * @returns either the channel or an error
+ */
+export const ChannelMiddleware: IRequestMiddleware<
+  "IResponseErrorInternal",
+  Channel
+> = async (request) =>
+  pipe(
+    request.header("x-channel"),
+    E.fromPredicate(Channel.is, (_) =>
+      ResponseErrorInternal(`Failed to decode provided channel`),
+    ),
+  );

--- a/apps/io-services-cms-webapp/src/utils/__tests__/check-source-ip.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/check-source-ip.test.ts
@@ -1,0 +1,46 @@
+import { IPString } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+import { describe, expect, it } from "vitest";
+import { checkSourceIp } from "../check-source-ip";
+
+describe("checkSourceIp", () => {
+  it.each`
+    scenario                                                                              | ip                     | authzCidrs          | expectedErrorKind                         | expectedErrorDetailRegExp
+    ${"provided ip is empty"}                                                             | ${O.none}              | ${new Set()}        | ${"IResponseErrorInternal"}               | ${/IP address cannot be extracted from the request$/}
+    ${"provided ip is not empty, but ip is not included in authz CIDRs (without prefix)"} | ${O.some("127.0.0.2")} | ${["127.0.0.1"]}    | ${"IResponseErrorForbiddenNotAuthorized"} | ${/.*$/}
+    ${"provided ip is not empty, but ip is not included in authz CIDRs (with prefix)"}    | ${O.some("127.0.0.2")} | ${["127.0.0.1/31"]} | ${"IResponseErrorForbiddenNotAuthorized"} | ${/.*$/}
+  `(
+    "should return an error response when $scenario",
+    ({ ip, authzCidrs, expectedErrorKind, expectedErrorDetailRegExp }) => {
+      // when
+      const res = checkSourceIp(ip, authzCidrs);
+
+      // then
+      expect(E.isLeft(res)).toBeTruthy();
+      if (E.isLeft(res)) {
+        expect(res.left.kind).toStrictEqual(expectedErrorKind);
+        expect(res.left.detail).toMatch(expectedErrorDetailRegExp);
+      }
+    },
+  );
+
+  it.each`
+    scenario                                                | authzCidrs
+    ${"authz CIDRs is empty"}                               | ${new Set()}
+    ${"ip is not included in authz CIDRs (without prefix)"} | ${["127.0.0.1"]}
+    ${"ip is not included in authz CIDRs (with prefix)"}    | ${["127.0.0.1/24"]}
+  `("should return the valid ip when $scenario", ({ authzCidrs }) => {
+    // given
+    const ip = "127.0.0.1" as IPString;
+
+    // when
+    const res = checkSourceIp(O.some(ip), authzCidrs);
+
+    // then
+    expect(E.isRight(res)).toBeTruthy();
+    if (E.isRight(res)) {
+      expect(res.right).toStrictEqual(ip);
+    }
+  });
+});

--- a/apps/io-services-cms-webapp/src/utils/__tests__/check-source-ip.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/check-source-ip.test.ts
@@ -1,4 +1,3 @@
-import { IPString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { describe, expect, it } from "vitest";
@@ -26,14 +25,12 @@ describe("checkSourceIp", () => {
   );
 
   it.each`
-    scenario                                                | authzCidrs
-    ${"authz CIDRs is empty"}                               | ${new Set()}
-    ${"ip is not included in authz CIDRs (without prefix)"} | ${["127.0.0.1"]}
-    ${"ip is not included in authz CIDRs (with prefix)"}    | ${["127.0.0.1/24"]}
-  `("should return the valid ip when $scenario", ({ authzCidrs }) => {
-    // given
-    const ip = "127.0.0.1" as IPString;
-
+    scenario                                                | ip                    | authzCidrs
+    ${"authz CIDRs is empty"}                               | ${"127.0.0.1"}        | ${new Set()}
+    ${"ip is not included in authz CIDRs (without prefix)"} | ${"127.0.0.1"}        | ${["127.0.0.1"]}
+    ${"ip is not included in authz CIDRs (with prefix)"}    | ${"::ffff:127.0.0.1"} | ${["127.0.0.1/24"]}
+    ${"ip is not included in authz CIDRs (with prefix)"}    | ${"::ffff:127.0.0.1"} | ${["0.0.0.0/0"]}
+  `("should return the valid ip when $scenario", ({ ip, authzCidrs }) => {
     // when
     const res = checkSourceIp(O.some(ip), authzCidrs);
 

--- a/apps/io-services-cms-webapp/src/utils/__tests__/check-source-ip.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/check-source-ip.test.ts
@@ -7,8 +7,8 @@ describe("checkSourceIp", () => {
   it.each`
     scenario                                                                              | ip                     | authzCidrs          | expectedErrorKind                         | expectedErrorDetailRegExp
     ${"provided ip is empty"}                                                             | ${O.none}              | ${new Set()}        | ${"IResponseErrorInternal"}               | ${/IP address cannot be extracted from the request$/}
-    ${"provided ip is not empty, but ip is not included in authz CIDRs (without prefix)"} | ${O.some("127.0.0.2")} | ${["127.0.0.1"]}    | ${"IResponseErrorForbiddenNotAuthorized"} | ${/.*$/}
-    ${"provided ip is not empty, but ip is not included in authz CIDRs (with prefix)"}    | ${O.some("127.0.0.2")} | ${["127.0.0.1/31"]} | ${"IResponseErrorForbiddenNotAuthorized"} | ${/.*$/}
+    ${"provided ip is not empty, but ip is not included in authz CIDRs (without prefix)"} | ${O.some("127.0.0.2")} | ${["127.0.0.1"]}    | ${"IResponseErrorForbiddenNotAuthorized"} | ${/^.*$/}
+    ${"provided ip is not empty, but ip is not included in authz CIDRs (with prefix)"}    | ${O.some("127.0.0.2")} | ${["127.0.0.1/31"]} | ${"IResponseErrorForbiddenNotAuthorized"} | ${/^.*$/}
   `(
     "should return an error response when $scenario",
     ({ ip, authzCidrs, expectedErrorKind, expectedErrorDetailRegExp }) => {

--- a/apps/io-services-cms-webapp/src/utils/check-source-ip.ts
+++ b/apps/io-services-cms-webapp/src/utils/check-source-ip.ts
@@ -11,7 +11,12 @@ import * as E from "fp-ts/lib/Either";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as RS from "fp-ts/lib/ReadonlySet";
 import { pipe } from "fp-ts/lib/function";
-import { BlockList } from "net";
+import { BlockList, isIPv6 } from "net";
+
+/**
+ * ::ffff: is a subnet prefix for IPv4 (32 bit) addresses that are placed inside an IPv6 (128 bit) space.
+ */
+const IPv4ToIPv6SubnetPrefix = "::ffff:";
 
 /**
  * Checks if an IP address is contained within a list of CIDR ranges.
@@ -29,7 +34,12 @@ const isIpInCidrList = (ip: IPString, cidrList: ReadonlySet<CIDR>): boolean =>
       else blockList.addAddress(subnet);
       return blockList;
     }),
-    (blockList) => blockList.check(ip),
+    (blockList) =>
+      blockList.check(
+        isIPv6(ip) && ip.startsWith(IPv4ToIPv6SubnetPrefix)
+          ? ip.split(IPv4ToIPv6SubnetPrefix)[1]
+          : ip,
+      ),
   );
 
 /**

--- a/apps/io-services-cms-webapp/src/utils/check-source-ip.ts
+++ b/apps/io-services-cms-webapp/src/utils/check-source-ip.ts
@@ -1,0 +1,62 @@
+import { CIDR } from "@pagopa/io-functions-commons/dist/generated/definitions/CIDR";
+import { ClientIp } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import {
+  IResponseErrorForbiddenNotAuthorized,
+  IResponseErrorInternal,
+  ResponseErrorForbiddenNotAuthorized,
+  ResponseErrorInternal,
+} from "@pagopa/ts-commons/lib/responses";
+import { IPString } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
+import * as RA from "fp-ts/lib/ReadonlyArray";
+import * as RS from "fp-ts/lib/ReadonlySet";
+import { pipe } from "fp-ts/lib/function";
+import { BlockList } from "net";
+
+/**
+ * Checks if an IP address is contained within a list of CIDR ranges.
+ *
+ * @param ip - The IP address to check.
+ * @param cidrList - An array of CIDR ranges in "IP/prefix" format (e.g., "192.168.0.0/24").
+ * @returns - `true` if the IP is contained within the CIDR list, otherwise `false`.
+ */
+const isIpInCidrList = (ip: IPString, cidrList: ReadonlySet<CIDR>): boolean =>
+  pipe(
+    Array.from(cidrList),
+    RA.reduce(new BlockList(), (blockList, cidr) => {
+      const [subnet, prefix] = cidr.split("/");
+      if (prefix) blockList.addSubnet(subnet, parseInt(prefix, 10));
+      else blockList.addAddress(subnet);
+      return blockList;
+    }),
+    (blockList) => blockList.check(ip),
+  );
+
+/**
+ * Checks if an IP address is contained within a list of CIDR ranges.
+ * @param maybeClientIp - The IP address to check.
+ * @param authzCidrs - An array of CIDR ranges in "IP/prefix" format (e.g., "192.168.0.0/24").
+ * @returns Either an error response or the validated ip
+ */
+const checkSourceIp = (
+  maybeClientIp: ClientIp,
+  authzCidrs: ReadonlySet<CIDR>,
+): E.Either<
+  IResponseErrorForbiddenNotAuthorized | IResponseErrorInternal,
+  IPString
+> =>
+  pipe(
+    maybeClientIp,
+    E.fromOption(() =>
+      ResponseErrorInternal("IP address cannot be extracted from the request"),
+    ),
+    E.chainW(
+      E.fromPredicate(
+        (clientIp) =>
+          RS.isEmpty(authzCidrs) || isIpInCidrList(clientIp, authzCidrs),
+        () => ResponseErrorForbiddenNotAuthorized,
+      ),
+    ),
+  );
+
+export { checkSourceIp };

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/edit-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/edit-service.test.ts
@@ -1,10 +1,11 @@
 import { Container } from "@azure/cosmos";
 import { ApimUtils } from "@io-services-cms/external-clients";
 import {
+  FsmItemNotFoundError,
+  FsmNoTransitionMatchedError,
   ServiceLifecycle,
-  ServicePublication,
-  stores,
 } from "@io-services-cms/models";
+import { CIDR } from "@pagopa/io-functions-commons/dist/generated/definitions/CIDR";
 import {
   RetrievedSubscriptionCIDRs,
   SubscriptionCIDRsModel,
@@ -12,61 +13,101 @@ import {
 import { UserGroup } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
-import {
-  IPatternStringTag,
-  NonEmptyString,
-} from "@pagopa/ts-commons/lib/strings";
-import * as O from "fp-ts/lib/Option";
+import { ResponseErrorForbiddenNotAuthorized } from "@pagopa/ts-commons/lib/responses";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import request from "supertest";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IConfig } from "../../../config";
 import { WebServerDependencies, createWebServer } from "../../index";
 
-const { validateServiceTopicRequest } = vi.hoisted(() => ({
-  validateServiceTopicRequest: vi.fn(),
+const aService = {
+  id: "aServiceId",
+  data: {
+    name: "aServiceName",
+    description: "aServiceDescription",
+    authorized_recipients: [],
+    max_allowed_payment_amount: 123,
+    metadata: {
+      address: "via tal dei tali 123",
+      email: "service@email.it",
+      pec: "service@pec.it",
+      scope: "LOCAL",
+      topic_id: 1,
+    },
+    organization: {
+      name: "anOrganizationName",
+      fiscal_code: "12345678901",
+    },
+    require_secure_channel: false,
+  },
+} as unknown as ServiceLifecycle.ItemType;
+
+const {
+  serviceOwnerCheckManageTaskMock,
+  validateServiceTopicRequestMock,
+  validateServiceTopicRequestWrapperMock,
+  payloadToItemMock,
+  payloadToItemResponseMock,
+  itemToResponseWrapperMock,
+  itemToResponseMock,
+  itemToResponseResponseMock,
+  logErrorResponseMock,
+  getLoggerMock,
+  fsmLifecycleClientMock,
+  fsmLifecycleClientCreatorMock,
+} = vi.hoisted(() => {
+  const payloadToItemResponseMock = "payloadToItemResponse";
+  const itemToResponseResponseMock = { value: "itemToResponseResponse" };
+  const itemToResponseMock = vi.fn(() => TE.right(itemToResponseResponseMock));
+  const logErrorResponseMock = vi.fn((err) => err);
+  const validateServiceTopicRequestMock = vi.fn(() => TE.right(void 0));
+  const fsmLifecycleClientMock = {
+    edit: vi.fn<any[], any>(() =>
+      TE.right({ ...aService, fsm: { state: "draft" } }),
+    ),
+  };
+  return {
+    serviceOwnerCheckManageTaskMock: vi.fn<any[], any>((_, serviceId) =>
+      TE.right(serviceId),
+    ),
+    validateServiceTopicRequestMock: validateServiceTopicRequestMock,
+    validateServiceTopicRequestWrapperMock: vi.fn(
+      () => validateServiceTopicRequestMock,
+    ),
+    payloadToItemMock: vi.fn(() => payloadToItemResponseMock),
+    payloadToItemResponseMock,
+    itemToResponseWrapperMock: vi.fn(() => itemToResponseMock),
+    itemToResponseMock,
+    itemToResponseResponseMock,
+    logErrorResponseMock,
+    getLoggerMock: vi.fn(() => ({ logErrorResponse: logErrorResponseMock })),
+    fsmLifecycleClientMock,
+    fsmLifecycleClientCreatorMock: vi.fn(() => fsmLifecycleClientMock),
+  };
+});
+
+vi.mock("../../../utils/subscription", () => ({
+  serviceOwnerCheckManageTask: serviceOwnerCheckManageTaskMock,
 }));
 
 vi.mock("../../../utils/service-topic-validator", () => ({
-  validateServiceTopicRequest: validateServiceTopicRequest,
+  validateServiceTopicRequest: validateServiceTopicRequestWrapperMock,
 }));
 
-const { getServiceTopicDao } = vi.hoisted(() => ({
-  getServiceTopicDao: vi.fn(() => ({
-    findById: vi.fn((id: number) =>
-      TE.right(O.some({ id, name: "topic name" })),
-    ),
-  })),
+vi.mock("../../../utils/converters/service-lifecycle-converters", () => ({
+  itemToResponse: itemToResponseWrapperMock,
+  payloadToItem: payloadToItemMock,
 }));
 
-vi.mock("../../../utils/service-topic-dao", () => ({
-  getDao: getServiceTopicDao,
+vi.mock("../../../utils/logger", () => ({
+  getLogger: getLoggerMock,
 }));
-
-const serviceLifecycleStore =
-  stores.createMemoryStore<ServiceLifecycle.ItemType>();
-const fsmLifecycleClientCreator = ServiceLifecycle.getFsmClient(
-  serviceLifecycleStore,
-);
-
-const servicePublicationStore =
-  stores.createMemoryStore<ServicePublication.ItemType>();
-const fsmPublicationClient = ServicePublication.getFsmClient(
-  servicePublicationStore,
-);
 
 const aManageSubscriptionId = "MANAGE-123";
 const anUserId = "123";
-const ownerId = `/an/owner/${anUserId}`;
 
-const mockApimService = {
-  getSubscription: vi.fn(() =>
-    TE.right({
-      _etag: "_etag",
-      ownerId: anUserId,
-    }),
-  ),
-} as unknown as ApimUtils.ApimService;
+const mockApimService = {} as unknown as ApimUtils.ApimService;
 
 const mockConfig = {
   BACKOFFICE_INTERNAL_SUBNET_CIDRS: ["127.193.0.0/20"],
@@ -74,10 +115,7 @@ const mockConfig = {
 
 const aRetrievedSubscriptionCIDRs: RetrievedSubscriptionCIDRs = {
   subscriptionId: aManageSubscriptionId as NonEmptyString,
-  cidrs: [] as unknown as ReadonlySet<
-    string &
-      IPatternStringTag<"^([0-9]{1,3}[.]){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$">
-  >,
+  cidrs: [] as unknown as ReadonlySet<CIDR>,
   _etag: "_etag",
   _rid: "_rid",
   _self: "_self",
@@ -111,39 +149,25 @@ const mockAppinsights = {
   trackError: vi.fn(),
 } as any;
 
-const mockContext = {
-  log: {
-    error: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn(),
-  },
-} as any;
+const mockContext = {} as any;
 
-const mockBlobService = {
-  createBlockBlobFromText: vi.fn((_, __, ___, cb) => cb(null, "any")),
-} as any;
-
-const mockServiceTopicDao = {
-  findAllNotDeletedTopics: vi.fn(() => TE.right([])),
-} as any;
-
-afterEach(() => {
-  vi.clearAllMocks();
+beforeEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("editService", () => {
-  validateServiceTopicRequest.mockReturnValue(() => TE.right(void 0));
+  const logPrefix = "EditServiceHandler";
 
   const app = createWebServer({
     basePath: "api",
     apimService: mockApimService,
     config: mockConfig,
-    fsmLifecycleClientCreator,
-    fsmPublicationClient,
+    fsmLifecycleClientCreator: fsmLifecycleClientCreatorMock,
+    fsmPublicationClient: vi.fn(),
     subscriptionCIDRsModel,
     telemetryClient: mockAppinsights,
-    blobService: mockBlobService,
-    serviceTopicDao: mockServiceTopicDao,
+    blobService: vi.fn(),
+    serviceTopicDao: vi.fn(),
   } as unknown as WebServerDependencies);
 
   setAppContext(app, mockContext);
@@ -177,108 +201,161 @@ describe("editService", () => {
     },
   };
 
-  const aService = {
-    id: "aServiceId",
-    data: {
-      name: "aServiceName",
-      description: "aServiceDescription",
-      authorized_recipients: [],
-      max_allowed_payment_amount: 123,
-      metadata: {
-        address: "via tal dei tali 123",
-        email: "service@email.it",
-        pec: "service@pec.it",
-        scope: "LOCAL",
-        topic_id: 1,
-      },
-      organization: {
-        name: "anOrganizationName",
-        fiscal_code: "12345678901",
-      },
-      require_secure_channel: false,
-    },
-  } as unknown as ServiceLifecycle.ItemType;
-
   it("should fail when cannot find requested service", async () => {
+    // given
+    const serviceId = aService.id;
+    fsmLifecycleClientMock.edit.mockReturnValueOnce(
+      TE.left(new FsmItemNotFoundError(serviceId)),
+    );
+
+    // when
     const response = await request(app)
-      .put("/api/services/s4")
+      .put(`/api/services/${serviceId}`)
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", UserGroup.ApiServiceWrite)
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.warn).toHaveBeenCalledOnce();
+    // then
     expect(response.statusCode).toBe(404);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
   });
 
   it("should fail when requested operation in not allowed (transition's preconditions fails)", async () => {
-    await serviceLifecycleStore.save("s1", {
-      ...aService,
-      fsm: { state: "deleted" },
-    })();
+    // given
+    const serviceId = aService.id;
+    fsmLifecycleClientMock.edit.mockReturnValueOnce(
+      TE.left(new FsmNoTransitionMatchedError()),
+    );
 
+    // when
     const response = await request(app)
-      .put("/api/services/s1")
+      .put(`/api/services/${serviceId}`)
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", UserGroup.ApiServiceWrite)
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.warn).toHaveBeenCalledOnce();
+    // then
     expect(response.statusCode).toBe(409);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
   });
 
   it("should not allow the operation without right group", async () => {
+    // given
+    const serviceId = aService.id;
+
+    // when
     const response = await request(app)
-      .put("/api/services/s1")
+      .put(`/api/services/${serviceId}`)
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", "OtherGroup")
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
+    // then
     expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientMock.edit).not.toHaveBeenCalled();
   });
 
   it("should edit a service", async () => {
-    await serviceLifecycleStore.save("s4", {
-      ...aService,
-      fsm: { state: "rejected" },
-    })();
+    // given
+    const serviceId = aService.id;
 
+    // when
     const response = await request(app)
-      .put("/api/services/s4")
+      .put(`/api/services/${serviceId}`)
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", UserGroup.ApiServiceWrite)
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aManageSubscriptionId);
 
+    // then
     expect(response.statusCode).toBe(200);
-    expect(response.body.status.value).toBe("draft");
-    expect(response.body.metadata.address).toBe("via casa mia 245");
-    expect(mockContext.log.error).not.toHaveBeenCalled();
+    expect(response.body).toStrictEqual(itemToResponseResponseMock);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
-  it("should not allow the operation without right userId", async () => {
-    const aDifferentManageSubscriptionId = "MANAGE-456";
-    const aDifferentUserId = "456";
 
+  it("should not allow the operation without right userId", async () => {
+    // given
+    const serviceId = aService.id;
+    const error = ResponseErrorForbiddenNotAuthorized;
+    serviceOwnerCheckManageTaskMock.mockReturnValueOnce(TE.left(error));
+
+    // when
     const response = await request(app)
-      .put("/api/services/s4")
+      .put(`/api/services/${serviceId}`)
       .send(aServicePayload)
       .set("x-user-email", "example@email.com")
       .set("x-user-groups", UserGroup.ApiServiceWrite)
-      .set("x-user-id", aDifferentUserId)
-      .set("x-subscription-id", aDifferentManageSubscriptionId);
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
 
-    expect(mockContext.log.warn).toHaveBeenCalledOnce();
+    // then
     expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
   });
   it("should not allow the operation without manageKey", async () => {
+    // given
     const aNotManageSubscriptionId = "NOT-MANAGE-123";
 
+    // when
     const response = await request(app)
       .put("/api/services/s4")
       .send(aServicePayload)
@@ -287,29 +364,25 @@ describe("editService", () => {
       .set("x-user-id", anUserId)
       .set("x-subscription-id", aNotManageSubscriptionId);
 
-    expect(mockApimService.getSubscription).not.toHaveBeenCalled();
+    // then
     expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientMock.edit).not.toHaveBeenCalled();
   });
 
   it("should edit a service if cidrs array contains 0.0.0.0/0", async () => {
-    await serviceLifecycleStore.save("s4", {
-      ...aService,
-      fsm: { state: "rejected" },
-    })();
-
     const aNewRetrievedSubscriptionCIDRs = {
       ...aRetrievedSubscriptionCIDRs,
-      cidrs: ["0.0.0.0/0"] as unknown as ReadonlySet<
-        string &
-          IPatternStringTag<"^([0-9]{1,3}[.]){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$">
-      >,
+      cidrs: ["0.0.0.0/0"] as unknown as ReadonlySet<CIDR>,
     };
 
-    mockFetchAll.mockImplementationOnce(() =>
-      Promise.resolve({
-        resources: [aNewRetrievedSubscriptionCIDRs],
-      }),
-    );
+    mockFetchAll.mockResolvedValueOnce({
+      resources: [aNewRetrievedSubscriptionCIDRs],
+    });
 
     const response = await request(app)
       .put("/api/services/s4")
@@ -320,29 +393,20 @@ describe("editService", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(response.statusCode).toBe(200);
-    expect(mockContext.log.error).not.toHaveBeenCalled();
-    expect(response.body.status.value).toBe("draft");
+    expect(response.body).toStrictEqual(itemToResponseResponseMock);
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 
   it("should edit a service if cidrs array contains only the IP address of the host", async () => {
-    await serviceLifecycleStore.save("s4", {
-      ...aService,
-      fsm: { state: "rejected" },
-    })();
-
     const aNewRetrievedSubscriptionCIDRs = {
       ...aRetrievedSubscriptionCIDRs,
-      cidrs: ["127.0.0.1/32"] as unknown as ReadonlySet<
-        string &
-          IPatternStringTag<"^([0-9]{1,3}[.]){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$">
-      >,
+      cidrs: ["127.0.0.1/32"] as unknown as ReadonlySet<CIDR>,
     };
 
-    mockFetchAll.mockImplementationOnce(() =>
-      Promise.resolve({
-        resources: [aNewRetrievedSubscriptionCIDRs],
-      }),
-    );
+    mockFetchAll.mockResolvedValueOnce({
+      resources: [aNewRetrievedSubscriptionCIDRs],
+    });
 
     const response = await request(app)
       .put("/api/services/s4")
@@ -353,29 +417,20 @@ describe("editService", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(response.statusCode).toBe(200);
-    expect(mockContext.log.error).not.toHaveBeenCalled();
-    expect(response.body.status.value).toBe("draft");
+    expect(response.body).toStrictEqual(itemToResponseResponseMock);
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 
   it("should not edit a service if cidrs array doesn't contains the IP address of the host", async () => {
-    await serviceLifecycleStore.save("s4", {
-      ...aService,
-      fsm: { state: "rejected" },
-    })();
-
     const aNewRetrievedSubscriptionCIDRs = {
       ...aRetrievedSubscriptionCIDRs,
-      cidrs: ["127.1.1.2/32"] as unknown as ReadonlySet<
-        string &
-          IPatternStringTag<"^([0-9]{1,3}[.]){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$">
-      >,
+      cidrs: ["127.1.1.2/32"] as unknown as ReadonlySet<CIDR>,
     };
 
-    mockFetchAll.mockImplementationOnce(() =>
-      Promise.resolve({
-        resources: [aNewRetrievedSubscriptionCIDRs],
-      }),
-    );
+    mockFetchAll.mockResolvedValueOnce({
+      resources: [aNewRetrievedSubscriptionCIDRs],
+    });
 
     const response = await request(app)
       .put("/api/services/s4")
@@ -386,31 +441,26 @@ describe("editService", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(response.statusCode).toBe(403);
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+    expect(payloadToItemMock).not.toHaveBeenCalled();
+    expect(itemToResponseMock).not.toHaveBeenCalled();
+    expect(fsmLifecycleClientMock.edit).not.toHaveBeenCalled();
   });
 
   it("should edit a service if cidrs array contains the IP address of the host", async () => {
-    await serviceLifecycleStore.save("s4", {
-      ...aService,
-      fsm: { state: "rejected" },
-    })();
-
     const aNewRetrievedSubscriptionCIDRs = {
       ...aRetrievedSubscriptionCIDRs,
       cidrs: [
         "127.1.1.2/32",
         "127.0.0.1/32",
         "127.2.2.3/32",
-      ] as unknown as ReadonlySet<
-        string &
-          IPatternStringTag<"^([0-9]{1,3}[.]){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$">
-      >,
+      ] as unknown as ReadonlySet<CIDR>,
     };
 
-    mockFetchAll.mockImplementationOnce(() =>
-      Promise.resolve({
-        resources: [aNewRetrievedSubscriptionCIDRs],
-      }),
-    );
+    mockFetchAll.mockResolvedValueOnce({
+      resources: [aNewRetrievedSubscriptionCIDRs],
+    });
 
     const response = await request(app)
       .put("/api/services/s4")
@@ -421,7 +471,8 @@ describe("editService", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     expect(response.statusCode).toBe(200);
-    expect(mockContext.log.error).not.toHaveBeenCalled();
-    expect(response.body.status.value).toBe("draft");
+    expect(response.body).toStrictEqual(itemToResponseResponseMock);
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/patch-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/patch-service.test.ts
@@ -1,0 +1,243 @@
+import { ApimUtils } from "@io-services-cms/external-clients";
+import { ServiceLifecycle } from "@io-services-cms/models";
+import { SubscriptionCIDRsModel } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
+import { UserGroup } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { ResponseErrorForbiddenNotAuthorized } from "@pagopa/ts-commons/lib/responses";
+import * as TE from "fp-ts/lib/TaskEither";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IConfig } from "../../../config";
+import { WebServerDependencies, createWebServer } from "../../index";
+
+const aService = {
+  id: "aServiceId",
+  data: {
+    name: "aServiceName",
+    description: "aServiceDescription",
+    authorized_recipients: [],
+    max_allowed_payment_amount: 123,
+    metadata: {
+      address: "via tal dei tali 123",
+      email: "service@email.it",
+      pec: "service@pec.it",
+      scope: "LOCAL",
+      topic_id: 1,
+    },
+    organization: {
+      name: "anOrganizationName",
+      fiscal_code: "12345678901",
+    },
+    require_secure_channel: false,
+  },
+} as unknown as ServiceLifecycle.ItemType;
+
+const {
+  serviceOwnerCheckManageTaskMock,
+  logErrorResponseMock,
+  getLoggerMock,
+  patchMock,
+  fsmLifecycleClientCreatorMock,
+} = vi.hoisted(() => {
+  const logErrorResponseMock = vi.fn((err) => err);
+  const patchMock = vi.fn<any[], any>(() => TE.right(aService));
+  return {
+    serviceOwnerCheckManageTaskMock: vi.fn<any[], any>((_, serviceId) =>
+      TE.right(serviceId),
+    ),
+    logErrorResponseMock,
+    getLoggerMock: vi.fn(() => ({ logErrorResponse: logErrorResponseMock })),
+    patchMock,
+    fsmLifecycleClientCreatorMock: vi.fn(() => ({
+      getStore: () => ({
+        patch: patchMock,
+      }),
+    })),
+  };
+});
+
+vi.mock("../../../utils/subscription", () => ({
+  serviceOwnerCheckManageTask: serviceOwnerCheckManageTaskMock,
+}));
+
+vi.mock("../../../utils/logger", () => ({
+  getLogger: getLoggerMock,
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("patchService", () => {
+  const logPrefix = "PatchServiceHandler";
+  const aManageSubscriptionId = "MANAGE-123";
+  const anUserId = "123";
+  const mockApimService = {} as unknown as ApimUtils.ApimService;
+  const mockConfig = {
+    BACKOFFICE_INTERNAL_SUBNET_CIDRS: ["127.0.0.1/32"],
+  } as unknown as IConfig;
+  const mockAppinsights = {
+    trackEvent: vi.fn(),
+    trackError: vi.fn(),
+  } as any;
+  const mockContext = {} as any;
+
+  const app = createWebServer({
+    basePath: "api",
+    apimService: mockApimService,
+    config: mockConfig,
+    fsmLifecycleClientCreator: fsmLifecycleClientCreatorMock,
+    fsmPublicationClient: vi.fn(),
+    subscriptionCIDRsModel: {} as SubscriptionCIDRsModel,
+    telemetryClient: mockAppinsights,
+    blobService: vi.fn(),
+    serviceTopicDao: vi.fn(),
+  } as unknown as WebServerDependencies);
+
+  setAppContext(app, mockContext);
+
+  const aServicePayload = {
+    name: "string",
+    description: "string",
+    organization: {
+      name: "string",
+      fiscal_code: "12345678901",
+      department_name: "string",
+    },
+    require_secure_channel: true,
+    authorized_recipients: ["AAAAAA00A00A000A"],
+    max_allowed_payment_amount: 0,
+    metadata: {
+      web_url: "string",
+      app_ios: "string",
+      app_android: "string",
+      tos_url: "string",
+      privacy_url: "string",
+      address: "via casa mia 245",
+      phone: "string",
+      email: "string",
+      pec: "string",
+      cta: "string",
+      token_name: "string",
+      support_url: "string",
+      scope: "NATIONAL",
+      topic_id: 1,
+    },
+  };
+
+  it("should fail when cannot find requested service", async () => {
+    // given
+    const serviceId = aService.id;
+    patchMock.mockReturnValueOnce(TE.left(new Error("patch error")));
+
+    // when
+    const response = await request(app)
+      .patch(`/api/services/${serviceId}`)
+      .send(aServicePayload)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(500);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(patchMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+  });
+
+  it("should not allow the operation without right group", async () => {
+    // given
+    const serviceId = aService.id;
+
+    // when
+    const response = await request(app)
+      .patch(`/api/services/${serviceId}`)
+      .send(aServicePayload)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", "OtherGroup")
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+  });
+
+  it("should patch a service", async () => {
+    // given
+    const serviceId = aService.id;
+
+    // when
+    const response = await request(app)
+      .patch(`/api/services/${serviceId}`)
+      .send(aServicePayload)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toStrictEqual(aService);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(patchMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+  });
+
+  it("should not allow the operation without right userId", async () => {
+    // given
+    const serviceId = aService.id;
+    const error = ResponseErrorForbiddenNotAuthorized;
+    serviceOwnerCheckManageTaskMock.mockReturnValueOnce(TE.left(error));
+
+    // when
+    const response = await request(app)
+      .patch(`/api/services/${serviceId}`)
+      .send(aServicePayload)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+  });
+});

--- a/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/create-service.ts
@@ -8,33 +8,26 @@ import {
   IAzureApiAuthorization,
   UserGroup,
 } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import { IAzureUserAttributesManage } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_user_attributes_manage";
-import {
-  ClientIp,
-  ClientIpMiddleware,
-} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import { ClientIpMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import {
   withRequestMiddlewares,
   wrapRequestHandler,
 } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
-import {
-  checkSourceIpForHandler,
-  clientIPAndCidrTuple as ipTuple,
-} from "@pagopa/io-functions-commons/dist/src/utils/source_ip_check";
 import { ulidGenerator } from "@pagopa/io-functions-commons/dist/src/utils/strings";
 import {
   HttpStatusCodeEnum,
   ResponseErrorInternal,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
 import { IConfig } from "../../config";
+import { CreateServicePayload } from "../../generated/api/CreateServicePayload";
 import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";
-import { ServicePayload as ServiceRequestPayload } from "../../generated/api/ServicePayload";
 import { SelfcareUserGroupsMiddleware } from "../../lib/middlewares/selfcare-user-groups-middleware";
 import {
   EventNameEnum,
@@ -42,6 +35,7 @@ import {
   trackEventOnResponseOK,
 } from "../../utils/applicationinsight";
 import { AzureUserAttributesManageMiddlewareWrapper } from "../../utils/azure-user-attributes-manage-middleware-wrapper";
+import { checkSourceIp } from "../../utils/check-source-ip";
 import {
   itemToResponse,
   payloadToItem,
@@ -55,18 +49,15 @@ import { validateServiceTopicRequest } from "../../utils/service-topic-validator
 
 const logPrefix = "CreateServiceHandler";
 
-type HandlerResponseTypes =
-  | ErrorResponseTypes
-  | IResponseJsonWithStatus<ServiceResponsePayload>;
-
 type ICreateServiceHandler = (
   context: Context,
   auth: IAzureApiAuthorization,
-  clientIp: ClientIp,
-  attrs: IAzureUserAttributesManage,
-  servicePayload: ServiceRequestPayload,
+  servicePayload: CreateServicePayload,
   authzGroupIds: readonly NonEmptyString[],
-) => Promise<HandlerResponseTypes>;
+) => TE.TaskEither<
+  ErrorResponseTypes,
+  IResponseJsonWithStatus<ServiceResponsePayload>
+>;
 
 interface Dependencies {
   apimService: ApimUtils.ApimService;
@@ -98,7 +89,7 @@ export const makeCreateServiceHandler =
     fsmLifecycleClientCreator,
     telemetryClient,
   }: Dependencies): ICreateServiceHandler =>
-  (context, auth, _, __, servicePayload, authzGroupIds) => {
+  (context, auth, servicePayload, authzGroupIds) => {
     const logger = getLogger(context, logPrefix);
     const serviceId = ulidGenerator();
 
@@ -139,18 +130,13 @@ export const makeCreateServiceHandler =
           userSubscriptionId: auth.subscriptionId,
         }),
       ),
-      TE.toUnion,
-    )();
+    );
   };
 
 export const applyRequestMiddelwares =
   (config: IConfig, subscriptionCIDRsModel: SubscriptionCIDRsModel) =>
   (handler: ICreateServiceHandler) => {
     const middlewaresWrap = withRequestMiddlewares(
-      // extract the Azure functions context
-      ContextMiddleware(),
-      // only allow requests by users belonging to certain groups
-      AzureApiAuthMiddleware(new Set([UserGroup.ApiServiceWrite])),
       // extract the client IP from the request
       ClientIpMiddleware,
       // check manage key
@@ -158,14 +144,27 @@ export const applyRequestMiddelwares =
         subscriptionCIDRsModel,
         config,
       ),
+      // extract the Azure functions context
+      ContextMiddleware(),
+      // only allow requests by users belonging to certain groups
+      AzureApiAuthMiddleware(new Set([UserGroup.ApiServiceWrite])),
       // validate the reuqest body to be in the expected shape
-      RequiredBodyPayloadMiddleware(ServiceRequestPayload),
+      RequiredBodyPayloadMiddleware(CreateServicePayload),
       SelfcareUserGroupsMiddleware(),
     );
     return wrapRequestHandler(
-      middlewaresWrap(
-        // eslint-disable-next-line max-params
-        checkSourceIpForHandler(handler, (_, __, c, u) => ipTuple(c, u)),
+      middlewaresWrap((...args) =>
+        pipe(
+          args,
+          ([clientIp, userAttributesManage, ...rest]) =>
+            pipe(
+              checkSourceIp(clientIp, userAttributesManage.authorizedCIDRs),
+              E.map((_) => rest),
+            ),
+          TE.fromEither,
+          TE.chainW((args) => handler(...args)),
+          TE.toUnion,
+        )(),
       ),
     );
   };

--- a/apps/io-services-cms-webapp/src/webservice/index.ts
+++ b/apps/io-services-cms-webapp/src/webservice/index.ts
@@ -66,6 +66,10 @@ import {
 } from "./controllers/get-services";
 import { makeInfoHandler } from "./controllers/info";
 import {
+  applyRequestMiddelwares as applyPatchServiceRequestMiddelwares,
+  makePatchServiceHandler,
+} from "./controllers/patch-service";
+import {
   applyRequestMiddelwares as applyPublishServiceRequestMiddelwares,
   makePublishServiceHandler,
 } from "./controllers/publish-service";
@@ -214,6 +218,18 @@ export const createWebServer = ({
         telemetryClient,
       }),
       applyEditServiceRequestMiddelwares(config, subscriptionCIDRsModel),
+    ),
+  );
+
+  router.patch(
+    serviceLifecyclePath,
+    pipe(
+      makePatchServiceHandler({
+        apimService,
+        fsmLifecycleClientCreator,
+        telemetryClient,
+      }),
+      applyPatchServiceRequestMiddelwares(config),
     ),
   );
 

--- a/apps/io-services-cms-webapp/turbo.json
+++ b/apps/io-services-cms-webapp/turbo.json
@@ -1,0 +1,30 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "generate:definitions": {
+      "inputs": [
+        "openapi.yaml",
+        "../../packages/io-services-cms-models/openapi/*.yaml"
+      ],
+      "outputs": [
+        "src/generated/api/**/*"
+      ]
+    },
+    "generate:avro": {
+      "inputs": [
+        "avro/**"
+      ],
+      "outputs": [
+        "src/generated/avro/**/*"
+      ]
+    },
+    "generate": {
+      "dependsOn": [
+        "generate:definitions",
+        "generate:avro"
+      ]
+    }
+  }
+}

--- a/packages/io-services-cms-models/openapi/services-cms-schemas.yaml
+++ b/packages/io-services-cms-models/openapi/services-cms-schemas.yaml
@@ -94,6 +94,28 @@ ServicePayload:
       required:
         - metadata
     - $ref: '#/ServiceData'
+CreateServicePayload:
+  description: A payload used to create a service.
+  allOf:
+    - type: object
+      properties:
+        metadata:
+          $ref: '#/CreateServicePayloadMetadata'
+      required:
+        - metadata
+    - $ref: '#/ServiceData'
+PatchServicePayload:
+  description: A payload used to patch a service.
+  type: object
+  properties:
+    metadata:
+      type: object
+      properties:
+        group_id:
+          type: string
+          minLength: 1
+  required:
+    - metadata
 ServiceData:
   type: object
   description: Service basic data
@@ -194,6 +216,18 @@ ServiceMetadata:
           minLength: 1
 ServicePayloadMetadata:
   description: A set of service metadata properties on request payload
+  allOf:
+    - $ref: '#/ServiceBaseMetadata'
+    - type: object
+      properties:
+        topic_id:
+          type: number
+          description: The topic id
+          example: 3
+      required:
+        - topic_id
+CreateServicePayloadMetadata:
+  description: A set of service metadata properties on create request payload
   allOf:
     - $ref: '#/ServiceBaseMetadata'
     - type: object

--- a/packages/io-services-cms-models/src/lib/fsm/store.memory.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/store.memory.ts
@@ -51,6 +51,26 @@ export const createMemoryStore = <
       ),
     // for testing
     inspect: () => m,
+    patch: (id: string, value) =>
+      pipe(
+        m.get(id),
+        O.fromNullable,
+        O.map((found) => ({
+          ...found,
+          data: {
+            ...found.data,
+            metadata: {
+              ...found.data.metadata,
+              group_id: value.data.metadata.group_id,
+            },
+          },
+        })),
+        O.map((item) => m.set(id, item)),
+        O.map((map) => map.get(id)),
+        O.chain(O.fromPredicate((item) => !!item)),
+        O.map((item) => item as T),
+        TE.fromOption(() => new Error("No item found with id " + id)),
+      ),
     save: (id: string, value) =>
       pipe(
         () => Promise.resolve(m.set(id, value)),

--- a/packages/io-services-cms-models/src/lib/fsm/types.ts
+++ b/packages/io-services-cms-models/src/lib/fsm/types.ts
@@ -4,6 +4,8 @@ import * as O from "fp-ts/Option";
 import * as TE from "fp-ts/TaskEither";
 import * as t from "io-ts";
 
+import { Patchable } from "../../service-lifecycle/definitions";
+
 /**
  * Metadata to be appended to an element to describe
  */
@@ -11,21 +13,23 @@ export type StateMetadata<S extends string> = t.TypeOf<
   ReturnType<typeof StateMetadata<S>>
 >;
 export const StateMetadata = <S extends string>(state: S) =>
-  t.type({
-    fsm: t.intersection([
-      t.type({
-        /* the current element state */
-        state: t.literal(state),
-      }),
-      // optional, free-form metadata values
-      t.record(t.string, t.unknown),
-      // optional, well-known metadata values
-      t.partial({
-        /* store the information of which transition provoked the state change */
-        lastTransition: t.string,
-      }),
-    ]),
-  });
+  t.exact(
+    t.type({
+      fsm: t.intersection([
+        t.type({
+          /* the current element state */
+          state: t.literal(state),
+        }),
+        // optional, free-form metadata values
+        t.record(t.string, t.unknown),
+        // optional, well-known metadata values
+        t.partial({
+          /* store the information of which transition provoked the state change */
+          lastTransition: t.string,
+        }),
+      ]),
+    }),
+  );
 
 export type WithState<S extends string, T> = t.TypeOf<
   ReturnType<typeof WithState<S, T>>
@@ -51,6 +55,7 @@ export interface FSMStore<
   getServiceIdsByGroupIds: (
     groupIds: readonly string[],
   ) => TE.TaskEither<Error, readonly string[]>;
+  patch: (id: string, data: Patchable) => TE.TaskEither<Error, TT>;
   save: (
     id: string,
     data: TT,

--- a/packages/io-services-cms-models/src/service-history/index.ts
+++ b/packages/io-services-cms-models/src/service-history/index.ts
@@ -11,14 +11,14 @@ export const ServiceHistory = t.union([
     LifecycleItemType,
     t.type({
       last_update: NonEmptyString,
-      serviceId: Service.types[0].props.id,
+      serviceId: Service.type.types[0].props.id,
     }),
   ]),
   t.intersection([
     PublicationItemType,
     t.type({
       last_update: NonEmptyString,
-      serviceId: Service.types[0].props.id,
+      serviceId: Service.type.types[0].props.id,
     }),
   ]),
 ]);

--- a/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/__tests__/index.test.ts
@@ -183,6 +183,52 @@ describe("apply", () => {
         fsm: expect.objectContaining({ state: "submitted" }),
       }),
     },
+    {
+      title:
+        "an item creation with group_id and then an edit that do not have to override group_id",
+      id: aServiceId,
+      actions: [
+        () =>
+          fsmClientWithoutAuthz.create(aServiceId, {
+            data: {
+              ...aService,
+              data: {
+                ...aService.data,
+                metadata: {
+                  ...aService.data.metadata,
+                  group_id: "foo" as NonEmptyString,
+                },
+              },
+            },
+          }),
+        () =>
+          fsmClientWithoutAuthz.edit(aServiceId, {
+            data: changeName(
+              {
+                ...aService,
+                data: {
+                  ...aService.data,
+                  metadata: {
+                    ...aService.data.metadata,
+                    group_id: "bar" as NonEmptyString,
+                  },
+                },
+              },
+              "new name",
+            ),
+          }),
+        () => fsmClientWithoutAuthz.submit(aServiceId, { autoPublish: false }),
+      ],
+      expected: expect.objectContaining({
+        ...aService,
+        data: {
+          ...aService.data,
+          name: "new name",
+          metadata: { ...aService.data.metadata, group_id: "foo" },
+        },
+        fsm: expect.objectContaining({ state: "submitted" }),
+      }),
+    },
   ])("should apply $title", expectSuccess);
 
   // invalid sequences

--- a/packages/io-services-cms-models/src/service-lifecycle/definitions.ts
+++ b/packages/io-services-cms-models/src/service-lifecycle/definitions.ts
@@ -178,19 +178,21 @@ export type ServiceId = t.TypeOf<typeof ServiceId>;
 export const ServiceId = NonEmptyString;
 
 export type Service = t.TypeOf<typeof Service>;
-export const Service = t.intersection([
-  t.type({
-    data: t.intersection([
-      ServiceData,
-      t.type({ metadata: ServiceMetadata, organization: OrganizationData }),
-    ]),
-    id: ServiceId,
-  }),
-  t.partial({
-    modified_at: t.Integer,
-    version: NonEmptyString,
-  }),
-]);
+export const Service = t.exact(
+  t.intersection([
+    t.type({
+      data: t.intersection([
+        ServiceData,
+        t.type({ metadata: ServiceMetadata, organization: OrganizationData }),
+      ]),
+      id: ServiceId,
+    }),
+    t.partial({
+      modified_at: t.Integer,
+      version: NonEmptyString,
+    }),
+  ]),
+);
 
 export type ServiceStrict = t.TypeOf<typeof ServiceStrict>;
 export const ServiceStrict = t.intersection([
@@ -223,3 +225,7 @@ export const ServiceQualityStrict = t.intersection([
     ]),
   }),
 ]);
+
+export interface Patchable {
+  data: { metadata: { group_id?: string } };
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "generate": {
       "inputs": [
         "./openapi.yaml",
-        "./avro/**"
+        "./openapi/*.yaml"
       ],
       "outputs": [
         "src/generated/**/*"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Allow operator to edit service without overriding group

#### List of Changes
<!--- Describe your changes in detail -->
- create a new `patchService` endpoint to allow group overriding (only for admin users)
- FSM edit actions now do not override `group_id`
- remove any group's logics from BO edit-service

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To prevent the group change request from causing a status change in the FSM

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Unit Tests
- Run app locally

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
