### PR TITLE
[IOPAE-1792] Added apikey group tags pagination in overview page

### DIFF
--- a/.changeset/rotten-singers-sell.md
+++ b/.changeset/rotten-singers-sell.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added apikey group tags pagination in overview page

--- a/apps/backoffice/src/components/api-keys/api-keys-card/api-keys-card.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-card/api-keys-card.tsx
@@ -20,6 +20,8 @@ import { ApiKeysGroupTag } from "../api-keys-groups/api-keys-group-tag";
 
 const { GROUP_APIKEY_ENABLED } = getConfiguration();
 const KEYS_ROUTE_PATH = "/keys";
+const MAX_APIKEY_GROUP_TO_DISPLAY = 2;
+const GET_MANAGE_GROUP_SUBSCRIPTIONS_LIMIT = 10;
 
 export const ApiKeysCard = () => {
   const { t } = useTranslation();
@@ -53,6 +55,9 @@ export const ApiKeysCard = () => {
     },
   ];
 
+  const getRemainingApiKeyGroupCount = () =>
+    mspData ? mspData.pagination.count - MAX_APIKEY_GROUP_TO_DISPLAY : 0;
+
   useEffect(() => {
     if (showManageKeyRoot) {
       mkFetchData("getManageKeys", {}, SubscriptionKeys);
@@ -60,7 +65,10 @@ export const ApiKeysCard = () => {
     if (showManageKeyGroup) {
       mspFetchData(
         "getManageSubscriptions",
-        { kind: SubscriptionTypeEnum.MANAGE_GROUP, limit: 10 },
+        {
+          kind: SubscriptionTypeEnum.MANAGE_GROUP,
+          limit: GET_MANAGE_GROUP_SUBSCRIPTIONS_LIMIT,
+        },
         SubscriptionPagination,
         {
           notify: "errors",
@@ -92,15 +100,23 @@ export const ApiKeysCard = () => {
               <ApiKeysGroupsEmptyState apiKeysGroups={mspData?.value} />
               {mspData?.value && mspData.value.length > 0 && (
                 <Box paddingTop={2}>
-                  {mspData?.value.map((apiKeyGroup) => (
+                  {mspData?.value
+                    .slice(0, MAX_APIKEY_GROUP_TO_DISPLAY)
+                    .map((apiKeyGroup) => (
+                      <ApiKeysGroupTag
+                        key={apiKeyGroup.id}
+                        label={apiKeyGroup.name}
+                        onClick={() =>
+                          router.push(`${KEYS_ROUTE_PATH}?id=${apiKeyGroup.id}`)
+                        }
+                      />
+                    ))}
+                  {mspData.pagination.count > MAX_APIKEY_GROUP_TO_DISPLAY && (
                     <ApiKeysGroupTag
-                      key={apiKeyGroup.id}
-                      label={apiKeyGroup.name}
-                      onClick={() =>
-                        router.push(`${KEYS_ROUTE_PATH}?id=${apiKeyGroup.id}`)
-                      }
+                      label={`+${getRemainingApiKeyGroupCount()}`}
+                      onClick={() => router.push(KEYS_ROUTE_PATH)}
                     />
-                  ))}
+                  )}
                 </Box>
               )}
             </>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added apikey group tags pagination in Overview page.

**Use case:** if apikey group count is greater than 2, it shows a final "+N" tag where `N=ApiKeyGroup Count - 2`.

**Note:** _watch red circle on screenshot._

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

_**USE CASE:** User has **3** apikey group._
<img width="1728" alt="Screenshot 2025-02-12 alle 17 07 45" src="https://github.com/user-attachments/assets/dc75f052-14fa-4393-bb88-9d0ad3a2968b" />

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
