### PR TITLE
[IOPAE-1852] Added GroupFilterType on checkInstitutionGroupsExistence openapi and set it on generate ApiKey Group initial check

### DIFF
--- a/.changeset/proud-melons-applaud.md
+++ b/.changeset/proud-melons-applaud.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added GroupFilterType on checkInstitutionGroupsExistence and set filter=UNBOUNDED on generate ApiKey Group initial check

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -967,6 +967,15 @@ paths:
           required: true
           schema:
             type: string
+        - name: filter
+          in: query
+          description: |
+            Group filter:
+            * `ALL` - All (active) groups
+            * `UNBOUND` - Only (active) groups without any subscription (API Key) related
+          required: false
+          schema:
+            $ref: '#/components/schemas/GroupFilterType'
       responses:
         '200':
           description: At least one active Group exists

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/button-generate-api-keys-group.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/button-generate-api-keys-group.tsx
@@ -1,5 +1,6 @@
 import { AccessControl } from "@/components/access-control";
 import { useDialog } from "@/components/dialog-provider";
+import { GroupFilterTypeEnum } from "@/generated/api/GroupFilterType";
 import { client } from "@/hooks/use-fetch";
 import { SelfcareRoles } from "@/types/auth";
 import { Add } from "@mui/icons-material";
@@ -15,9 +16,10 @@ export interface ButtonGenerateApiKeysGroupProps {
   onGenerateClick: () => void;
 }
 
-const checkGroupsExists = async (institutionId: string) => {
+const checkUnboundedGroupsExists = async (institutionId: string) => {
   try {
     const maybeResponse = await client.checkInstitutionGroupsExistence({
+      filter: GroupFilterTypeEnum.UNBOUND,
       institutionId,
     });
 
@@ -39,11 +41,11 @@ export const ButtonGenerateApiKeysGroup = ({
   const showDialog = useDialog();
 
   const handleOnGenerateClick = async () => {
-    const hasAtLeastOneGroup = await checkGroupsExists(
+    const hasAtLeastOneUnboundedGroup = await checkUnboundedGroupsExists(
       session?.user?.institution.id as string,
     );
 
-    if (hasAtLeastOneGroup) {
+    if (hasAtLeastOneUnboundedGroup) {
       onGenerateClick();
     } else {
       const noGroupAvailableCreateOne = await showDialog({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added GroupFilterType on checkInstitutionGroupsExistence and set filter=UNBOUNDED on generate ApiKey Group initial check.
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
When Admin user click on "Generate Group ApiKey" the starting check must control the existence of any active and unbounded group, not only the existence of active groups.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
