### PR TITLE
[IOPAE-1815] backoffice bulkpatch check on active group

### DIFF
--- a/.changeset/rude-stingrays-perform.md
+++ b/.changeset/rude-stingrays-perform.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+added check for active group on bulk patch


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[added check on group status on bulkpatch api](https://github.com/pagopa/io-services-cms/commit/a800802d3a0b23bae6ebc79f86b6204f1bdfbd14)
[added unit test](https://github.com/pagopa/io-services-cms/commit/50a2909c7ff86b70d5e35773bb188074f6010592)
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
the necessity to check if the group passed in the service bulk patch is active.
#### How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
