### PR TITLE
[IOPAE-1854] Added loader on single apikey group accordion item

### DIFF
--- a/.changeset/bright-peas-retire.md
+++ b/.changeset/bright-peas-retire.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added loader on single apikey group accordion item

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group.tsx
@@ -9,6 +9,7 @@ import {
   AccordionSummary,
   Box,
   Button,
+  CircularProgress,
   Stack,
 } from "@mui/material";
 import { useTranslation } from "next-i18next";
@@ -112,31 +113,37 @@ export const ApiKeyGroup = ({
           )}
         </Stack>
       </AccordionSummary>
-      {apiKey.primary_key && apiKey.cidrs && (
-        <AccordionDetails
-          sx={{
-            border: borderStyle,
-            borderRadius: 1,
-            margin: 3,
-            marginTop: 1,
-          }}
-        >
-          <ApiKeys
-            keys={{
-              primary_key: apiKey.primary_key,
-              secondary_key: apiKey.secondary_key,
+      {canBeExpanded() ? (
+        apiKey.primary_key && apiKey.cidrs ? (
+          <AccordionDetails
+            sx={{
+              border: borderStyle,
+              borderRadius: 1,
+              margin: 3,
+              marginTop: 1,
             }}
-            onRotateKey={(type) => onRotateKey(type, subscriptionId)}
-            type="manage" // TODO: must add new type for "manage_group"
-          />
-          <AuthorizedCidrs
-            cidrs={apiKey.cidrs as unknown as string[]}
-            description="routes.keys.authorizedCidrs.description"
-            editable={true}
-            onSaveClick={(cidrs) => onUpdateCidrs(cidrs, subscriptionId)}
-          />
-        </AccordionDetails>
-      )}
+          >
+            <ApiKeys
+              keys={{
+                primary_key: apiKey.primary_key,
+                secondary_key: apiKey.secondary_key,
+              }}
+              onRotateKey={(type) => onRotateKey(type, subscriptionId)}
+              type="manage" // TODO: must add new type for "manage_group"
+            />
+            <AuthorizedCidrs
+              cidrs={apiKey.cidrs as unknown as string[]}
+              description="routes.keys.authorizedCidrs.description"
+              editable={true}
+              onSaveClick={(cidrs) => onUpdateCidrs(cidrs, subscriptionId)}
+            />
+          </AccordionDetails>
+        ) : (
+          <Box paddingY={1} textAlign="center">
+            <CircularProgress size={30} />
+          </Box>
+        )
+      ) : null}
     </Accordion>
   );
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
When user try to expand a single apikey group accordion item, a circular loader is displayed during the loading waiting time.

_**Note:** watch video below to better appreciate development behaviour._

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
Need to return an UI feedback during loading waiting time.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

https://github.com/user-attachments/assets/18ec8ce1-33fd-4929-aa4a-311074a155b9


<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
