### PR TITLE
[IOPAE-1678] backoffice group unbound any api

### DIFF
--- a/.changeset/red-months-sniff.md
+++ b/.changeset/red-months-sniff.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+added checkGroupUnboundedServiceExistence

--- a/apps/backoffice/src/app/api/services/group-unbound/any/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/services/group-unbound/any/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BackOfficeUser } from "../../../../../../../types/next-auth";
+import { GET } from "../route";
+
+const backofficeUserMock = {
+  parameters: { subscriptionId: "subscriptionId" },
+} as BackOfficeUser;
+
+const {
+  isAdminMock,
+  userAuthzMock,
+  retrieveUnboundedGroupServicesMock,
+  withJWTAuthHandlerMock,
+} = vi.hoisted(() => {
+  const isAdminMock = vi.fn(() => true);
+  return {
+    isAdminMock,
+    userAuthzMock: vi.fn(() => ({ isAdmin: isAdminMock })),
+    retrieveUnboundedGroupServicesMock: vi.fn(),
+    withJWTAuthHandlerMock: vi.fn(
+      (
+        handler: (
+          nextRequest: NextRequest,
+          context: { params: any; backofficeUser: BackOfficeUser },
+        ) => Promise<NextResponse> | Promise<Response>,
+      ) =>
+        async (nextRequest: NextRequest, { params }: { params: {} }) => {
+          return handler(nextRequest, {
+            params,
+            backofficeUser: backofficeUserMock,
+          });
+        },
+    ),
+  };
+});
+
+vi.mock("@/lib/be/services/business", () => ({
+  retrieveUnboundedGroupServices: retrieveUnboundedGroupServicesMock,
+}));
+vi.mock("@/lib/be/wrappers", () => ({
+  withJWTAuthHandler: withJWTAuthHandlerMock,
+}));
+vi.mock("@/lib/be/authz", () => ({
+  userAuthz: userAuthzMock,
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Check existence of group-unbound Services API", () => {
+  it("should return a forbidden respose when user is not an admin", async () => {
+    //given
+    const nextRequest = new NextRequest("http://localhost");
+    isAdminMock.mockReturnValueOnce(false);
+
+    //when
+    const result = await GET(nextRequest, {});
+
+    //then
+    expect(result.status).toBe(403);
+    const jsonBody = await result.json();
+    expect(jsonBody.detail).toStrictEqual("Role not authorized");
+    expect(userAuthzMock).toHaveBeenCalledOnce();
+    expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
+    expect(isAdminMock).toHaveBeenCalledOnce();
+    expect(isAdminMock).toHaveBeenCalledWith();
+    expect(retrieveUnboundedGroupServicesMock).not.toHaveBeenCalled();
+  });
+
+  it("should return an error response when retrieveUnboundedGroupServices fails", async () => {
+    //given
+    const nextRequest = new NextRequest("http://localhost");
+    isAdminMock.mockReturnValueOnce(true);
+    const error = new Error("error from retrieveUnboundedGroupServices");
+    retrieveUnboundedGroupServicesMock.mockRejectedValueOnce(error);
+
+    //when
+    const result = await GET(nextRequest, {});
+
+    //then
+    expect(result.status).toBe(500);
+    const jsonBody = await result.json();
+    expect(jsonBody.title).toStrictEqual(
+      "GroupUnboundServicesCheckExistenceError",
+    );
+    expect(jsonBody.detail).toStrictEqual("Something went wrong");
+    expect(userAuthzMock).toHaveBeenCalledOnce();
+    expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
+    expect(isAdminMock).toHaveBeenCalledOnce();
+    expect(isAdminMock).toHaveBeenCalledWith();
+    expect(retrieveUnboundedGroupServicesMock).toHaveBeenCalled();
+    expect(retrieveUnboundedGroupServicesMock).toHaveBeenCalledWith(
+      backofficeUserMock,
+    );
+  });
+  it.each`
+    scenario                                                          | statusCode | groupUnboundServiceResult
+    ${"the result list of the group unbounded services is empty"}     | ${204}     | ${[]}
+    ${"the result list of the group unbounded services is not empty"} | ${200}     | ${[{ id: "id1", name: "service name 1" }, { id: "id2", name: "service name 2" }]}
+  `(
+    "Should return $statusCode when $scenario",
+    async ({ statusCode, groupUnboundServiceResult }) => {
+      //given
+      const nextRequest = new NextRequest("http://localhost");
+      isAdminMock.mockReturnValueOnce(true);
+      retrieveUnboundedGroupServicesMock.mockResolvedValueOnce(
+        groupUnboundServiceResult,
+      );
+
+      //when
+      const result = await GET(nextRequest, {});
+
+      //then
+      expect(result.status).toBe(statusCode);
+      expect(userAuthzMock).toHaveBeenCalledOnce();
+      expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith();
+      expect(retrieveUnboundedGroupServicesMock).toHaveBeenCalled();
+      expect(retrieveUnboundedGroupServicesMock).toHaveBeenCalledWith(
+        backofficeUserMock,
+      );
+    },
+  );
+});

--- a/apps/backoffice/src/app/api/services/group-unbound/any/route.ts
+++ b/apps/backoffice/src/app/api/services/group-unbound/any/route.ts
@@ -1,0 +1,42 @@
+import { UnboundedGroupServices } from "@/generated/api/UnboundedGroupServices";
+import { userAuthz } from "@/lib/be/authz";
+import {
+  handleForbiddenErrorResponse,
+  handleInternalErrorResponse,
+} from "@/lib/be/errors";
+import { retrieveUnboundedGroupServices } from "@/lib/be/services/business";
+import { withJWTAuthHandler } from "@/lib/be/wrappers";
+import { NextRequest, NextResponse } from "next/server";
+
+import { BackOfficeUser } from "../../../../../../types/next-auth";
+
+/**
+ * @operationId checkGroupUnboundedServiceExistence
+ * @description Check for the existence of at least one service owned by the calling user that is not related to any group
+ */
+export const GET = withJWTAuthHandler(
+  async (
+    _: NextRequest,
+    { backofficeUser }: { backofficeUser: BackOfficeUser },
+  ): Promise<NextResponse<UnboundedGroupServices>> => {
+    try {
+      if (!userAuthz(backofficeUser).isAdmin()) {
+        return handleForbiddenErrorResponse("Role not authorized");
+      }
+      const result = await retrieveUnboundedGroupServices(backofficeUser);
+      const existsAtLeastOneService = result.length !== 0;
+      return new NextResponse(null, {
+        status: existsAtLeastOneService ? 200 : 204,
+      });
+    } catch (error) {
+      console.error(
+        `An Error has occurred while checking the existence of group-unbounded services for user having userId: ${backofficeUser.parameters.subscriptionId}, caused by: `,
+        error,
+      );
+      return handleInternalErrorResponse(
+        "GroupUnboundServicesCheckExistenceError",
+        error,
+      );
+    }
+  },
+);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added the checkGroupUnboundedServiceExistence api in order to check if there is at least one group unbound service for the given user

#### List of Changes

<!--- Describe your changes in detail -->
[added group unbuond service any api](https://github.com/pagopa/io-services-cms/commit/056eecbdd86f448f2abf4706262b6e1670007433)

[added unit test](https://github.com/pagopa/io-services-cms/commit/823c24a7b8df049ad4f35b1bd6615c8ae5502d8b)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Required to check if the user has at least one  group unbound service
#### How Has This Been Tested?
Unit test
Local environment connected to Prod resources
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
