### PR TITLE
[IOPAE-1876] backoffice change auth controls regenerate keys

### DIFF
--- a/.changeset/sixty-spies-grab.md
+++ b/.changeset/sixty-spies-grab.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+add auth check for admin on regenerate manage keys

--- a/apps/backoffice/src/app/api/keys/manage/[keyType]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/keys/manage/[keyType]/__tests__/route.test.ts
@@ -93,4 +93,20 @@ describe("Regenerate Manage Keys API", () => {
 
     expect(result.status).toBe(500);
   });
+
+  it("should return 403", async () => {
+    getToken.mockReturnValueOnce(
+      Promise.resolve({
+        ...mocks.jwtMock,
+        institution: { ...mocks.jwtMock.institution, role: "operator" },
+      }),
+    );
+
+    // Mock NextRequest
+    const request = new NextRequest(new URL("http://localhost"));
+
+    const result = await PUT(request, { params: { keyType: "secondary" } });
+
+    expect(result.status).toBe(403);
+  });
 });

--- a/apps/backoffice/src/app/api/keys/manage/[keyType]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/keys/manage/[keyType]/__tests__/route.test.ts
@@ -24,6 +24,14 @@ const mocks: {
   } as unknown as BackOfficeUser,
 }));
 
+vi.hoisted(() => {
+  const originalEnv = process.env;
+  process.env = {
+    ...originalEnv,
+    GROUP_AUTHZ_ENABLED: "true",
+  };
+});
+
 const { getToken } = vi.hoisted(() => ({
   getToken: vi.fn().mockReturnValue(Promise.resolve(mocks.jwtMock)),
 }));

--- a/apps/backoffice/src/app/api/keys/manage/[keyType]/route.ts
+++ b/apps/backoffice/src/app/api/keys/manage/[keyType]/route.ts
@@ -3,7 +3,8 @@ import {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
 } from "@/config/constants";
 import { SubscriptionKeyType } from "@/generated/api/SubscriptionKeyType";
-import { handlerErrorLog } from "@/lib/be/errors";
+import { userAuthz } from "@/lib/be/authz";
+import { handleForbiddenErrorResponse, handlerErrorLog } from "@/lib/be/errors";
 import { regenerateManageSubscritionApiKey } from "@/lib/be/keys/business";
 import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
