### PR TITLE
fix: Fixed apikey group feature activation on services list items

### DIFF
--- a/.changeset/polite-lamps-argue.md
+++ b/.changeset/polite-lamps-argue.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fixed apikey group feature activation on services list items

--- a/apps/backoffice/src/pages/services/index.tsx
+++ b/apps/backoffice/src/pages/services/index.tsx
@@ -125,7 +125,8 @@ export default function Services() {
         <Button
           disabled={
             isServiceStatusValueDeleted(service.status.value) ||
-            isOperatorAndServiceBoundedToInactiveGroup(session)(service)
+            (hasApiKeyGroupsFeatures(GROUP_APIKEY_ENABLED)(session) &&
+              isOperatorAndServiceBoundedToInactiveGroup(session)(service))
           }
           onClick={() =>
             hasTwoDifferentVersions(service)
@@ -137,6 +138,7 @@ export default function Services() {
             hasTwoDifferentVersions(service) ? (
               <CallSplit
                 color={
+                  hasApiKeyGroupsFeatures(GROUP_APIKEY_ENABLED)(session) &&
                   isOperatorAndServiceBoundedToInactiveGroup(session)(service)
                     ? "disabled"
                     : "primary"
@@ -323,7 +325,10 @@ export default function Services() {
     const result: TableRowMenuAction[] = [];
 
     // Group Check: no menu actions for operator and services with not active selfcare bounded group
-    if (isOperatorAndServiceBoundedToInactiveGroup(session)(service))
+    if (
+      hasApiKeyGroupsFeatures(GROUP_APIKEY_ENABLED)(session) &&
+      isOperatorAndServiceBoundedToInactiveGroup(session)(service)
+    )
       return result;
 
     // Lifecycle actions


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
In the case of an operator user, the services associated with suspended groups, returned in the Service List Page, were represented in disabled mode, thus not allowing access to the detail and the context menu.
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
