### PR TITLE
[IOPAE-1873] add empty response patch service

### DIFF
--- a/.changeset/proud-poets-film.md
+++ b/.changeset/proud-poets-film.md
@@ -1,0 +1,6 @@
+---
+"io-services-cms-webapp": patch
+"io-services-cms-backoffice": patch
+---
+
+change patch service response code into 204

--- a/apps/backoffice/openapi.yaml
+++ b/apps/backoffice/openapi.yaml
@@ -500,12 +500,8 @@ paths:
               $ref: '#/components/schemas/PatchServicePayload'
         required: true
       responses:
-        '200':
+        '204':
           description: Service updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceLifecycle'
         '400':
           description: Invalid payload
         '401':

--- a/apps/backoffice/src/app/api/services/[serviceId]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/services/[serviceId]/__tests__/route.test.ts
@@ -215,12 +215,14 @@ describe("Services API", () => {
         if (requestPayload.metadata.group_id) {
           groupExistsMock.mockReturnValueOnce(true);
         }
-
+        forwardIoServicesCmsRequestMock.mockReturnValueOnce(
+          new NextResponse(null, { status: 204 }),
+        );
         // when
         const result = await PATCH(request, { params });
 
         // then
-        expect(result.status).toBe(200);
+        expect(result.status).toBe(204);
         expect(userAuthzMock).toHaveBeenCalledOnce();
         expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
         expect(isAdminMock).toHaveBeenCalledOnce();

--- a/apps/io-services-cms-webapp/openapi.yaml
+++ b/apps/io-services-cms-webapp/openapi.yaml
@@ -267,12 +267,8 @@ paths:
               $ref: '#/components/schemas/PatchServicePayload'
         required: true
       responses:
-        '200':
+        '204':
           description: Service updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceLifecycle'
         '400':
           description: Invalid payload
         '401':
@@ -347,12 +343,8 @@ paths:
               $ref: '#/components/schemas/PatchServicePayload'
         required: true
       responses:
-        '200':
+        '204':
           description: Service updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceLifecycle'
         '400':
           description: Invalid payload
         '401':

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/patch-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/patch-service.test.ts
@@ -194,7 +194,6 @@ describe("patchService", () => {
 
     // then
     expect(response.statusCode).toBe(204);
-    expect(response.body).toStrictEqual(aService);
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(
       mockApimService,

--- a/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/patch-service.test.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/__tests__/patch-service.test.ts
@@ -193,7 +193,7 @@ describe("patchService", () => {
       .set("x-subscription-id", aManageSubscriptionId);
 
     // then
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(204);
     expect(response.body).toStrictEqual(aService);
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledOnce();
     expect(serviceOwnerCheckManageTaskMock).toHaveBeenCalledWith(

--- a/apps/io-services-cms-webapp/src/webservice/controllers/patch-service.ts
+++ b/apps/io-services-cms-webapp/src/webservice/controllers/patch-service.ts
@@ -15,9 +15,9 @@ import {
   wrapRequestHandler,
 } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
 import {
-  IResponseSuccessJson,
+  IResponseSuccessNoContent,
   ResponseErrorInternal,
-  ResponseSuccessJson,
+  ResponseSuccessNoContent,
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
@@ -48,7 +48,7 @@ type EditServiceHandler = (
   auth: IAzureApiAuthorization,
   serviceId: ServiceLifecycle.definitions.ServiceId,
   servicePayload: PatchServicePayload,
-) => TE.TaskEither<ErrorResponseTypes, IResponseSuccessJson<unknown>>;
+) => TE.TaskEither<ErrorResponseTypes, IResponseSuccessNoContent>;
 
 export const makePatchServiceHandler =
   ({
@@ -72,7 +72,7 @@ export const makePatchServiceHandler =
           TE.mapLeft((err) =>
             ResponseErrorInternal("Failed to patch caused by: " + err.message),
           ),
-          TE.map(ResponseSuccessJson),
+          TE.map(ResponseSuccessNoContent),
         ),
       ),
       TE.map(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[change openapi patch service response status code into 204](https://github.com/pagopa/io-services-cms/commit/7eb6358f4f64ed790544bce6659ad1b589bb24e1)
[implementation change status code on patch service](https://github.com/pagopa/io-services-cms/commit/15ba0bc20a52d5d91cbf6c8c8633e31ac7cf0148)
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit tests
Local environment connected to prod resources
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
