### PR TITLE
[IOPAE-1858] Added active group existence control when admin user click on "Associate groups" in Services Page

### DIFF
--- a/.changeset/chilly-needles-eat.md
+++ b/.changeset/chilly-needles-eat.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added active group control when admin user click on "Associate groups" in Services Page

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -343,6 +343,11 @@
         "visibility": "Visibility on IO",
         "group": "Group"
       },
+      "noActiveGroupsModal": {
+        "title": "Associate groups",
+        "description": "It is not possible to add services to groups because there is no active group.<br/><br/>To proceed, go to the “Groups” section in the Reserved Area and check the configuration.",
+        "confirm": "Verify groups"
+      },
       "noGroupUnboundedServicesModal": {
         "title": "Associate groups",
         "description": "You cannot add services to groups because they have already been assigned. To change existing associations, go into the details of the individual services."

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -343,6 +343,11 @@
         "visibility": "Visibilità in IO",
         "group": "Gruppo"
       },
+      "noActiveGroupsModal": {
+        "title": "Associa gruppi",
+        "description": "Non è possibile aggiungere servizi ai gruppi perché non c'è nessun gruppo attivo.<br/><br/>Per procedere, vai alla sezione “Gruppi” in Area Riservata e verifica la configurazione.",
+        "confirm": "Verifica gruppi"
+      },
       "noGroupUnboundedServicesModal": {
         "title": "Associa gruppi",
         "description": "Non è possibile aggiungere servizi ai gruppi perché sono già stati assegnati. Per modificare le associazioni esistenti entra nel dettaglio dei singoli servizi."


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added active group existence control when admin user click on "Associate groups" in Services Page.

_**Note:** watch video below to better appreciate developments._

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/user-attachments/assets/2ff12f43-20bb-4b50-8551-5862a27f2fc1


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