@@ -23,6 +24,11 @@ export const PUT = withJWTAuthHandler(
     }: { backofficeUser: BackOfficeUserEnriched; params: { keyType: string } },
   ) => {
     try {
+      if (!userAuthz(backofficeUser).isAdmin()) {
+        return handleForbiddenErrorResponse(
+          "Requested subscription is out of your scope",
+        );
+      }
       const decodedKeyType = SubscriptionKeyType.decode(params.keyType);
 
       if (E.isLeft(decodedKeyType)) {

--- a/apps/backoffice/src/app/api/keys/manage/[keyType]/route.ts
+++ b/apps/backoffice/src/app/api/keys/manage/[keyType]/route.ts
@@ -1,3 +1,4 @@
+import { getConfiguration } from "@/config";
 import {
   HTTP_STATUS_BAD_REQUEST,
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -24,7 +25,10 @@ export const PUT = withJWTAuthHandler(
     }: { backofficeUser: BackOfficeUserEnriched; params: { keyType: string } },
   ) => {
     try {
-      if (!userAuthz(backofficeUser).isAdmin()) {
+      if (
+        getConfiguration().GROUP_AUTHZ_ENABLED &&
+        !userAuthz(backofficeUser).isAdmin()
+      ) {
         return handleForbiddenErrorResponse(
           "Requested subscription is out of your scope",
         );

--- a/apps/backoffice/src/app/api/keys/manage/[keyType]/route.ts
+++ b/apps/backoffice/src/app/api/keys/manage/[keyType]/route.ts
@@ -29,9 +29,7 @@ export const PUT = withJWTAuthHandler(
         getConfiguration().GROUP_AUTHZ_ENABLED &&
         !userAuthz(backofficeUser).isAdmin()
       ) {
-        return handleForbiddenErrorResponse(
-          "Requested subscription is out of your scope",
-        );
+        return handleForbiddenErrorResponse("Role not authorized");
       }
       const decodedKeyType = SubscriptionKeyType.decode(params.keyType);
 

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/__tests__/route.test.ts
@@ -65,9 +65,7 @@ describe("regenerateManageSubscriptionKey", () => {
     // then
     const jsonBody = await result.json();
     expect(result.status).toBe(403);
-    expect(jsonBody.detail).toEqual(
-      "Requested subscription is out of your scope",
-    );
+    expect(jsonBody.detail).toEqual("Role not authorized");
     expect(userAuthzMock).toHaveBeenCalledOnce();
     expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
     expect(isAdminMock).toHaveBeenCalledOnce();

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/__tests__/route.test.ts
@@ -9,12 +9,15 @@ const backofficeUserMock = { permissions: {} } as BackOfficeUser;
 const {
   userAuthzMock,
   isGroupAllowedMock,
+  isAdminMock,
   regenerateManageSubscritionApiKeyMock,
   withJWTAuthHandlerMock,
 } = vi.hoisted(() => ({
   isGroupAllowedMock: vi.fn(() => true),
+  isAdminMock: vi.fn(() => true),
   userAuthzMock: vi.fn(() => ({
     isGroupAllowed: isGroupAllowedMock,
+    isAdmin: isAdminMock,
   })),
   regenerateManageSubscritionApiKeyMock: vi.fn(),
   withJWTAuthHandlerMock: vi.fn(
@@ -52,7 +55,7 @@ describe("regenerateManageSubscriptionKey", () => {
     const nextRequest = new NextRequest("http://localhost");
     const groupId = "groupId";
     const subscriptionId = `MANAGE-GROUP-${groupId}`;
-    isGroupAllowedMock.mockReturnValueOnce(false);
+    isAdminMock.mockReturnValueOnce(false);
 
     // when
     const result = await PUT(nextRequest, {
@@ -67,8 +70,8 @@ describe("regenerateManageSubscriptionKey", () => {
     );
     expect(userAuthzMock).toHaveBeenCalledOnce();
     expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
-    expect(isGroupAllowedMock).toHaveBeenCalledOnce();
-    expect(isGroupAllowedMock).toHaveBeenCalledWith(groupId);
+    expect(isAdminMock).toHaveBeenCalledOnce();
+    expect(isAdminMock).toHaveBeenCalledWith();
     expect(regenerateManageSubscritionApiKeyMock).not.toHaveBeenCalled();
   });
 
@@ -77,7 +80,7 @@ describe("regenerateManageSubscriptionKey", () => {
     const nextRequest = new NextRequest("http://localhost");
     const groupId = "groupId";
     const subscriptionId = `MANAGE-GROUP-${groupId}`;
-    isGroupAllowedMock.mockReturnValueOnce(true);
+    isAdminMock.mockReturnValueOnce(true);
     const keyType = "invalid";
 
     // when
@@ -91,8 +94,8 @@ describe("regenerateManageSubscriptionKey", () => {
     expect(jsonBody.detail).toMatch(/is not a valid/);
     expect(userAuthzMock).toHaveBeenCalledOnce();
     expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
-    expect(isGroupAllowedMock).toHaveBeenCalledOnce();
-    expect(isGroupAllowedMock).toHaveBeenCalledWith(groupId);
+    expect(isAdminMock).toHaveBeenCalledOnce();
+    expect(isAdminMock).toHaveBeenCalledWith();
     expect(regenerateManageSubscritionApiKeyMock).not.toHaveBeenCalled();
   });
 
@@ -119,8 +122,8 @@ describe("regenerateManageSubscriptionKey", () => {
     expect(jsonBody).toStrictEqual(expectedResponse);
     expect(userAuthzMock).toHaveBeenCalledOnce();
     expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
-    expect(isGroupAllowedMock).toHaveBeenCalledOnce();
-    expect(isGroupAllowedMock).toHaveBeenCalledWith(groupId);
+    expect(isAdminMock).toHaveBeenCalledOnce();
+    expect(isAdminMock).toHaveBeenCalledWith();
     expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledOnce();
     expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledWith(
       subscriptionId,
@@ -139,7 +142,7 @@ describe("regenerateManageSubscriptionKey", () => {
       const keyType = "primary";
       const groupId = "groupId";
       const subscriptionId = `MANAGE-GROUP-${groupId}`;
-      isGroupAllowedMock.mockReturnValueOnce(true);
+      isAdminMock.mockReturnValueOnce(true);
       regenerateManageSubscritionApiKeyMock.mockRejectedValueOnce(error);
 
       // when
@@ -154,8 +157,8 @@ describe("regenerateManageSubscriptionKey", () => {
       expect(jsonBody.detail).toEqual(expectedDetail);
       expect(userAuthzMock).toHaveBeenCalledOnce();
       expect(userAuthzMock).toHaveBeenCalledWith(backofficeUserMock);
-      expect(isGroupAllowedMock).toHaveBeenCalledOnce();
-      expect(isGroupAllowedMock).toHaveBeenCalledWith(groupId);
+      expect(isAdminMock).toHaveBeenCalledOnce();
+      expect(isAdminMock).toHaveBeenCalledWith();
       expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledOnce();
       expect(regenerateManageSubscritionApiKeyMock).toHaveBeenCalledWith(
         subscriptionId,

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/route.ts
@@ -31,9 +31,7 @@ export const PUT = withJWTAuthHandler(
     },
   ): Promise<NextResponse<ResponseError | SubscriptionKeys>> => {
     if (!userAuthz(backofficeUser).isAdmin()) {
-      return handleForbiddenErrorResponse(
-        "Requested subscription is out of your scope",
-      );
+      return handleForbiddenErrorResponse("Role not authorized");
     }
     try {
       const maybeDecodedKeyType = SubscriptionKeyType.decode(params.keyType);

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/keys/[keyType]/route.ts
@@ -11,7 +11,6 @@ import {
 import { regenerateManageSubscritionApiKey } from "@/lib/be/keys/business";
 import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
-import { ApimUtils } from "@io-services-cms/external-clients";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import * as E from "fp-ts/lib/Either";
 import { NextRequest, NextResponse } from "next/server";
@@ -31,13 +30,7 @@ export const PUT = withJWTAuthHandler(
       params: { keyType: string; subscriptionId: string };
     },
   ): Promise<NextResponse<ResponseError | SubscriptionKeys>> => {
-    if (
-      !userAuthz(backofficeUser).isGroupAllowed(
-        params.subscriptionId.substring(
-          ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX.length,
-        ),
-      )
-    ) {
+    if (!userAuthz(backofficeUser).isAdmin()) {
       return handleForbiddenErrorResponse(
         "Requested subscription is out of your scope",
       );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[add auth check on regenerater manage api key for admin](https://github.com/pagopa/io-services-cms/commit/c767f3e926df8e806b11774c11ddcceb83ea640e)
[added feature flag check](https://github.com/pagopa/io-services-cms/pull/1196/commits/191f607531e2132b471af2629fdcdd464e203629)
<!--- Describe your changes in detail -->

#### Motivation and Context
The necessity to grant the invocation on regenerate manage api keys operations only for the admin
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
