### PR TITLE
[IOPAE-1804] CMS delete unbound service from group

### DIFF
--- a/.changeset/blue-knives-clap.md
+++ b/.changeset/blue-knives-clap.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+added function to unbound a service from its group

--- a/apps/io-services-cms-webapp/UnboundServiceFromGroup/function.json
+++ b/apps/io-services-cms-webapp/UnboundServiceFromGroup/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "services/{serviceId}/group",
+      "methods": ["delete"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "httpEntryPoint"
+}

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/unbound-service-group.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/unbound-service-group.test.ts
@@ -1,0 +1,190 @@
+import { ApimUtils } from "@io-services-cms/external-clients";
+import { ServiceLifecycle } from "@io-services-cms/models";
+import { SubscriptionCIDRsModel } from "@pagopa/io-functions-commons/dist/src/models/subscription_cidrs";
+import { UserGroup } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { ResponseErrorForbiddenNotAuthorized } from "@pagopa/ts-commons/lib/responses";
+import * as TE from "fp-ts/lib/TaskEither";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IConfig } from "../../../config";
+import { WebServerDependencies, createWebServer } from "../../index";
+
+const aService = {
+  id: "aServiceId",
+} as unknown as ServiceLifecycle.ItemType;
+
+const {
+  serviceOwnerCheckManageTaskMock,
+  logErrorResponseMock,
+  getLoggerMock,
+  patchMock,
+  fsmLifecycleClientCreatorMock,
+} = vi.hoisted(() => {
+  const logErrorResponseMock = vi.fn((err) => err);
+  const patchMock = vi.fn<any[], any>(() => TE.right(aService));
+  return {
+    serviceOwnerCheckManageTaskMock: vi.fn<any[], any>((_, serviceId) =>
+      TE.right(serviceId),
+    ),
+    logErrorResponseMock,
+    getLoggerMock: vi.fn(() => ({ logErrorResponse: logErrorResponseMock })),
+    patchMock,
+    fsmLifecycleClientCreatorMock: vi.fn(() => ({
+      getStore: () => ({
+        patch: patchMock,
+      }),
+    })),
+  };
+});
+
+vi.mock("../../../utils/subscription", () => ({
+  serviceOwnerCheckManageTask: serviceOwnerCheckManageTaskMock,
+}));
+
+vi.mock("../../../utils/logger", () => ({
+  getLogger: getLoggerMock,
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("unboundServiceGroup", () => {
+  const logPrefix = "UnboundServiceGroupHandler";
+  const aManageSubscriptionId = "MANAGE-123";
+  const anUserId = "123";
+  const mockApimService = {} as unknown as ApimUtils.ApimService;
+  const mockConfig = {
+    BACKOFFICE_INTERNAL_SUBNET_CIDRS: ["127.0.0.1/32"],
+  } as unknown as IConfig;
+  const mockAppinsights = {
+    trackEvent: vi.fn(),
+    trackError: vi.fn(),
+  } as any;
+  const mockContext = {} as any;
+  const app = createWebServer({
+    basePath: "api",
+    apimService: mockApimService,
+    config: mockConfig,
+    fsmLifecycleClientCreator: fsmLifecycleClientCreatorMock,
+    fsmPublicationClient: vi.fn(),
+    subscriptionCIDRsModel: {} as SubscriptionCIDRsModel,
+    telemetryClient: mockAppinsights,
+    blobService: vi.fn(),
+    serviceTopicDao: vi.fn(),
+  } as unknown as WebServerDependencies);
+
+  setAppContext(app, mockContext);
+
+  it("should not allow the operation without right userId", async () => {
+    // given
+    const serviceId = aService.id;
+    const error = ResponseErrorForbiddenNotAuthorized;
+    serviceOwnerCheckManageTaskMock.mockReturnValueOnce(TE.left(error));
+
+    // when
+    const response = await request(app)
+      .delete(`/api/services/${serviceId}/group`)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+  });
+
+  it("should not allow the operation without right group", async () => {
+    // given
+    const serviceId = aService.id;
+
+    // when
+    const response = await request(app)
+      .delete(`/api/services/${serviceId}/group`)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", "OtherGroup")
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(403);
+    expect(serviceOwnerCheckManageTaskMock).not.toHaveBeenCalled();
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+  });
+
+  it("should fail when cannot find requested service", async () => {
+    // given
+    const serviceId = aService.id;
+    patchMock.mockReturnValueOnce(TE.left(new Error("patch error")));
+
+    // when
+    const response = await request(app)
+      .delete(`/api/services/${serviceId}/group`)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(500);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(patchMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).toHaveBeenCalledWith(mockContext, logPrefix);
+    expect(logErrorResponseMock).toHaveBeenCalledOnce();
+    expect(logErrorResponseMock).toHaveBeenCalledWith(expect.anything(), {
+      serviceId,
+      userSubscriptionId: aManageSubscriptionId,
+    });
+  });
+
+  it("should unbound a service from its group", async () => {
+    // given
+    const serviceId = aService.id;
+
+    // when
+    const response = await request(app)
+      .delete(`/api/services/${serviceId}/group`)
+      .set("x-user-email", "example@email.com")
+      .set("x-user-groups", UserGroup.ApiServiceWrite)
+      .set("x-user-id", anUserId)
+      .set("x-subscription-id", aManageSubscriptionId);
+
+    // then
+    expect(response.statusCode).toBe(204);
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
+    expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
+      mockApimService,
+      serviceId,
+      aManageSubscriptionId,
+      anUserId,
+    );
+    expect(patchMock).toHaveBeenCalledOnce();
+    expect(getLoggerMock).not.toHaveBeenCalled();
+    expect(logErrorResponseMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/io-services-cms-webapp/src/webservice/controllers/unbound-service-group.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/unbound-service-group.ts
@@ -1,0 +1,120 @@
+import { Context } from "@azure/functions";
+import { ApimUtils } from "@io-services-cms/external-clients";
+import { ServiceLifecycle } from "@io-services-cms/models";
+import {
+  AzureApiAuthMiddleware,
+  IAzureApiAuthorization,
+  UserGroup,
+} from "@pagopa/io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { ClientIpMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
+import {
+  withRequestMiddlewares,
+  wrapRequestHandler,
+} from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
+import {
+  IResponseSuccessNoContent,
+  ResponseErrorInternal,
+  ResponseSuccessNoContent,
+} from "@pagopa/ts-commons/lib/responses";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+import { pipe } from "fp-ts/lib/function";
+
+import { IConfig } from "../../config";
+import {
+  EventNameEnum,
+  TelemetryClient,
+  trackEventOnResponseOK,
+} from "../../utils/applicationinsight";
+import { checkSourceIp } from "../../utils/check-source-ip";
+import { ErrorResponseTypes, getLogger } from "../../utils/logger";
+import { serviceOwnerCheckManageTask } from "../../utils/subscription";
+
+const logPrefix = "UnboundServiceGroupHandler";
+
+interface Dependencies {
+  apimService: ApimUtils.ApimService;
+  fsmLifecycleClientCreator: ServiceLifecycle.FsmClientCreator;
+  telemetryClient: TelemetryClient;
+}
+
+type UnboundServiceGroupHandler = (
+  context: Context,
+  auth: IAzureApiAuthorization,
+  serviceId: ServiceLifecycle.definitions.ServiceId,
+) => TE.TaskEither<ErrorResponseTypes, IResponseSuccessNoContent>;
+
+export const makeUnboundServiceGroupHandler =
+  ({
+    apimService,
+    fsmLifecycleClientCreator,
+    telemetryClient,
+  }: Dependencies): UnboundServiceGroupHandler =>
+  (context, auth, serviceId) =>
+    pipe(
+      serviceOwnerCheckManageTask(
+        apimService,
+        serviceId,
+        auth.subscriptionId,
+        auth.userId,
+      ),
+      TE.chainW((sId) =>
+        pipe(
+          fsmLifecycleClientCreator()
+            .getStore()
+            .patch(sId, { data: { metadata: { group_id: undefined } } }),
+          TE.mapLeft((err) =>
+            ResponseErrorInternal("Failed to patch caused by: " + err.message),
+          ),
+          TE.map(ResponseSuccessNoContent),
+        ),
+      ),
+      TE.map(
+        trackEventOnResponseOK(telemetryClient, EventNameEnum.EditService, {
+          serviceId,
+          userSubscriptionId: auth.subscriptionId,
+        }),
+      ),
+      TE.mapLeft((err) =>
+        getLogger(context, logPrefix).logErrorResponse(err, {
+          serviceId,
+          userSubscriptionId: auth.subscriptionId,
+        }),
+      ),
+    );
+
+export const applyRequestMiddelwares =
+  (config: IConfig) => (handler: UnboundServiceGroupHandler) => {
+    const middlewaresWrap = withRequestMiddlewares(
+      // extract the client IP from the request
+      ClientIpMiddleware,
+      // extract the Azure functions context
+      ContextMiddleware(),
+      // only allow requests by users belonging to certain groups
+      AzureApiAuthMiddleware(new Set([UserGroup.ApiServiceWrite])),
+      // extract the service id from the path variables
+      RequiredParamMiddleware("serviceId", NonEmptyString),
+    );
+    return wrapRequestHandler(
+      middlewaresWrap((...args) =>
+        pipe(
+          args,
+          (z) => z,
+          ([clientIp, ...rest]) =>
+            pipe(
+              checkSourceIp(
+                clientIp,
+                new Set(config.BACKOFFICE_INTERNAL_SUBNET_CIDRS),
+              ),
+              E.map((_) => rest),
+            ),
+          TE.fromEither,
+          TE.chainW((args) => handler(...args)),
+          TE.toUnion,
+        )(),
+      ),
+    );
+  };

--- a/apps/io-services-cms-webapp/src/webservice/index.ts
+++ b/apps/io-services-cms-webapp/src/webservice/index.ts
@@ -82,6 +82,10 @@ import {
   makeReviewServiceHandler,
 } from "./controllers/review-service";
 import {
+  applyRequestMiddelwares as applyUnboundServiceGroupRequestMiddelwares,
+  makeUnboundServiceGroupHandler,
+} from "./controllers/unbound-service-group";
+import {
   applyRequestMiddelwares as applyUnpublishServiceRequestMiddelwares,
   makeUnpublishServiceHandler,
 } from "./controllers/unpublish-service";
@@ -242,6 +246,18 @@ export const createWebServer = ({
         telemetryClient,
       }),
       applyDeleteServiceRequestMiddelwares(config, subscriptionCIDRsModel),
+    ),
+  );
+
+  router.delete(
+    `${serviceLifecyclePath}/group`,
+    pipe(
+      makeUnboundServiceGroupHandler({
+        apimService,
+        fsmLifecycleClientCreator,
+        telemetryClient,
+      }),
+      applyUnboundServiceGroupRequestMiddelwares(config),
     ),
   );
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[added function to unbound a service from its group](https://github.com/pagopa/io-services-cms/commit/868e535d35929d1d7ad7e9d6321a51e2c258b9d1)
[added unit test](https://github.com/pagopa/io-services-cms/commit/b8dd3baeca659f34f6931e1ff0e0bfa035b4309a)
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The necessity of an api to unboun a service from its group

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test
local environment connected to prod environment
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
