### PR TITLE
[IOPAE-1570] bff add manage group keys regenerate endpoint handler

### DIFF
--- a/.changeset/metal-goats-add.md
+++ b/.changeset/metal-goats-add.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/external-clients": minor
+"io-services-cms-backoffice": minor
+---
+
+add regenerateManageSubscriptionKey route handler

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/__tests__/route.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NextRequest, NextResponse } from "next/server";
+import { BackOfficeUser } from "../../../../../../../../types/next-auth";
+import { PUT } from "../route";
+
+const backofficeUserMock = { permissions: {} } as BackOfficeUser;
+
+const {
+  isAdminMock,
+  regenerateManageSubscritionApiKeyMock,
+  withJWTAuthHandlerMock,
+} = vi.hoisted(() => ({
+  isAdminMock: vi.fn(() => true),
+  regenerateManageSubscritionApiKeyMock: vi.fn(),
+  withJWTAuthHandlerMock: vi.fn(
+    (
+      handler: (
+        nextRequest: NextRequest,
+        context: { backofficeUser: BackOfficeUser; params: any },
+      ) => Promise<NextResponse> | Promise<Response>,
+    ) =>
+      async (nextRequest: NextRequest, { params }: { params: {} }) =>
+        handler(nextRequest, {
+          backofficeUser: backofficeUserMock,
+          params,
+        }),
+  ),
+}));
+
+vi.mock("@/lib/be/wrappers", () => ({
+  withJWTAuthHandler: withJWTAuthHandlerMock,
+}));
+vi.mock("@/lib/be/authz", () => ({
+  isAdmin: isAdminMock,
+}));
+vi.mock("@/lib/be/keys/business", () => ({
+  regenerateManageSubscritionApiKey: regenerateManageSubscritionApiKeyMock,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("regenerateManageSubscriptionKey", () => {
+  it.each`
+    scenario                                         | selcGroups
+    ${"selcGroups is not defined"}                   | ${undefined}
+    ${"has no groups"}                               | ${[]}
+    ${"requested subscription-group does not match"} | ${["anotherGroupId"]}
+  `(
+    "should return an unauthorized response when user is not admin and $scenario",
+    async ({ selcGroups }) => {
+      // given
+      const nextRequest = new NextRequest("http://localhost");
+      const subscriptionId = "MANAGE-GROUP-groupId";
+      isAdminMock.mockReturnValueOnce(false);
+      backofficeUserMock.permissions.selcGroups = selcGroups;
+
+      // when
+      const result = await PUT(nextRequest, {
+        params: { subscriptionId },
+      });
+
+      // then
+      const jsonBody = await result.json();
+      expect(result.status).toBe(403);
+      expect(jsonBody.detail).toEqual(
+        "Requested subscription is out of your scope",
+      );
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(regenerateManageSubscritionApiKeyMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("should return a bad request when key type is not valid", async () => {
+    // given
+    const nextRequest = new NextRequest("http://localhost");
+    const subscriptionId = "MANAGE-GROUP-groupId";
+    isAdminMock.mockReturnValueOnce(true);
+    backofficeUserMock.permissions.selcGroups = undefined;
+    const keyType = "invalid";
+
+    // when
+    const result = await PUT(nextRequest, {
+      params: { subscriptionId, keyType },
+    });
+
+    // then
+    const jsonBody = await result.json();
+    expect(result.status).toBe(400);
+    expect(jsonBody.detail).toMatch(/is not a valid/);
+    expect(isAdminMock).toHaveBeenCalledOnce();
+    expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+    expect(regenerateManageSubscritionApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  it.each`
+    scenario                                                      | isAdmin  | selcGroups
+    ${"user id admin"}                                            | ${true}  | ${undefined}
+    ${"user id not admin but requested subscription-group match"} | ${false} | ${["groupId"]}
+  `(
+    "should return an unauthorized response when user is not admin and $scenario",
+    async ({ isAdmin, selcGroups }) => {
+      // given
+      const nextRequest = new NextRequest("http://localhost");
+      const subscriptionId = "MANAGE-GROUP-groupId";
+      const keyType = "primary";
+      isAdminMock.mockReturnValueOnce(isAdmin);
+      backofficeUserMock.permissions.selcGroups = selcGroups;
+      const expectedResponse = { foo: "bar" };
+      regenerateManageSubscritionApiKeyMock.mockResolvedValueOnce(
+        expectedResponse,
+      );
+
+      // when
+      const result = await PUT(nextRequest, {
+        params: { subscriptionId, keyType },
+      });
+
+      // then
+      const jsonBody = await result.json();
+      expect(result.status).toBe(200);
+      expect(jsonBody).toStrictEqual(expectedResponse);
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledOnce();
+      expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledWith(
+        subscriptionId,
+        keyType,
+      );
+    },
+  );
+
+  it.each`
+    scenario             | expectedStatusCode | error          | expectedTitle                 | expectedDetail
+    ${"a generic error"} | ${500}             | ${new Error()} | ${"ManageKeyRegenerateError"} | ${"Something went wrong"}
+  `(
+    "should return an error response when retrieveManageSubscriptionApiKeys rejects with ",
+    async ({ error, expectedStatusCode, expectedTitle, expectedDetail }) => {
+      // given
+      const nextRequest = new NextRequest("http://localhost");
+      const subscriptionId = "MANAGE-GROUP-groupId";
+      const keyType = "primary";
+      isAdminMock.mockReturnValueOnce(true);
+      regenerateManageSubscritionApiKeyMock.mockRejectedValueOnce(error);
+
+      // when
+      const result = await PUT(nextRequest, {
+        params: { subscriptionId, keyType },
+      });
+
+      // then
+      const jsonBody = await result.json();
+      expect(result.status).toBe(expectedStatusCode);
+      expect(jsonBody.title).toEqual(expectedTitle);
+      expect(jsonBody.detail).toEqual(expectedDetail);
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledOnce();
+      expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledWith(
+        subscriptionId,
+        keyType,
+      );
+    },
+  );
+});

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/route.ts
@@ -1,0 +1,71 @@
+import { ResponseError } from "@/generated/api/ResponseError";
+import { SubscriptionKeyType } from "@/generated/api/SubscriptionKeyType";
+import { SubscriptionKeys } from "@/generated/api/SubscriptionKeys";
+import { isAdmin } from "@/lib/be/authz";
+import {
+  handleBadRequestErrorResponse,
+  handleForbiddenErrorResponse,
+  handleInternalErrorResponse,
+  handlerErrorLog,
+} from "@/lib/be/errors";
+import { regenerateManageSubscritionApiKey } from "@/lib/be/keys/business";
+import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
+import { withJWTAuthHandler } from "@/lib/be/wrappers";
+import { ApimUtils } from "@io-services-cms/external-clients";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import * as E from "fp-ts/lib/Either";
+import { NextRequest, NextResponse } from "next/server";
+
+import { BackOfficeUser } from "../../../../../../../types/next-auth";
+
+/**
+ * @operationId regenerateManageSubscriptionKey
+ * @description Regenerate Manage key by key type
+ */
+export const PUT = withJWTAuthHandler(
+  async (
+    _: NextRequest,
+    {
+      backofficeUser,
+      params,
+    }: {
+      backofficeUser: BackOfficeUser;
+      params: { keyType: string; subscriptionId: string };
+    },
+  ): Promise<NextResponse<ResponseError | SubscriptionKeys>> => {
+    if (
+      !isAdmin(backofficeUser) &&
+      !backofficeUser.permissions.selcGroups?.includes(
+        params.subscriptionId.substring(
+          ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX.length,
+        ),
+      )
+    ) {
+      return handleForbiddenErrorResponse(
+        "Requested subscription is out of your scope",
+      );
+    }
+    try {
+      const maybeDecodedKeyType = SubscriptionKeyType.decode(params.keyType);
+
+      if (E.isLeft(maybeDecodedKeyType)) {
+        return handleBadRequestErrorResponse(
+          readableReport(maybeDecodedKeyType.left),
+        );
+      }
+
+      const manageKeysResponse = await regenerateManageSubscritionApiKey(
+        params.subscriptionId,
+        maybeDecodedKeyType.right,
+      );
+
+      return sanitizedNextResponseJson(manageKeysResponse);
+    } catch (error) {
+      handlerErrorLog(
+        `An Error has occurred while regenerating ${params.keyType} Manage Subscription Keys for subscriptionId: ${params.subscriptionId}`,
+        error,
+      );
+      return handleInternalErrorResponse("ManageKeyRegenerateError", error);
+    }
+  },
+);

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -114,7 +114,7 @@ export interface ApimService {
     productName: NonEmptyString,
   ) => TE.TaskEither<ApimRestError, O.Option<ProductContract>>;
   readonly getSubscription: (
-    serviceId: string,
+    subscriptionId: string,
   ) => TE.TaskEither<ApimRestError, SubscriptionContract>;
   readonly getUser: (
     userId: string,
@@ -133,10 +133,10 @@ export interface ApimService {
     filter?: string,
   ) => TE.TaskEither<ApimRestError, readonly SubscriptionContract[]>;
   readonly listSecrets: (
-    serviceId: string,
+    subscriptionId: string,
   ) => TE.TaskEither<ApimRestError, SubscriptionKeysContract>;
   readonly regenerateSubscriptionKey: (
-    serviceId: string,
+    subscriptionId: string,
     keyType: SubscriptionKeyType,
   ) => TE.TaskEither<ApimRestError, SubscriptionContract>;
   readonly upsertSubscription: (
@@ -181,8 +181,13 @@ export const getApimService = (
       apimServiceName,
       productName,
     ),
-  getSubscription: (serviceId) =>
-    getSubscription(apimClient, apimResourceGroup, apimServiceName, serviceId),
+  getSubscription: (subscriptionId) =>
+    getSubscription(
+      apimClient,
+      apimResourceGroup,
+      apimServiceName,
+      subscriptionId,
+    ),
   getUser: (userId) =>
     getUser(apimClient, apimResourceGroup, apimServiceName, userId),
   getUserByEmail: (userEmail, fetchGroups) =>
@@ -210,14 +215,14 @@ export const getApimService = (
       offset,
       limit,
     ),
-  listSecrets: (serviceId) =>
-    listSecrets(apimClient, apimResourceGroup, apimServiceName, serviceId),
-  regenerateSubscriptionKey: (serviceId, keyType) =>
+  listSecrets: (subscriptionId) =>
+    listSecrets(apimClient, apimResourceGroup, apimServiceName, subscriptionId),
+  regenerateSubscriptionKey: (subscriptionId, keyType) =>
     regenerateSubscriptionKey(
       apimClient,
       apimResourceGroup,
       apimServiceName,
-      serviceId,
+      subscriptionId,
       keyType,
     ),
   upsertSubscription: (ownerId, subscriptionId) =>
@@ -338,14 +343,14 @@ const getUserGroups = (
  * @param apimClient
  * @param apimResourceGroup
  * @param apimServiceName
- * @param serviceId
+ * @param subscriptionId
  * @returns
  */
 const getSubscription = (
   apimClient: ApiManagementClient,
   apimResourceGroup: string,
   apimServiceName: string,
-  serviceId: string,
+  subscriptionId: string,
 ) =>
   pipe(
     TE.tryCatch(
@@ -353,7 +358,7 @@ const getSubscription = (
         apimClient.subscription.get(
           apimResourceGroup,
           apimServiceName,
-          serviceId,
+          subscriptionId,
         ),
       identity,
     ),
@@ -366,14 +371,14 @@ const getSubscription = (
  * @param apimClient
  * @param apimResourceGroup
  * @param apimServiceName
- * @param serviceId
+ * @param subscriptionId
  * @returns
  */
 const listSecrets = (
   apimClient: ApiManagementClient,
   apimResourceGroup: string,
   apimServiceName: string,
-  serviceId: string,
+  subscriptionId: string,
 ) =>
   pipe(
     TE.tryCatch(
@@ -381,7 +386,7 @@ const listSecrets = (
         apimClient.subscription.listSecrets(
           apimResourceGroup,
           apimServiceName,
-          serviceId,
+          subscriptionId,
         ),
       identity,
     ),
@@ -519,7 +524,7 @@ const getUserSubscriptions = (
  * @param apimClient
  * @param apimResourceGroup
  * @param apimServiceName
- * @param serviceId
+ * @param subscriptionId
  * @param keyType
  * @returns updated subscription
  */
@@ -527,7 +532,7 @@ const regenerateSubscriptionKey = (
   apimClient: ApiManagementClient,
   apimResourceGroup: string,
   apimServiceName: string,
-  serviceId: string,
+  subscriptionId: string,
   keyType: SubscriptionKeyType,
 ): TE.TaskEither<ApimRestError, SubscriptionListSecretsResponse> =>
   pipe(
@@ -537,13 +542,13 @@ const regenerateSubscriptionKey = (
           return apimClient.subscription.regeneratePrimaryKey(
             apimResourceGroup,
             apimServiceName,
-            serviceId,
+            subscriptionId,
           );
         case SubscriptionKeyTypeEnum.secondary:
           return apimClient.subscription.regenerateSecondaryKey(
             apimResourceGroup,
             apimServiceName,
-            serviceId,
+            subscriptionId,
           );
         default:
           // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-case-declarations
@@ -558,7 +563,7 @@ const regenerateSubscriptionKey = (
           apimClient.subscription.listSecrets(
             apimResourceGroup,
             apimServiceName,
-            serviceId,
+            subscriptionId,
           ),
         E.toError,
       ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
We have to implement missing `regenerateManageSubscriptionKey` route handler

#### List of Changes
<!--- Describe your changes in detail -->
- [refactor: rename serviceId to subscriptionId](https://github.com/pagopa/io-services-cms/commit/62e169b8f818a2f3eb980325261cf7b4ebd181b3)
- [add regenerateManageSubscriptionKey route handler](https://github.com/pagopa/io-services-cms/commit/0e10200fed61d1637a3fa9c2f3ee760c210a7897)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`regenerateManageSubscriptionKey` OpenAPI operation had been defined, but its implementation has been lacking.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
