### PR TITLE
[IOPAE-1675] backoffice active group filter on service list

### DIFF
--- a/.changeset/rude-colts-drive.md
+++ b/.changeset/rude-colts-drive.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+added filter by active group on service list

--- a/apps/backoffice/src/lib/be/__tests__/services.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/services.test.ts
@@ -945,6 +945,30 @@ describe("Services TEST", () => {
       });
     });
 
+    it("when retrieveInstitutionGroups fails an error is returned", async () => {
+      // given
+      const error = new Error("error from retrieveInstitutionGroups");
+      retrieveInstitutionGroups.mockRejectedValueOnce(error);
+
+      // Mock NextRequest
+      const request = new NextRequest(new URL("http://localhost"));
+
+      // when and then
+      await expect(
+        retrieveServiceList(request, aBackofficeUser, 10, 0),
+      ).rejects.toThrowError(error);
+
+      expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
+      expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
+        aBackofficeUser.institution.id,
+      );
+      expect(userAuthzMock).not.toHaveBeenCalledOnce();
+      expect(isAdminMock).not.toHaveBeenCalledOnce();
+      expect(getSubscriptionsMock).not.toHaveBeenCalledOnce();
+      expect(retrieveLifecycleServicesMock).not.toHaveBeenCalledOnce();
+      expect(retrievePublicationServicesMock).not.toHaveBeenCalledOnce();
+    });
+
     it("when retrievePublicationServices fails an error is returned", async () => {
       // given
       getSubscriptionsMock.mockReturnValueOnce(
@@ -1052,6 +1076,11 @@ describe("Services TEST", () => {
     it("should return an error when selcGroups has at leas one element but retrieveAuthorizedServiceIds fails", async () => {
       // given
       const error = new Error("message");
+      retrieveInstitutionGroups.mockResolvedValueOnce([
+        mocks.aGroup,
+        { id: "g1", name: "group1", state: "ACTIVE" },
+        { id: "g2", name: "group2", state: "ACTIVE" },
+      ]);
       retrieveAuthorizedServiceIdsMock.mockReturnValueOnce(TE.left(error));
       const request = new NextRequest(new URL("http://localhost"));
       const backofficeUser = {
@@ -1070,12 +1099,15 @@ describe("Services TEST", () => {
       expect(userAuthzMock).toHaveBeenCalledWith(backofficeUser);
       expect(isAdminMock).toHaveBeenCalledOnce();
       expect(isAdminMock).toHaveBeenCalledWith();
+      expect(retrieveInstitutionGroups).toHaveBeenCalled();
+      expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
+        backofficeUser.institution.id,
+      );
       expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledOnce();
       expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledWith(
         backofficeUser.permissions.selcGroups,
       );
       expect(getSubscriptionsMock).not.toHaveBeenCalled();
-      expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
       expect(retrieveLifecycleServicesMock).not.toHaveBeenCalled();
       expect(retrievePublicationServicesMock).not.toHaveBeenCalled();
     });
@@ -1095,21 +1127,43 @@ describe("Services TEST", () => {
           : []
         : serviceId;
 
+    const isGroupActive = (
+      selcGroup: string,
+      institutionGroups: Group[],
+    ): boolean => {
+      return institutionGroups.some(
+        (group) => group.id === selcGroup && group.state === StateEnum.ACTIVE,
+      );
+    };
+
+    const getExpectedActiveGroups = (
+      selcGroups: string[],
+      institutionGroups: Group[],
+    ): string[] => {
+      return selcGroups.filter((selcGroup) =>
+        isGroupActive(selcGroup, institutionGroups),
+      );
+    };
+
     it.each`
-      scenario                                                                                          | selcGroups     | serviceId      | authzServiceIds
-      ${"selcGroups is undefined, serviceId is undefined (authzServiceIds doesn't matters)"}            | ${undefined}   | ${undefined}   | ${undefined}
-      ${"selcGroups has no elements, serviceId is undefined (authzServiceIds doesn't matters)"}         | ${[]}          | ${undefined}   | ${undefined}
-      ${"selcGroups is undefined, serviceId is defined (authzServiceIds doesn't matters)"}              | ${undefined}   | ${"serviceId"} | ${undefined}
-      ${"selcGroups has no elements, serviceId is defined (authzServiceIds doesn't matters)"}           | ${[]}          | ${"serviceId"} | ${undefined}
-      ${"selcGroups has at least one element, serviceId is undefined and authzServiceIds is empty"}     | ${["groupId"]} | ${undefined}   | ${[]}
-      ${"selcGroups has at least one element, serviceId is defined and authzServiceIds is empty"}       | ${["groupId"]} | ${"serviceId"} | ${[]}
-      ${"selcGroups has at least one element, serviceId is undefined and authzServiceIds is not empty"} | ${["groupId"]} | ${undefined}   | ${["authzServiceId"]}
-      ${"selcGroups has at least one element, serviceId is defined and authzServiceIds is not empty"}   | ${["groupId"]} | ${"serviceId"} | ${["authzServiceId"]}
+      scenario                                                                                                                                                     | selcGroups      | institutionGroups                                                                                                | serviceId      | authzServiceIds
+      ${"selcGroups is undefined, groupMap (doesn't matters), serviceId is undefined (authzServiceIds doesn't matters)"}                                           | ${undefined}    | ${[]}                                                                                                            | ${undefined}   | ${undefined}
+      ${"selcGroups has no elements, groupMap (doesn't matters), serviceId is undefined (authzServiceIds doesn't matters)"}                                        | ${[]}           | ${[]}                                                                                                            | ${undefined}   | ${undefined}
+      ${"selcGroups is undefined, groupMap (doesn't matters), serviceId is defined (authzServiceIds doesn't matters)"}                                             | ${undefined}    | ${[]}                                                                                                            | ${"serviceId"} | ${undefined}
+      ${"selcGroups has no elements, groupMap (doesn't matters), serviceId is defined (authzServiceIds doesn't matters)"}                                          | ${[]}           | ${[]}                                                                                                            | ${"serviceId"} | ${undefined}
+      ${"selcGroups has at least one element, groupMap has no matching group, serviceId is undefined and authzServiceIds is empty"}                                | ${["group_id"]} | ${[{ id: "g1", name: "group", state: "ACTIVE" }]}                                                                | ${undefined}   | ${[]}
+      ${"selcGroups has at least one element, groupMap has matching group but is not active, serviceId is undefined and authzServiceIds is empty"}                 | ${["group_id"]} | ${[{ id: "group_id", name: "group", state: "SUSPENDED" }]}                                                       | ${undefined}   | ${[]}
+      ${"selcGroups has at least one element, groupMap has an active matching group, serviceId is  undefined and authzServiceIds is empty"}                        | ${["group_id"]} | ${[{ id: "group_id", name: "group", state: "ACTIVE" }]}                                                          | ${undefined}   | ${[]}
+      ${"selcGroups has at least one element, groupMap has an active matching group and a non active group, serviceId is  undefined and authzServiceIds is empty"} | ${["group_id"]} | ${[{ id: "group_id", name: "group", state: "ACTIVE" }, { id: "group_id2", name: "group2", state: "SUSPENDED" }]} | ${undefined}   | ${[]}
+      ${"selcGroups has at least one element, groupMap has an active matching group, serviceId is defined and authzServiceIds is empty"}                           | ${["group_id"]} | ${[{ id: "group_id", name: "group", state: "ACTIVE" }]}                                                          | ${"serviceId"} | ${[]}
+      ${"selcGroups has at least one element, groupMap has an active matching group, serviceId is undefined and authzServiceIds is not empty"}                     | ${["group_id"]} | ${[{ id: "group_id", name: "group", state: "ACTIVE" }]}                                                          | ${undefined}   | ${["authzServiceId"]}
+      ${"selcGroups has at least one element, groupMap has an active matching group, serviceId is defined and authzServiceIds is not empty"}                       | ${["group_id"]} | ${[{ id: "group_id", name: "group", state: "ACTIVE" }]}                                                          | ${"serviceId"} | ${["authzServiceId"]}
     `(
       "should return an error when $scenario, but getSubscriptions fails",
-      async ({ selcGroups, serviceId, authzServiceIds }) => {
+      async ({ selcGroups, institutionGroups, serviceId, authzServiceIds }) => {
         // given
         const error = new Error("message");
+        retrieveInstitutionGroups.mockResolvedValueOnce(institutionGroups);
         getSubscriptionsMock.mockReturnValueOnce(TE.left(error));
         const request = new NextRequest(new URL("http://localhost"));
         const backofficeUser = {
@@ -1133,10 +1187,18 @@ describe("Services TEST", () => {
         expect(userAuthzMock).toHaveBeenCalledWith(backofficeUser);
         expect(isAdminMock).toHaveBeenCalledOnce();
         expect(isAdminMock).toHaveBeenCalledWith();
+        expect(retrieveInstitutionGroups).toHaveBeenCalled();
+        expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
+          backofficeUser.institution.id,
+        );
+
         if (selcGroups && selcGroups.length > 0) {
           expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledOnce();
           expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledWith(
-            backofficeUser.permissions.selcGroups,
+            getExpectedActiveGroups(
+              backofficeUser.permissions.selcGroups,
+              institutionGroups,
+            ),
           );
         } else {
           expect(retrieveAuthorizedServiceIdsMock).not.toHaveBeenCalled();
@@ -1152,7 +1214,6 @@ describe("Services TEST", () => {
             serviceId,
           ),
         );
-        expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
         expect(retrieveLifecycleServicesMock).not.toHaveBeenCalled();
         expect(retrievePublicationServicesMock).not.toHaveBeenCalled();
       },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[addded service list filter by active groups](https://github.com/pagopa/io-services-cms/commit/b10780651be20b21ef4fda025423df47911f58cf)
[added unit tests](https://github.com/pagopa/io-services-cms/commit/baf7c587efdb96d779c3a777b37ad2e36de59ace)
<!--- Describe your changes in detail -->

#### Motivation and Context
Required to retrieve only a list of services associated with active groups for an operator
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
