### PR TITLE
[IOPAE-1363] Added ButtonAssociateGroup on Services page

### DIFF
--- a/.changeset/eighty-trainers-work.md
+++ b/.changeset/eighty-trainers-work.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added AssociateGroups button on Services page

--- a/apps/backoffice/mocks/handlers/backend-handlers.ts
+++ b/apps/backoffice/mocks/handlers/backend-handlers.ts
@@ -239,6 +239,29 @@ export const buildHandlers = () => {
 
       return resultArray[0];
     }),
+    http.get(`${baseURL}/services/group-unbound/any`, () => {
+      const resultArray = [
+        new HttpResponse(null, {
+          status: 200,
+        }),
+        new HttpResponse(null, {
+          status: 204,
+        }),
+        new HttpResponse(null, {
+          status: 401,
+        }),
+        new HttpResponse(null, {
+          status: 403,
+        }),
+        new HttpResponse(null, {
+          status: 429,
+        }),
+        new HttpResponse(null, {
+          status: 500,
+        }),
+      ];
+      return resultArray[1];
+    }),
     http.get(`${baseURL}/services/topics`, () => {
       const resultArray = [
         new HttpResponse(JSON.stringify(getGetServiceTopics200Response()), {

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -310,6 +310,10 @@
         "status": "Status",
         "visibility": "Visibility on IO",
         "group": "Group"
+      },
+      "noGroupUnboundedServicesModal": {
+        "title": "Associate groups",
+        "description": "You cannot add services to groups because they have already been assigned. To change existing associations, go into the details of the individual services."
       }
     },
     "service": {
@@ -384,11 +388,16 @@
     },
     "groups": {
       "title": "Groups",
-      "description": ""
+      "description": "",
+      "associate": {
+        "title": "Associate groups",
+        "description": "Here you can associate existing services to your groups."
+      }
     }
   },
   "service": {
     "actions": {
+      "associateGroups": "Associate groups",
       "create": "Create a service",
       "delete": "Delete",
       "edit": "Edit",

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -310,6 +310,10 @@
         "status": "Stato",
         "visibility": "Visibilità in IO",
         "group": "Gruppo"
+      },
+      "noGroupUnboundedServicesModal": {
+        "title": "Associa gruppi",
+        "description": "Non è possibile aggiungere servizi ai gruppi perché sono già stati assegnati. Per modificare le associazioni esistenti entra nel dettaglio dei singoli servizi."
       }
     },
     "service": {
@@ -384,11 +388,16 @@
     },
     "groups": {
       "title": "Gruppi",
-      "description": ""
+      "description": "",
+      "associate": {
+        "title": "Associa gruppi",
+        "description": "Qui puoi associare i servizi esistenti ai tuoi gruppi."
+      }
     }
   },
   "service": {
     "actions": {
+      "associateGroups": "Associa gruppi",
       "create": "Crea un servizio",
       "delete": "Elimina",
       "edit": "Modifica",

--- a/apps/backoffice/src/components/dialog-provider/index.tsx
+++ b/apps/backoffice/src/components/dialog-provider/index.tsx
@@ -14,6 +14,8 @@ interface DialogOptions {
   cancelButtonLabel?: string;
   /** label for confirm button: if specified, overwrite default value */
   confirmButtonLabel?: string;
+  hideCancelButton?: boolean;
+  hideConfirmButton?: boolean;
   /** dialog body message */
   message?: string;
   /** dialog title */
@@ -78,24 +80,28 @@ const DialogProvider: React.FC<{
           ></Typography>
         </DialogContent>
         <DialogActions sx={{ padding: "16px 24px" }}>
-          <Button
-            data-testid="bo-io-dialog-provider-cancel-button"
-            onClick={handleCancel}
-            variant="outlined"
-          >
-            {options.cancelButtonLabel
-              ? t(options.cancelButtonLabel)
-              : t("buttons.cancel")}
-          </Button>
-          <Button
-            data-testid="bo-io-dialog-provider-confirm-button"
-            onClick={handleConfirm}
-            variant="contained"
-          >
-            {options.confirmButtonLabel
-              ? t(options.confirmButtonLabel)
-              : t("buttons.confirm")}
-          </Button>
+          {!options.hideCancelButton && (
+            <Button
+              data-testid="bo-io-dialog-provider-cancel-button"
+              onClick={handleCancel}
+              variant="outlined"
+            >
+              {options.cancelButtonLabel
+                ? t(options.cancelButtonLabel)
+                : t("buttons.cancel")}
+            </Button>
+          )}
+          {!options.hideConfirmButton && (
+            <Button
+              data-testid="bo-io-dialog-provider-confirm-button"
+              onClick={handleConfirm}
+              variant="contained"
+            >
+              {options.confirmButtonLabel
+                ? t(options.confirmButtonLabel)
+                : t("buttons.confirm")}
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
       <DialogContext.Provider value={showDialog}>

--- a/apps/backoffice/src/components/groups/button-associate-group.tsx
+++ b/apps/backoffice/src/components/groups/button-associate-group.tsx
@@ -1,0 +1,66 @@
+import { getConfiguration } from "@/config";
+import { client } from "@/hooks/use-fetch";
+import { SupervisedUserCircle } from "@mui/icons-material";
+import { Button } from "@mui/material";
+import * as E from "fp-ts/lib/Either";
+import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
+
+import { AccessControl } from "../access-control";
+import { useDialog } from "../dialog-provider";
+
+const ASSOCIATE_GROUP_ROUTE = "/groups/associate";
+const { GROUP_APIKEY_ENABLED } = getConfiguration();
+
+const checkAtLeastOneGroupUnboundedServiceExists = async () => {
+  try {
+    const maybeResponse = await client.checkGroupUnboundedServiceExistence({});
+
+    if (E.isRight(maybeResponse)) {
+      return maybeResponse.right.status === 200;
+    }
+    return false;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const ButtonAssociateGroup = () => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const showDialog = useDialog();
+
+  const handleClick = async () => {
+    const atLeastOneGroupUnboundedServiceExists =
+      await checkAtLeastOneGroupUnboundedServiceExists();
+
+    if (atLeastOneGroupUnboundedServiceExists) {
+      router.push(ASSOCIATE_GROUP_ROUTE);
+    } else {
+      await showDialog({
+        confirmButtonLabel: t("buttons.close"),
+        hideCancelButton: true,
+        message: t("routes.services.noGroupUnboundedServicesModal.description"),
+        title: t("routes.services.noGroupUnboundedServicesModal.title"),
+      });
+    }
+  };
+
+  if (!GROUP_APIKEY_ENABLED) return null;
+
+  return (
+    <AccessControl
+      requiredPermissions={["ApiServiceWrite"]}
+      requiredRole="admin"
+    >
+      <Button
+        onClick={handleClick}
+        size="medium"
+        startIcon={<SupervisedUserCircle />}
+        variant="outlined"
+      >
+        {t("service.actions.associateGroups")}
+      </Button>
+    </AccessControl>
+  );
+};

--- a/apps/backoffice/src/components/groups/index.ts
+++ b/apps/backoffice/src/components/groups/index.ts
@@ -1,0 +1,1 @@
+export * from "./button-associate-group";

--- a/apps/backoffice/src/pages/groups/associate.tsx
+++ b/apps/backoffice/src/pages/groups/associate.tsx
@@ -1,0 +1,46 @@
+import { PageHeader } from "@/components/headers";
+import { AppLayout, PageLayout } from "@/layouts";
+import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { ReactElement } from "react";
+
+const pageTitleLocaleKey = "routes.groups.associate.title";
+const pageDescriptionLocaleKey = "routes.groups.associate.description";
+
+export default function AssociateGroups() {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  return (
+    <>
+      <PageHeader
+        description={pageDescriptionLocaleKey}
+        hideBreadcrumbs
+        onExitClick={() => router.push("/services")}
+        showExit
+        title={pageTitleLocaleKey}
+      />
+      {t("TODO")}
+    </>
+  );
+}
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export async function getStaticProps({ locale }: any) {
+  return {
+    props: {
+      // pass the translation props to the page component
+      ...(await serverSideTranslations(locale)),
+    },
+  };
+}
+
+AssociateGroups.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <AppLayout hideSidenav>
+      <PageLayout isFullWidth={false}>{page}</PageLayout>
+    </AppLayout>
+  );
+};
+
+AssociateGroups.requiredRole = "admin";

--- a/apps/backoffice/src/pages/services/index.tsx
+++ b/apps/backoffice/src/pages/services/index.tsx
@@ -2,6 +2,7 @@ import { AccessControl } from "@/components/access-control";
 import { ApiKeysGroupTag } from "@/components/api-keys/api-keys-groups/api-keys-group-tag";
 import { useDialog } from "@/components/dialog-provider";
 import { EmptyStateLayer } from "@/components/empty-state";
+import { ButtonAssociateGroup } from "@/components/groups";
 import { PageHeader } from "@/components/headers";
 import {
   ServiceContextMenuActions,
@@ -412,9 +413,7 @@ export default function Services() {
     );
   };
 
-  //TODO: id not used, is it a leftover?
-  /*eslint-disable @typescript-eslint/no-unused-vars */
-  const getServices = (id?: string) => {
+  const getServices = () => {
     servicesFetchData(
       "getServiceList",
       {
@@ -491,24 +490,27 @@ export default function Services() {
           />
         </Grid>
         <Grid item xs="auto">
-          <AccessControl requiredPermissions={["ApiServiceWrite"]}>
-            <NextLink
-              href={CREATE_SERVICE_ROUTE}
-              passHref
-              style={{ textDecoration: "none" }}
-            >
-              <Button
-                onClick={() => {
-                  trackServiceCreateStartEvent();
-                }}
-                size="medium"
-                startIcon={<Add />}
-                variant="contained"
+          <Stack direction="row" spacing={2}>
+            <AccessControl requiredPermissions={["ApiServiceWrite"]}>
+              <NextLink
+                href={CREATE_SERVICE_ROUTE}
+                passHref
+                style={{ textDecoration: "none" }}
               >
-                {t("service.actions.create")}
-              </Button>
-            </NextLink>
-          </AccessControl>
+                <Button
+                  onClick={() => {
+                    trackServiceCreateStartEvent();
+                  }}
+                  size="medium"
+                  startIcon={<Add />}
+                  variant="contained"
+                >
+                  {t("service.actions.create")}
+                </Button>
+              </NextLink>
+            </AccessControl>
+            <ButtonAssociateGroup />
+          </Stack>
         </Grid>
       </Grid>
       {noService ? (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added `ButtonAssociateGroup` on **Services** page.

**Note 1:** _Follow commits history to better understand developments._
**Note 2:** _Watch videos below to better appreciate developed use cases._

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
Need to associate one or more services to a group.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

**Use Case 1:** happy flow _(Associate page is just a placeholder)_

https://github.com/user-attachments/assets/2fd1cade-19e8-4ed2-bc22-378dee6a0c25

**Use Case 2:** no group unbounded services _(All services are asociated to a group)_

https://github.com/user-attachments/assets/3210027c-f68c-4641-b186-390823b4e5a9


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
