### PR TITLE
[IOPAE-1800] Added ux/ui for suspended group/apikeys

### DIFF
--- a/.changeset/silly-houses-applaud.md
+++ b/.changeset/silly-houses-applaud.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added ux/ui for suspended group/apikeys

--- a/apps/backoffice/mocks/data/backend-data.ts
+++ b/apps/backoffice/mocks/data/backend-data.ts
@@ -340,7 +340,9 @@ export const getMockManageSubscriptions = (
   kind: SubscriptionType,
 ) => {
   const purifiedLimit = limit
-    ? faker.number.int({ max: limit, min: 1 })
+    ? limit >= 10
+      ? faker.number.int({ max: limit, min: 10 })
+      : faker.number.int({ max: 10, min: limit })
     : faker.helpers.arrayElement([10, 20, 50, 100]);
   const purifiedOffset =
     offset !== undefined && offset >= 0 && offset < 99
@@ -349,7 +351,7 @@ export const getMockManageSubscriptions = (
 
   const total =
     kind === SubscriptionTypeEnum.MANAGE_GROUP
-      ? [...Array.from(Array(purifiedLimit).keys())]
+      ? [...Array.from(Array(purifiedLimit + 15).keys())]
       : [1];
 
   return {
@@ -358,7 +360,7 @@ export const getMockManageSubscriptions = (
       limit: purifiedLimit,
       offset: purifiedOffset,
     },
-    value: total.map((_) => ({
+    value: [...Array.from(Array(purifiedLimit).keys())].map((_) => ({
       ...getMockManageSubscription(),
     })),
   };

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -418,6 +418,12 @@
         "noGroupModal": {
           "description": "You have not yet created any groups to generate API Keys. <br/><br/>To proceed, go to the “Groups” section in the Reserved Area and create new groups. Once finished, you can generate API Keys and associate them with groups.",
           "confirm": "Add group"
+        },
+        "state": {
+          "suspended": {
+            "label": "Group API Keys are suspended",
+            "tooltip": "The group has been suspended in the Reserved Area and its API Keys are blocked."
+          }
         }
       },
       "manage": {

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -418,6 +418,12 @@
         "noGroupModal": {
           "description": "Non hai ancora creato alcun gruppo per generare le API Key. <br/><br/>Per procedere, vai alla sezione “Gruppi” in Area Riservata e crea nuovi gruppi. Una volta terminato, potrai generare le API Key e associarle ai gruppi.",
           "confirm": "Crea gruppo"
+        },
+        "state": {
+          "suspended": {
+            "label": "API Key del gruppo sospese",
+            "tooltip": "Il gruppo è stato sospeso in Area Riservata e le relative API Key sono bloccate."
+          }
         }
       },
       "manage": {

--- a/apps/backoffice/src/components/api-keys/api-key-tag.tsx
+++ b/apps/backoffice/src/components/api-keys/api-key-tag.tsx
@@ -1,0 +1,74 @@
+import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
+import { useTranslation } from "next-i18next";
+import { ReactElement } from "react";
+
+interface ApiKeyTagProps {
+  color?:
+    | "default"
+    | "error"
+    | "info"
+    | "primary"
+    | "secondary"
+    | "success"
+    | "warning";
+  disabled?: boolean;
+  icon?: ReactElement;
+  id?: string;
+  label: string;
+  /** If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis. */
+  noWrap?: boolean;
+  onClick?: () => void;
+  tooltip?: string;
+}
+
+const baseStyle = {
+  borderRadius: 0.5,
+  marginBottom: 1,
+  marginRight: 1,
+};
+
+const ellipsisStyle = {
+  "& .MuiChip-label": {
+    display: "block",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  maxWidth: "90px",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+/** `ApiKeyTag` base component */
+export const ApiKeyTag = ({
+  color,
+  disabled,
+  icon,
+  id,
+  label,
+  noWrap,
+  onClick,
+  tooltip,
+}: ApiKeyTagProps) => {
+  const { t } = useTranslation();
+
+  const getNoWrapStyle = () => (noWrap ? ellipsisStyle : {});
+
+  return (
+    <Tooltip arrow placement="top" title={t(tooltip ?? "")}>
+      <Chip
+        clickable={!!onClick}
+        color={color}
+        disabled={disabled}
+        icon={icon}
+        key={id}
+        label={t(label)}
+        onClick={onClick}
+        size="small"
+        sx={{ ...baseStyle, ...getNoWrapStyle() }}
+      />
+    </Tooltip>
+  );
+};

--- a/apps/backoffice/src/components/api-keys/api-keys-card/api-keys-card.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-card/api-keys-card.tsx
@@ -15,13 +15,13 @@ import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { useEffect } from "react";
 
+import { ApiKeyTag } from "../api-key-tag";
 import { ApiKeysGroupsEmptyState } from "../api-keys-groups";
 import { ApiKeysGroupTag } from "../api-keys-groups/api-keys-group-tag";
 
 const { GROUP_APIKEY_ENABLED } = getConfiguration();
 const KEYS_ROUTE_PATH = "/keys";
-const MAX_APIKEY_GROUP_TO_DISPLAY = 2;
-const GET_MANAGE_GROUP_SUBSCRIPTIONS_LIMIT = 10;
+const MAX_APIKEY_GROUP_TO_DISPLAY = 5;
 
 export const ApiKeysCard = () => {
   const { t } = useTranslation();
@@ -67,7 +67,7 @@ export const ApiKeysCard = () => {
         "getManageSubscriptions",
         {
           kind: SubscriptionTypeEnum.MANAGE_GROUP,
-          limit: GET_MANAGE_GROUP_SUBSCRIPTIONS_LIMIT,
+          limit: MAX_APIKEY_GROUP_TO_DISPLAY,
         },
         SubscriptionPagination,
         {
@@ -105,14 +105,14 @@ export const ApiKeysCard = () => {
                     .map((apiKeyGroup) => (
                       <ApiKeysGroupTag
                         key={apiKeyGroup.id}
-                        label={apiKeyGroup.name}
                         onClick={() =>
                           router.push(`${KEYS_ROUTE_PATH}?id=${apiKeyGroup.id}`)
                         }
+                        value={apiKeyGroup}
                       />
                     ))}
                   {mspData.pagination.count > MAX_APIKEY_GROUP_TO_DISPLAY && (
-                    <ApiKeysGroupTag
+                    <ApiKeyTag
                       label={`+${getRemainingApiKeyGroupCount()}`}
                       onClick={() => router.push(KEYS_ROUTE_PATH)}
                     />

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group-tag.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group-tag.tsx
@@ -1,59 +1,47 @@
-import Chip from "@mui/material/Chip";
-import Tooltip from "@mui/material/Tooltip";
-import { useTranslation } from "next-i18next";
+import { StateEnum, Subscription } from "@/generated/api/Subscription";
+import { Warning } from "@mui/icons-material";
+
+import { ApiKeyTag } from "../api-key-tag";
 
 interface ApiKeysGroupTagProps {
   disabled?: boolean;
   id?: string;
-  /** Tag label text */
-  label: string;
   /** If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis. */
   noWrap?: boolean;
   onClick?: () => void;
+  value: Subscription;
 }
-
-const baseStyle = {
-  borderRadius: 0.5,
-  marginBottom: 1,
-  marginRight: 1,
-};
-
-const ellipsisStyle = {
-  "& .MuiChip-label": {
-    display: "block",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-  maxWidth: "90px",
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-};
 
 /** `ApiKeysGroupTag` component */
 export const ApiKeysGroupTag = ({
   disabled,
   id,
-  label,
   noWrap,
   onClick,
+  value,
 }: ApiKeysGroupTagProps) => {
-  const { t } = useTranslation();
+  const shouldBeDisabled = () =>
+    value.state !== StateEnum.active && value.state !== StateEnum.suspended;
 
-  const getNoWrapStyle = () => (noWrap ? ellipsisStyle : {});
+  const handleOnClick = () =>
+    !shouldBeDisabled() && onClick ? onClick() : undefined;
 
   return (
-    <Tooltip arrow placement="top" title={noWrap ? t(label) : ""}>
-      <Chip
-        clickable={!!onClick}
-        disabled={disabled}
-        key={id}
-        label={t(label)}
-        onClick={onClick}
-        size="small"
-        sx={{ ...baseStyle, ...getNoWrapStyle() }}
-      />
-    </Tooltip>
+    <ApiKeyTag
+      color={value.state === StateEnum.suspended ? "warning" : "default"}
+      disabled={disabled || shouldBeDisabled()}
+      icon={value.state === StateEnum.suspended ? <Warning /> : undefined}
+      id={id}
+      label={value.name}
+      noWrap={noWrap}
+      onClick={handleOnClick}
+      tooltip={
+        value.state === StateEnum.suspended
+          ? "routes.keys.groups.state.suspended.tooltip"
+          : noWrap
+            ? value.name
+            : ""
+      }
+    />
   );
 };

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-groups.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-groups.tsx
@@ -2,7 +2,7 @@
 import { useDialog } from "@/components/dialog-provider";
 import { Cidr } from "@/generated/api/Cidr";
 import { ManageKeyCIDRs } from "@/generated/api/ManageKeyCIDRs";
-import { Subscription } from "@/generated/api/Subscription";
+import { StateEnum, Subscription } from "@/generated/api/Subscription";
 import { SubscriptionKeyTypeEnum } from "@/generated/api/SubscriptionKeyType";
 import { SubscriptionKeys } from "@/generated/api/SubscriptionKeys";
 import { SubscriptionPagination } from "@/generated/api/SubscriptionPagination";
@@ -44,6 +44,7 @@ export interface RecordApiKeyValue {
   name: string;
   primary_key: string;
   secondary_key: string;
+  state?: StateEnum;
 }
 
 type ApiKeysGroupRecordset = Record<string, RecordApiKeyValue>;
@@ -56,6 +57,7 @@ const convertArrayToRecordset = (
       name: item.name,
       primary_key: "",
       secondary_key: "",
+      state: item.state,
     };
     return acc;
   }, {} as ApiKeysGroupRecordset);
@@ -115,6 +117,7 @@ export const ApiKeysGroups = (props: ApiKeysGroupsProps) => {
         name: "",
         primary_key: "",
         secondary_key: "",
+        state: undefined,
       };
 
       return {
@@ -142,6 +145,7 @@ export const ApiKeysGroups = (props: ApiKeysGroupsProps) => {
         name: apiKeys[subscriptionId].name,
         primary_key: "",
         secondary_key: "",
+        state: apiKeys[subscriptionId].state,
       };
 
       const maybeKeys = await getBffApiClient().fetchData(

--- a/apps/backoffice/src/components/groups/group-info-tag/group-info-tag.tsx
+++ b/apps/backoffice/src/components/groups/group-info-tag/group-info-tag.tsx
@@ -1,5 +1,6 @@
-import { ApiKeysGroupTag } from "@/components/api-keys/api-keys-groups/api-keys-group-tag";
 import { useDialog } from "@/components/dialog-provider";
+import { ServiceGroupTag } from "@/components/services";
+import { Group } from "@/generated/api/Group";
 import { Delete, Edit } from "@mui/icons-material";
 import { IconButton, Stack, Typography } from "@mui/material";
 import { ButtonNaked } from "@pagopa/mui-italia";
@@ -7,16 +8,15 @@ import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 
 export interface GroupInfoTagProps {
-  /** Group name */
-  name?: string;
   onAssociateClick?: () => void;
   onUnboundClick?: () => void;
+  value?: Group;
 }
 
 export const GroupInfoTag = ({
-  name,
   onAssociateClick,
   onUnboundClick,
+  value,
 }: GroupInfoTagProps) => {
   const { t } = useTranslation();
   const { data: session } = useSession();
@@ -36,7 +36,7 @@ export const GroupInfoTag = ({
   };
 
   // Unbounded service: only admin can bound it to a group
-  if (!name) {
+  if (!value) {
     if (session?.user?.institution.role === "admin")
       return (
         <ButtonNaked
@@ -60,7 +60,7 @@ export const GroupInfoTag = ({
   // Service already associated
   return (
     <Stack direction="row" spacing={1}>
-      <ApiKeysGroupTag label={name} />
+      <ServiceGroupTag value={value} />
       {session?.user?.institution.role === "admin" && (
         <>
           <IconButton

--- a/apps/backoffice/src/components/services/index.ts
+++ b/apps/backoffice/src/components/services/index.ts
@@ -1,6 +1,7 @@
 export * from "./adapters";
 export * from "./service-alerts";
 export * from "./service-context-menu";
+export * from "./service-group-tag";
 export * from "./service-history";
 export * from "./service-info";
 export * from "./service-info-content";

--- a/apps/backoffice/src/components/services/service-group-tag.tsx
+++ b/apps/backoffice/src/components/services/service-group-tag.tsx
@@ -1,0 +1,34 @@
+import { Group, StateEnum } from "@/generated/api/Group";
+import { Warning } from "@mui/icons-material";
+
+import { ApiKeyTag } from "../api-keys/api-key-tag";
+
+interface ServiceGroupTagProps {
+  id?: string;
+  /** If `true`, the text will not wrap, but instead will truncate with a text overflow ellipsis. */
+  noWrap?: boolean;
+  value: Group;
+}
+
+/** `ApiKeysGroupTag` component */
+export const ServiceGroupTag = ({
+  id,
+  noWrap,
+  value,
+}: ServiceGroupTagProps) => (
+  <ApiKeyTag
+    color={value.state === StateEnum.SUSPENDED ? "warning" : "default"}
+    disabled={value.state === StateEnum.DELETED}
+    icon={value.state === StateEnum.SUSPENDED ? <Warning /> : undefined}
+    id={id}
+    label={value.name}
+    noWrap={noWrap}
+    tooltip={
+      value.state === StateEnum.SUSPENDED
+        ? "routes.keys.groups.state.suspended.tooltip"
+        : noWrap
+          ? value.name
+          : ""
+    }
+  />
+);

--- a/apps/backoffice/src/components/services/service-info.tsx
+++ b/apps/backoffice/src/components/services/service-info.tsx
@@ -79,9 +79,9 @@ export const ServiceInfo = ({
         label: "routes.service.group.label",
         value: (
           <GroupInfoTag
-            name={data?.metadata.group?.name}
             onAssociateClick={() => setAssociateGroupOpen(true)}
             onUnboundClick={handleServiceGroupUnbound}
+            value={data?.metadata.group}
           />
         ),
       });

--- a/apps/backoffice/src/pages/services/index.tsx
+++ b/apps/backoffice/src/pages/services/index.tsx
@@ -1,9 +1,9 @@
 import { AccessControl } from "@/components/access-control";
-import { ApiKeysGroupTag } from "@/components/api-keys/api-keys-groups/api-keys-group-tag";
 import { useDialog } from "@/components/dialog-provider";
 import { EmptyStateLayer } from "@/components/empty-state";
 import { ButtonAssociateGroup } from "@/components/groups";
 import { PageHeader } from "@/components/headers";
+import { ServiceGroupTag } from "@/components/services";
 import {
   ServiceContextMenuActions,
   ServiceSearchById,
@@ -101,14 +101,7 @@ export default function Services() {
             alignment: "left",
             cellTemplate: (service) =>
               service.metadata?.group ? (
-                <ApiKeysGroupTag
-                  disabled={
-                    service.status.value ===
-                    ServiceLifecycleStatusTypeEnum.deleted
-                  }
-                  label={service.metadata.group?.name}
-                  noWrap
-                />
+                <ServiceGroupTag noWrap value={service.metadata.group} />
               ) : (
                 <></>
               ),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added ux/ui for suspended group/apikeys.
In general, all use cases related to the active, suspended and deleted states of an apikey/group have been handled.

_**Note:** Watch videos and screenshots below to better appreciate developments use cases._

#### List of Changes
Follow commits history to betetr understannd developments.
<!--- Describe your changes in detail -->

#### Motivation and Context
Need to have different layout and actions for different apikey/group state.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
**Overview of API KEY GROUPS card:** 
<img width="1711" alt="Screenshot 2025-02-17 alle 13 48 07" src="https://github.com/user-attachments/assets/681df257-03d4-400e-b09c-fdc77d9b77d9" />
<img width="1708" alt="Screenshot 2025-02-17 alle 13 48 16" src="https://github.com/user-attachments/assets/c0e55db7-d565-42d0-8fc6-3c8c47b8a4c7" />


**ApiKeys Groups section in ApiKeys Page:** 

https://github.com/user-attachments/assets/914c774d-2613-4796-8ce5-c2e23b259dcc


**Group column in Services table:** 

https://github.com/user-attachments/assets/b7ec23a7-3740-4e30-8fe0-f2fb03248b40

**Group info in 
<img width="1709" alt="Screenshot 2025-02-17 alle 13 54 54" src="https://github.com/user-attachments/assets/9ae09322-05a2-459a-94ac-a081d3824b3e" />
Service Details page:** 


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
