### PR TITLE
[IOPAE-1677] bff get institution groups api

### DIFF
--- a/.changeset/healthy-goats-decide.md
+++ b/.changeset/healthy-goats-decide.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+add getInstitutionGroups api

--- a/apps/backoffice/src/app/api/institutions/[institutionId]/groups/route.ts
+++ b/apps/backoffice/src/app/api/institutions/[institutionId]/groups/route.ts
@@ -1,18 +1,29 @@
-import { isAdmin, isInstitutionIdSameAsCaller } from "@/lib/be/authz";
+import { Group } from "@/generated/api/Group";
 import {
+  GroupFilterType,
+  GroupFilterTypeEnum,
+} from "@/generated/api/GroupFilterType";
+import { userAuthz as getUserAuthz } from "@/lib/be/authz";
+import {
+  handleBadRequestErrorResponse,
   handleForbiddenErrorResponse,
   handleInternalErrorResponse,
   handlerErrorLog,
 } from "@/lib/be/errors";
-import { retrieveUnboundInstitutionGroups } from "@/lib/be/institutions/business";
+import {
+  retrieveInstitutionGroups,
+  retrieveUnboundInstitutionGroups,
+} from "@/lib/be/institutions/business";
+import { getQueryParam } from "@/lib/be/req-res-utils";
 import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
 import { withJWTAuthHandler } from "@/lib/be/wrappers";
+import * as E from "fp-ts/lib/Either";
 import { NextRequest } from "next/server";
 
 import { BackOfficeUser } from "../../../../../../types/next-auth";
 
 /**
- * @operationId getUnboundInstitutionGroups
+ * @operationId getInstitutionGroups
  * @description Retrieve groups for an Institution ID
  */
 export const GET = withJWTAuthHandler(
@@ -23,18 +34,42 @@ export const GET = withJWTAuthHandler(
       params,
     }: { backofficeUser: BackOfficeUser; params: { institutionId: string } },
   ) => {
-    if (!isInstitutionIdSameAsCaller(backofficeUser, params.institutionId)) {
+    const userAuthz = getUserAuthz(backofficeUser);
+    if (!userAuthz.isInstitutionAllowed(params.institutionId)) {
       return handleForbiddenErrorResponse("Unauthorized institutionId");
     }
-    if (!isAdmin(backofficeUser)) {
+    if (!userAuthz.isAdmin()) {
       return handleForbiddenErrorResponse("Role not authorized");
     }
-    try {
-      const institutionResponse = await retrieveUnboundInstitutionGroups(
-        params.institutionId,
-        backofficeUser.parameters.userId,
+    const maybeFilter = getQueryParam(
+      request,
+      "filter",
+      GroupFilterType,
+      GroupFilterTypeEnum.ALL,
+    );
+    if (E.isLeft(maybeFilter)) {
+      return handleBadRequestErrorResponse(
+        `'filter' query param is not a valid ${GroupFilterType.name}`,
       );
-      return sanitizedNextResponseJson({ groups: institutionResponse });
+    }
+    try {
+      let groups: Group[];
+      switch (maybeFilter.right) {
+        case GroupFilterTypeEnum.ALL:
+          groups = await retrieveInstitutionGroups(params.institutionId);
+          break;
+        case GroupFilterTypeEnum.UNBOUND:
+          groups = await retrieveUnboundInstitutionGroups(
+            backofficeUser.parameters.userId,
+            params.institutionId,
+          );
+          break;
+        default:
+          // eslint-disable-next-line no-case-declarations
+          const _: never = maybeFilter.right;
+          throw new Error(`Invalid filter: ${maybeFilter.right}`);
+      }
+      return sanitizedNextResponseJson({ groups });
     } catch (error) {
       handlerErrorLog(
         `An Error has occurred while searching groups for institutionId: ${params.institutionId}`,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Change `getInstitutionGroups` API implementation in order to handle a new query param that will eventually filter the instutution groups

#### List of Changes
<!--- Describe your changes in detail -->
- [getInstitutionGroups api implementation](https://github.com/pagopa/io-services-cms/commit/8b2d1a3a7de4179f816acfec745854e1e4300542)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Required to get either all active groups or only unbounded groups

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
