### PR TITLE
[IOPAE-1679] auth control on get subscriptions

### DIFF
--- a/.changeset/large-cameras-joke.md
+++ b/.changeset/large-cameras-joke.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+auth control on get subscriptions

--- a/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
@@ -387,7 +387,7 @@ describe("Subscription API", () => {
         },
         permissions: {
           ...userMock.permissions,
-          selcGroups: ["group1", "group2"],
+          selcGroups: [],
         },
       }));
 

--- a/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
@@ -58,9 +58,9 @@ const userMock = {
 const stubs = { aGroup: { id: "aGroupId", name: "aGroupName" } };
 
 const mocks = vi.hoisted(() => {
-  const getUserMock = vi.fn(() => userMock);
+  const getUser = vi.fn(() => userMock);
   return {
-    getUserMock,
+    getUser,
     upsertManageSubscription: vi.fn(),
     getManageSubscriptions: vi.fn(),
     parseBody: vi.fn(),
@@ -75,7 +75,7 @@ const mocks = vi.hoisted(() => {
       ) =>
         async (nextRequest: NextRequest, { params }: { params: {} }) =>
           handler(nextRequest, {
-            backofficeUser: getUserMock(),
+            backofficeUser: getUser(),
             params,
           }),
     ),
@@ -110,7 +110,7 @@ describe("Subscription API", () => {
 
     it("should return a forbidden response when user is not an admin", async () => {
       // given
-      mocks.getUserMock.mockImplementationOnce(() => ({
+      mocks.getUser.mockImplementationOnce(() => ({
         ...userMock,
         institution: {
           ...userMock.institution,
@@ -133,7 +133,7 @@ describe("Subscription API", () => {
 
     it("should return a bad request when fails to parse request body", async () => {
       // given
-      mocks.getUserMock.mockImplementationOnce(() => ({
+      mocks.getUser.mockImplementationOnce(() => ({
         ...userMock,
         institution: {
           ...userMock.institution,
@@ -162,7 +162,7 @@ describe("Subscription API", () => {
 
     it("should return a bad request when the provided group is not found", async () => {
       // given
-      mocks.getUserMock.mockImplementationOnce(() => ({
+      mocks.getUser.mockImplementationOnce(() => ({
         ...userMock,
         institution: {
           ...userMock.institution,
@@ -200,7 +200,7 @@ describe("Subscription API", () => {
 
     it("should fails when upsertManageSubscription return an error", async () => {
       // given
-      mocks.getUserMock.mockImplementationOnce(() => ({
+      mocks.getUser.mockImplementationOnce(() => ({
         ...userMock,
         institution: {
           ...userMock.institution,
@@ -241,7 +241,7 @@ describe("Subscription API", () => {
 
     it("should return the upserted manage subscription", async () => {
       // given
-      mocks.getUserMock.mockImplementationOnce(() => ({
+      mocks.getUser.mockImplementationOnce(() => ({
         ...userMock,
         institution: {
           ...userMock.institution,
@@ -379,7 +379,7 @@ describe("Subscription API", () => {
       mocks.getQueryParam.mockImplementation((_, param) =>
         E.right(param === "kind" ? kind : param === "limit" ? limit : offset),
       );
-      mocks.getUserMock.mockImplementationOnce(() => ({
+      mocks.getUser.mockImplementationOnce(() => ({
         ...userMock,
         institution: {
           ...userMock.institution,
@@ -387,7 +387,7 @@ describe("Subscription API", () => {
         },
         permissions: {
           ...userMock.permissions,
-          selcGroups: [],
+          selcGroups: ["group1", "group2"],
         },
       }));
 
@@ -456,7 +456,7 @@ describe("Subscription API", () => {
         mocks.getManageSubscriptions.mockResolvedValueOnce(
           expectedSubscriptions,
         );
-        mocks.getUserMock.mockImplementationOnce(() => ({
+        mocks.getUser.mockImplementationOnce(() => ({
           ...userMock,
           institution: {
             ...userMock.institution,

--- a/apps/backoffice/src/app/api/subscriptions/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/route.ts
@@ -87,6 +87,7 @@ export const GET = withJWTAuthHandler(
     request,
     { backofficeUser }: { backofficeUser: BackOfficeUser },
   ): Promise<NextResponse<ResponseError | SubscriptionPagination>> => {
+    const userAuthzUtils = userAuthz(backofficeUser);
     const maybeKind = getQueryParam(request, "kind", SubscriptionType);
     if (E.isLeft(maybeKind)) {
       return handleBadRequestErrorResponse(
@@ -117,8 +118,8 @@ export const GET = withJWTAuthHandler(
     }
     if (
       maybeKind.right === SubscriptionTypeEnum.MANAGE_GROUP &&
-      !userAuthz(backofficeUser).isAdmin() &&
-      !userAuthz(backofficeUser).hasSelcGroups()
+      !userAuthzUtils.isAdmin() &&
+      userAuthzUtils.hasSelcGroups()
     ) {
       return handleForbiddenErrorResponse("Role not authorized");
     }
@@ -128,7 +129,7 @@ export const GET = withJWTAuthHandler(
         backofficeUser.parameters.userId,
         maybeLimit.right,
         maybeOffset.right,
-        userAuthz(backofficeUser).isAdmin()
+        userAuthzUtils.isAdmin()
           ? undefined
           : backofficeUser.permissions.selcGroups,
       );

--- a/apps/backoffice/src/app/api/subscriptions/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/route.ts
@@ -119,7 +119,7 @@ export const GET = withJWTAuthHandler(
     if (
       maybeKind.right === SubscriptionTypeEnum.MANAGE_GROUP &&
       !userAuthzUtils.isAdmin() &&
-      userAuthzUtils.hasSelcGroups()
+      !userAuthzUtils.hasSelcGroups()
     ) {
       return handleForbiddenErrorResponse("Role not authorized");
     }

--- a/apps/backoffice/src/lib/be/__tests__/authz.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/authz.test.ts
@@ -130,4 +130,22 @@ describe("userAuthz", () => {
       },
     );
   });
+
+  describe("hasSelcGroups", () => {
+    it.each`
+      scenario                                 | expectedResult | selcGroups
+      ${"the user's selcGroup is not defined"} | ${false}       | ${undefined}
+      ${"the user's selcGroup is empty"}       | ${false}       | ${[]}
+      ${"the user's selcGroup is not empty"}   | ${true}        | ${["group1", "group2"]}
+    `(
+      "should return $expectedResult with $scenario",
+      ({ expectedResult, selcGroups }) => {
+        expect(
+          userAuthz({
+            permissions: { selcGroups },
+          } as BackOfficeUser).hasSelcGroups(),
+        ).toBe(expectedResult);
+      },
+    );
+  });
 });

--- a/apps/backoffice/src/lib/be/authz.ts
+++ b/apps/backoffice/src/lib/be/authz.ts
@@ -20,6 +20,14 @@ export const userAuthz = (user: BackOfficeUser) => {
   const isAdmin = (): boolean => user.institution.role === SelfcareRoles.admin;
   return {
     /**
+     * Check if the user has at least one group
+     * @returns a boolean indicating whether the user has at least one group
+     */
+    hasSelcGroups: (): boolean =>
+      !!(
+        user.permissions.selcGroups && user.permissions.selcGroups.length !== 0
+      ),
+    /**
      * Check if the user role is admin
      * @returns a boolean indicating whether the user is admin or not
      */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[added auth control on get subscriptions](https://github.com/pagopa/io-services-cms/commit/0bc028d8e5a243b017a52c23e7bbcf9a192dbb98)
[added and refactor unit test](https://github.com/pagopa/io-services-cms/commit/4900eb031163e71c80adc297a520eb41a3e1c7c5)
[fix auth requirements](https://github.com/pagopa/io-services-cms/pull/1131/commits/84e3e09e854e4f0f13fc70751451980556b37f0e)
[fix unit tests](https://github.com/pagopa/io-services-cms/pull/1131/commits/215879d808351ad472fdbe6feb13d24b5308fd10)
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Required to make a check if the query param of the request is MANAGE_GROUP and the user is not an admin and hasn't any group
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
