### PR TITLE
[IOPAE-1867] backoffice add suspended group detail on service list

### DIFF
--- a/.changeset/strange-plants-flash.md
+++ b/.changeset/strange-plants-flash.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+show suspended group on service list

--- a/apps/backoffice/src/lib/be/__tests__/institutions.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/institutions.test.ts
@@ -201,12 +201,14 @@ describe("Institutions", () => {
         institutionId,
         1000,
         0,
+        undefined,
       );
       expect(getInstitutionGroupsMock).toHaveBeenNthCalledWith(
         2,
         institutionId,
         1000,
         1,
+        undefined,
       );
       expect(result).toStrictEqual([
         ...(mocks.institutionGroups.content?.map((userGroupResources) => ({
@@ -237,6 +239,7 @@ describe("Institutions", () => {
         (mocks.institutionGroups.content as any[])[0].institutionId,
         1000,
         0,
+        undefined,
       );
     });
   });
@@ -311,6 +314,7 @@ describe("Institutions", () => {
         institutionId,
         1000,
         0,
+        undefined,
       );
     });
 
@@ -349,6 +353,7 @@ describe("Institutions", () => {
         institutionId,
         1000,
         0,
+        undefined,
       );
     });
   });

--- a/apps/backoffice/src/lib/be/__tests__/services.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/services.test.ts
@@ -673,6 +673,7 @@ describe("Services TEST", () => {
         expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
         expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
           backofficeUser.institution.id,
+          "*",
         );
         expect(retrieveLifecycleServicesMock).toHaveBeenCalledOnce();
         expect(retrieveLifecycleServicesMock).toHaveBeenCalledWith([
@@ -802,6 +803,7 @@ describe("Services TEST", () => {
       expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
       expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
         aBackofficeUser.institution.id,
+        "*",
       );
       expect(retrieveLifecycleServicesMock).toHaveBeenCalledOnce();
       expect(retrieveLifecycleServicesMock).toHaveBeenCalledWith([
@@ -904,6 +906,7 @@ describe("Services TEST", () => {
       expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
       expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
         aBackofficeUser.institution.id,
+        "*",
       );
       expect(getSubscriptionsMock).toHaveBeenCalledOnce();
       expect(getSubscriptionsMock).toHaveBeenCalledWith(
@@ -1003,6 +1006,7 @@ describe("Services TEST", () => {
       expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
       expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
         aBackofficeUser.institution.id,
+        "*",
       );
       expect(getSubscriptionsMock).toHaveBeenCalledOnce();
       expect(getSubscriptionsMock).toHaveBeenCalledWith(
@@ -1058,6 +1062,7 @@ describe("Services TEST", () => {
       expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
       expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
         aBackofficeUser.institution.id,
+        "*",
       );
       expect(getSubscriptionsMock).toHaveBeenCalledOnce();
       expect(getSubscriptionsMock).toHaveBeenCalledWith(
@@ -1167,9 +1172,7 @@ describe("Services TEST", () => {
         if (selcGroups && selcGroups.length > 0) {
           expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledOnce();
           expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledWith(
-            selcGroups
-              .filter((group) => group.state === StateEnum.ACTIVE)
-              .map((group) => group.id),
+            selcGroups.map((group) => group.id),
           );
         } else {
           expect(retrieveAuthorizedServiceIdsMock).not.toHaveBeenCalled();

--- a/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
@@ -183,6 +183,7 @@ describe("withJWTAuthHandler", () => {
     expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
     expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
       mocks.jwtMock.institution.id,
+      "*",
     );
   });
 });

--- a/apps/backoffice/src/lib/be/institutions/business.ts
+++ b/apps/backoffice/src/lib/be/institutions/business.ts
@@ -15,6 +15,7 @@ import { ApimUtils } from "@io-services-cms/external-clients";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 import { GroupNotFoundError } from "../errors";
+import { GroupFilter } from "../selfcare-client";
 import { getManageSubscriptions } from "../subscriptions/business";
 
 // Type utility to extract the resolved type of a Promise
@@ -52,12 +53,18 @@ export const retrieveInstitution = async (
  */
 export const retrieveInstitutionGroups = async (
   institutionId: string,
+  state?: GroupFilter,
 ): Promise<Group[]> => {
   const groups: Group[] = [];
   let page = 0;
   let hasMoreItems = false;
   do {
-    const apiResult = await getInstitutionGroups(institutionId, 1000, page++);
+    const apiResult = await getInstitutionGroups(
+      institutionId,
+      1000,
+      page++,
+      state,
+    );
     groups.push(...toGroups(apiResult.content));
     hasMoreItems = apiResult.totalPages >= page;
   } while (hasMoreItems);

--- a/apps/backoffice/src/lib/be/institutions/selfcare.ts
+++ b/apps/backoffice/src/lib/be/institutions/selfcare.ts
@@ -6,7 +6,11 @@ import {
   InstitutionNotFoundError,
   ManagedInternalError,
 } from "@/lib/be/errors";
-import { UserInstitutions, getSelfcareClient } from "@/lib/be/selfcare-client";
+import {
+  GroupFilter,
+  UserInstitutions,
+  getSelfcareClient,
+} from "@/lib/be/selfcare-client";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { isAxiosError } from "axios";
 import * as E from "fp-ts/lib/Either";
@@ -60,11 +64,13 @@ export const getInstitutionGroups = async (
   institutionId: string,
   size?: number,
   page?: number,
+  state?: GroupFilter,
 ): Promise<PageOfUserGroupResource> => {
   const apiResult = await getSelfcareClient().getInstitutionGroups(
     institutionId,
     size,
     page,
+    state,
   )();
 
   if (E.isLeft(apiResult)) {

--- a/apps/backoffice/src/lib/be/selfcare-client.ts
+++ b/apps/backoffice/src/lib/be/selfcare-client.ts
@@ -1,3 +1,4 @@
+import { StateEnum } from "@/generated/api/Group";
 import { PageOfUserGroupResource } from "@/generated/selfcare/PageOfUserGroupResource";
 import { UserGroupResource } from "@/generated/selfcare/UserGroupResource";
 import {
@@ -24,6 +25,8 @@ export const UserInstitutions = t.readonlyArray(
 );
 export type UserInstitutions = t.TypeOf<typeof UserInstitutions>;
 
+export type GroupFilter = "*" | StateEnum;
+
 export interface SelfcareClient {
   getGroup: (
     id: NonEmptyString,
@@ -35,6 +38,7 @@ export interface SelfcareClient {
     institutionId: string,
     size?: number,
     page?: number,
+    state?: GroupFilter,
   ) => TE.TaskEither<Error, PageOfUserGroupResource>;
   getUserAuthorizedInstitutions: (
     userId: string,
@@ -151,6 +155,7 @@ const buildSelfcareClient = (): SelfcareClient => {
     institutionId: string,
     size?: number,
     page?: number,
+    state: GroupFilter = StateEnum.ACTIVE,
   ) =>
     pipe(
       TE.tryCatch(
@@ -160,7 +165,7 @@ const buildSelfcareClient = (): SelfcareClient => {
               institutionId,
               page,
               size,
-              status: "ACTIVE",
+              status: state === "*" ? undefined : state,
             },
           }),
         flow(

--- a/apps/backoffice/src/lib/be/services/business.ts
+++ b/apps/backoffice/src/lib/be/services/business.ts
@@ -2,7 +2,7 @@
 import { HTTP_STATUS_NO_CONTENT } from "@/config/constants";
 import { BulkPatchServicePayload } from "@/generated/api/BulkPatchServicePayload";
 import { BulkPatchServiceResponse } from "@/generated/api/BulkPatchServiceResponse";
-import { Group, StateEnum } from "@/generated/api/Group";
+import { Group } from "@/generated/api/Group";
 import { MigrationData } from "@/generated/api/MigrationData";
 import { MigrationDelegateList } from "@/generated/api/MigrationDelegateList";
 import { MigrationItemList } from "@/generated/api/MigrationItemList";
@@ -73,9 +73,7 @@ const retrieveSubscriptions = (
   backofficeUser.permissions.selcGroups &&
   backofficeUser.permissions.selcGroups.length > 0
     ? pipe(
-        backofficeUser.permissions.selcGroups
-          .filter((selcGroup) => selcGroup.state === StateEnum.ACTIVE)
-          .map((activeGroup) => activeGroup.id),
+        backofficeUser.permissions.selcGroups.map((group) => group.id),
         retrieveAuthorizedServiceIds,
         TE.chain((authzServiceIds) =>
           getSubscriptions(
@@ -125,7 +123,8 @@ export const retrieveServiceList = async (
         TE.chain((auth) =>
           auth.isAdmin() || !auth.hasSelcGroups()
             ? TE.tryCatch(
-                () => retrieveInstitutionGroups(backofficeUser.institution.id),
+                () =>
+                  retrieveInstitutionGroups(backofficeUser.institution.id, "*"),
                 E.toError,
               )
             : TE.right(backofficeUser.permissions.selcGroups),

--- a/apps/backoffice/src/lib/be/wrappers.ts
+++ b/apps/backoffice/src/lib/be/wrappers.ts
@@ -45,6 +45,7 @@ export const withJWTAuthHandler =
     } else {
       const institutionGroups = await retrieveInstitutionGroups(
         authenticationDetails.institution.id,
+        "*",
       );
       backofficeUser = {
         ...authenticationDetails,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[refactor list service with suspended groups](https://github.com/pagopa/io-services-cms/commit/71836f0577f04c27490744dc843ca19b276ba8ab)
[added filter on selfcare client](https://github.com/pagopa/io-services-cms/commit/7274bb1dbd422c10d5e703021fc1ec0220dadb20)
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The service list didn't contain the infos about the suspended groups
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test
Local environment connected to prod resources
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
