### PR TITLE
[IOPAE-1845] backoffice fix service list group

### DIFF
--- a/.changeset/shiny-lies-tan.md
+++ b/.changeset/shiny-lies-tan.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+fix group on service list

--- a/apps/backoffice/src/lib/be/services/business.ts
+++ b/apps/backoffice/src/lib/be/services/business.ts
@@ -136,9 +136,8 @@ export const retrieveServiceList = async (
     // get services from services-lifecycle cosmos containee and map to ServiceListItem
     TE.bind(
       "lifecycleServices",
-      ({ apimServices, groupsMap, serviceTopicsMap }) => {
-        console.log(groupsMap);
-        return pipe(
+      ({ apimServices, groupsMap, serviceTopicsMap }) =>
+        pipe(
           apimServices.value
             ? apimServices.value.map(
                 (subscription) => subscription.name as NonEmptyString,
@@ -146,8 +145,7 @@ export const retrieveServiceList = async (
             : [],
           retrieveLifecycleServices,
           TE.map(RA.map(toServiceListItem(serviceTopicsMap, groupsMap))),
-        );
-      },
+        ),
     ),
     // get services from services-publication cosmos container
     // create a Record list which contains the service id and its visibility


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[fix group on service list](https://github.com/pagopa/io-services-cms/commit/0aab0dd3ca65ee22d75d4a0ad0c9ab63b20fb9a9)
[fix unit test](https://github.com/pagopa/io-services-cms/commit/7328e28d32a10dd02fae7f0d31d5f445fd84a871)
<!--- Describe your changes in detail -->

#### Motivation and Context
It was necessary to fix a bug where the service group was not returned when the service list was fetched by an admin or operator without groups.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit test
Local environment connected to prod resources
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
