### PR TITLE
[IOPAE-1568] bff add manage group keys retrieve endpoint handler

### DIFF
--- a/.changeset/big-tools-know.md
+++ b/.changeset/big-tools-know.md
@@ -1,0 +1,6 @@
+---
+"io-services-cms-webapp": patch
+"@io-services-cms/external-clients": patch
+---
+
+fix listSecrets return type

--- a/.changeset/five-zoos-give.md
+++ b/.changeset/five-zoos-give.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+add getManageSubscriptionKeys route handler

--- a/apps/backoffice/src/app/api/institutions/[institutionId]/groups/any/route.ts
+++ b/apps/backoffice/src/app/api/institutions/[institutionId]/groups/any/route.ts
@@ -16,7 +16,7 @@ import { BackOfficeUser } from "../../../../../../../types/next-auth";
  */
 export const GET = withJWTAuthHandler(
   async (
-    request: NextRequest,
+    _: NextRequest,
     {
       backofficeUser,
       params,

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BackOfficeUser } from "../../../../../../../types/next-auth";
+import { ApiKeyNotFoundError } from "../../../../../../lib/be/errors";
+import { GET } from "../route";
+
+const backofficeUserMock = { permissions: {} } as BackOfficeUser;
+
+const {
+  isAdminMock,
+  retrieveManageSubscriptionApiKeysMock,
+  withJWTAuthHandlerMock,
+} = vi.hoisted(() => ({
+  isAdminMock: vi.fn(() => true),
+  retrieveManageSubscriptionApiKeysMock: vi.fn(),
+  withJWTAuthHandlerMock: vi.fn(
+    (
+      handler: (
+        nextRequest: NextRequest,
+        context: { backofficeUser: BackOfficeUser; params: any },
+      ) => Promise<NextResponse> | Promise<Response>,
+    ) =>
+      async (nextRequest: NextRequest, { params }: { params: {} }) =>
+        handler(nextRequest, {
+          backofficeUser: backofficeUserMock,
+          params,
+        }),
+  ),
+}));
+
+vi.mock("@/lib/be/wrappers", () => ({
+  withJWTAuthHandler: withJWTAuthHandlerMock,
+}));
+vi.mock("@/lib/be/authz", () => ({
+  isAdmin: isAdminMock,
+}));
+vi.mock("@/lib/be/keys/business", () => ({
+  retrieveManageSubscriptionApiKeys: retrieveManageSubscriptionApiKeysMock,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getManageSubscriptionKeys", () => {
+  it.each`
+    scenario                                         | selcGroups
+    ${"selcGroups is not defined"}                   | ${undefined}
+    ${"has no groups"}                               | ${[]}
+    ${"requested subscription-group does not match"} | ${["anotherGroupId"]}
+  `(
+    "should return an unauthorized response when user is not admin and $scenario",
+    async ({ selcGroups }) => {
+      // given
+      const nextRequest = new NextRequest("http://localhost");
+      const subscriptionId = "MANAGE-GROUP-groupId";
+      isAdminMock.mockReturnValueOnce(false);
+      backofficeUserMock.permissions.selcGroups = selcGroups;
+
+      // when
+      const result = await GET(nextRequest, {
+        params: { subscriptionId },
+      });
+
+      // then
+      const jsonBody = await result.json();
+      expect(result.status).toBe(403);
+      expect(jsonBody.detail).toEqual(
+        "Requested subscription is out of your scope",
+      );
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(retrieveManageSubscriptionApiKeysMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each`
+    scenario                                                      | isAdmin  | selcGroups
+    ${"user id admin"}                                            | ${true}  | ${undefined}
+    ${"user id not admin but requested subscription-group match"} | ${false} | ${["groupId"]}
+  `(
+    "should return an unauthorized response when user is not admin and $scenario",
+    async ({ isAdmin, selcGroups }) => {
+      // given
+      const nextRequest = new NextRequest("http://localhost");
+      const subscriptionId = "MANAGE-GROUP-groupId";
+      isAdminMock.mockReturnValueOnce(isAdmin);
+      backofficeUserMock.permissions.selcGroups = selcGroups;
+      const expectedResponse = { foo: "bar" };
+      retrieveManageSubscriptionApiKeysMock.mockResolvedValueOnce(
+        expectedResponse,
+      );
+
+      // when
+      const result = await GET(nextRequest, {
+        params: { subscriptionId },
+      });
+
+      // then
+      const jsonBody = await result.json();
+      expect(result.status).toBe(200);
+      expect(jsonBody).toStrictEqual(expectedResponse);
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(retrieveManageSubscriptionApiKeysMock).toHaveBeenCalledOnce();
+      expect(retrieveManageSubscriptionApiKeysMock).toHaveBeenCalledWith(
+        subscriptionId,
+      );
+    },
+  );
+
+  it.each`
+    scenario                 | expectedStatusCode | error                        | expectedTitle               | expectedDetail
+    ${"a generic error"}     | ${500}             | ${new Error()}               | ${"ManageKeyRetrieveError"} | ${"Something went wrong"}
+    ${"ApiKeyNotFoundError"} | ${404}             | ${new ApiKeyNotFoundError()} | ${"ApiKeyNotFoundError"}    | ${"the API does not exists"}
+  `(
+    "should return an error response when retrieveManageSubscriptionApiKeys rejects with ",
+    async ({ error, expectedStatusCode, expectedTitle, expectedDetail }) => {
+      // given
+      const nextRequest = new NextRequest("http://localhost");
+      const subscriptionId = "MANAGE-GROUP-groupId";
+      isAdminMock.mockReturnValueOnce(true);
+      retrieveManageSubscriptionApiKeysMock.mockRejectedValueOnce(error);
+
+      // when
+      const result = await GET(nextRequest, {
+        params: { subscriptionId },
+      });
+
+      // then
+      const jsonBody = await result.json();
+      expect(result.status).toBe(expectedStatusCode);
+      expect(jsonBody.title).toEqual(expectedTitle);
+      expect(jsonBody.detail).toEqual(expectedDetail);
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(retrieveManageSubscriptionApiKeysMock).toHaveBeenCalledOnce();
+      expect(retrieveManageSubscriptionApiKeysMock).toHaveBeenCalledWith(
+        subscriptionId,
+      );
+    },
+  );
+});

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/route.ts
@@ -1,0 +1,62 @@
+import { ResponseError } from "@/generated/api/ResponseError";
+import { SubscriptionKeys } from "@/generated/api/SubscriptionKeys";
+import { isAdmin } from "@/lib/be/authz";
+import {
+  ApiKeyNotFoundError,
+  handleForbiddenErrorResponse,
+  handleInternalErrorResponse,
+  handleNotFoundErrorResponse,
+  handlerErrorLog,
+} from "@/lib/be/errors";
+import { retrieveManageSubscriptionApiKeys } from "@/lib/be/keys/business";
+import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
+import { withJWTAuthHandler } from "@/lib/be/wrappers";
+import { ApimUtils } from "@io-services-cms/external-clients";
+import { NextRequest, NextResponse } from "next/server";
+
+import { BackOfficeUser } from "../../../../../../types/next-auth";
+
+/**
+ * @operationId getManageSubscriptionKeys
+ * @description Retrieve Manage Subscription keys
+ *
+ */
+export const GET = withJWTAuthHandler(
+  async (
+    _: NextRequest,
+    {
+      backofficeUser,
+      params,
+    }: { backofficeUser: BackOfficeUser; params: { subscriptionId: string } },
+  ): Promise<NextResponse<ResponseError | SubscriptionKeys>> => {
+    if (
+      !isAdmin(backofficeUser) &&
+      !backofficeUser.permissions.selcGroups?.includes(
+        params.subscriptionId.substring(
+          ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX.length,
+        ),
+      )
+    ) {
+      return handleForbiddenErrorResponse(
+        "Requested subscription is out of your scope",
+      );
+    }
+    // TODO: add subscription ownerId check. To do that we need to fetch first the subscription in order to get its ownerId and then check equality with backofficeUser.parameters.userId
+    try {
+      const subscriptionKeysResponse = await retrieveManageSubscriptionApiKeys(
+        params.subscriptionId,
+      );
+      console.log("subscriptionKeysResponse", subscriptionKeysResponse);
+      return sanitizedNextResponseJson(subscriptionKeysResponse);
+    } catch (error) {
+      handlerErrorLog(
+        `An Error has occurred while retrieving Manage Subscription Keys for subscriptionId: ${params.subscriptionId}`,
+        error,
+      );
+      if (error instanceof ApiKeyNotFoundError) {
+        return handleNotFoundErrorResponse("ApiKeyNotFoundError", error);
+      }
+      return handleInternalErrorResponse("ManageKeyRetrieveError", error);
+    }
+  },
+);

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -4,6 +4,7 @@ import {
   ProductContract,
   Resource,
   SubscriptionContract,
+  SubscriptionKeysContract,
   SubscriptionListSecretsResponse,
   UserContract,
   UserCreateParameters,
@@ -133,7 +134,7 @@ export interface ApimService {
   ) => TE.TaskEither<ApimRestError, readonly SubscriptionContract[]>;
   readonly listSecrets: (
     serviceId: string,
-  ) => TE.TaskEither<ApimRestError, SubscriptionContract>;
+  ) => TE.TaskEither<ApimRestError, SubscriptionKeysContract>;
   readonly regenerateSubscriptionKey: (
     serviceId: string,
     keyType: SubscriptionKeyType,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We have to implement missing `getManageSubscriptionKeys` route handler

#### List of Changes
<!--- Describe your changes in detail -->
- fix listSecrets return type
- add getManageSubscriptionKeys route handler

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`getManageSubscriptionKeys` OpenAPI operation had been defined, but its implementation has been lacking.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Unit Tests
- Run app locally

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
