### PR TITLE
[IOPAE-1879] backoffice change auth controls update manage key authorized cidr

### DIFF
--- a/.changeset/happy-onions-clap.md
+++ b/.changeset/happy-onions-clap.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+change auth controls update manage key authorized cidr

--- a/apps/backoffice/src/app/api/keys/manage/cidrs/route.ts
+++ b/apps/backoffice/src/app/api/keys/manage/cidrs/route.ts
@@ -1,9 +1,11 @@
+import { getConfiguration } from "@/config";
 import {
   HTTP_STATUS_BAD_REQUEST,
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
 } from "@/config/constants";
 import { ManageKeyCIDRs } from "@/generated/api/ManageKeyCIDRs";
-import { handlerErrorLog } from "@/lib/be/errors";
+import { userAuthz } from "@/lib/be/authz";
+import { handleForbiddenErrorResponse, handlerErrorLog } from "@/lib/be/errors";
 import {
   retrieveManageSubscriptionAuthorizedCIDRs,
   upsertManageSubscriptionAuthorizedCIDRs,
@@ -59,6 +61,14 @@ export const PUT = withJWTAuthHandler(
     try {
       const body = await request.json();
       const decodedBody = ManageKeyCIDRs.decode(body);
+      if (
+        getConfiguration().GROUP_AUTHZ_ENABLED &&
+        !userAuthz(backofficeUser).isAdmin()
+      ) {
+        return handleForbiddenErrorResponse(
+          "Requested subscription is out of your scope",
+        );
+      }
 
       if (E.isLeft(decodedBody)) {
         return NextResponse.json(

--- a/apps/backoffice/src/app/api/keys/manage/cidrs/route.ts
+++ b/apps/backoffice/src/app/api/keys/manage/cidrs/route.ts
@@ -65,9 +65,7 @@ export const PUT = withJWTAuthHandler(
         getConfiguration().GROUP_AUTHZ_ENABLED &&
         !userAuthz(backofficeUser).isAdmin()
       ) {
-        return handleForbiddenErrorResponse(
-          "Requested subscription is out of your scope",
-        );
+        return handleForbiddenErrorResponse("Role not authorized");
       }
 
       if (E.isLeft(decodedBody)) {

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/__tests__/route.test.ts
@@ -183,9 +183,7 @@ describe("Authorized CIDRs API", () => {
       // then
       const jsonBody = await result.json();
       expect(result.status).toBe(403);
-      expect(jsonBody.detail).toEqual(
-        "Requested subscription is out of your scope",
-      );
+      expect(jsonBody.detail).toEqual("Role not authorized");
       expect(mock.userAuthz).toHaveBeenCalledOnce();
       expect(mock.userAuthz).toHaveBeenCalledWith(aBackofficeUser);
       expect(mock.isAdminMock).toHaveBeenCalledOnce();

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/__tests__/route.test.ts
@@ -11,6 +11,7 @@ const anAuthrizedCIDRs = ["127.0.0.1" as Cidr];
 
 const mock: {
   isGroupAllowed: Mock;
+  isAdminMock: Mock;
   userAuthz: Mock;
   parseBody: Mock;
   retrieveManageSubscriptionAuthorizedCIDRs: Mock;
@@ -19,7 +20,11 @@ const mock: {
 } = vi.hoisted(() => ({
   isGroupAllowed: vi.fn(),
   parseBody: vi.fn(),
-  userAuthz: vi.fn(() => ({ isGroupAllowed: mock.isGroupAllowed })),
+  isAdminMock: vi.fn(() => true),
+  userAuthz: vi.fn(() => ({
+    isGroupAllowed: mock.isGroupAllowed,
+    isAdmin: mock.isAdminMock,
+  })),
   retrieveManageSubscriptionAuthorizedCIDRs: vi.fn(),
   upsertManageSubscriptionAuthorizedCIDRs: vi.fn(),
   withJWTAuthHandler: vi.fn(
@@ -168,7 +173,7 @@ describe("Authorized CIDRs API", () => {
       const nextRequest = new NextRequest("http://localhost");
       const groupId = "groupId";
       const subscriptionId = `MANAGE-GROUP-${groupId}`;
-      mock.isGroupAllowed.mockReturnValueOnce(false);
+      mock.isAdminMock.mockReturnValueOnce(false);
 
       // when
       const result = await PUT(nextRequest, {
@@ -183,8 +188,8 @@ describe("Authorized CIDRs API", () => {
       );
       expect(mock.userAuthz).toHaveBeenCalledOnce();
       expect(mock.userAuthz).toHaveBeenCalledWith(aBackofficeUser);
-      expect(mock.isGroupAllowed).toHaveBeenCalledOnce();
-      expect(mock.isGroupAllowed).toHaveBeenCalledWith(groupId);
+      expect(mock.isAdminMock).toHaveBeenCalledOnce();
+      expect(mock.isAdminMock).toHaveBeenCalledWith();
       expect(mock.parseBody).not.toHaveBeenCalled();
       expect(
         mock.upsertManageSubscriptionAuthorizedCIDRs,
@@ -214,8 +219,8 @@ describe("Authorized CIDRs API", () => {
       expect(jsonBody.detail).toEqual(error.message);
       expect(mock.userAuthz).toHaveBeenCalledOnce();
       expect(mock.userAuthz).toHaveBeenCalledWith(aBackofficeUser);
-      expect(mock.isGroupAllowed).toHaveBeenCalledOnce();
-      expect(mock.isGroupAllowed).toHaveBeenCalledWith(groupId);
+      expect(mock.isAdminMock).toHaveBeenCalledOnce();
+      expect(mock.isAdminMock).toHaveBeenCalledWith();
       expect(mock.parseBody).toHaveBeenCalledOnce();
       expect(mock.parseBody).toHaveBeenCalledWith(
         nextRequest,
@@ -251,8 +256,8 @@ describe("Authorized CIDRs API", () => {
       expect(jsonBody.detail).toEqual("Something went wrong");
       expect(mock.userAuthz).toHaveBeenCalledOnce();
       expect(mock.userAuthz).toHaveBeenCalledWith(aBackofficeUser);
-      expect(mock.isGroupAllowed).toHaveBeenCalledOnce();
-      expect(mock.isGroupAllowed).toHaveBeenCalledWith(groupId);
+      expect(mock.isAdminMock).toHaveBeenCalledOnce();
+      expect(mock.isAdminMock).toHaveBeenCalledWith();
       expect(mock.parseBody).toHaveBeenCalledOnce();
       expect(mock.parseBody).toHaveBeenCalledWith(
         nextRequest,
@@ -292,8 +297,8 @@ describe("Authorized CIDRs API", () => {
       expect(jsonBody).toStrictEqual({ cidrs: anAuthrizedCIDRs });
       expect(mock.userAuthz).toHaveBeenCalledOnce();
       expect(mock.userAuthz).toHaveBeenCalledWith(aBackofficeUser);
-      expect(mock.isGroupAllowed).toHaveBeenCalledOnce();
-      expect(mock.isGroupAllowed).toHaveBeenCalledWith(groupId);
+      expect(mock.isAdminMock).toHaveBeenCalledOnce();
+      expect(mock.isAdminMock).toHaveBeenCalledWith();
       expect(mock.parseBody).toHaveBeenCalledOnce();
       expect(mock.parseBody).toHaveBeenCalledWith(
         nextRequest,

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/route.ts
@@ -80,9 +80,7 @@ export const PUT = withJWTAuthHandler(
     },
   ): Promise<NextResponse<ResponseError | SubscriptionCIDRs>> => {
     if (!userAuthz(backofficeUser).isAdmin()) {
-      return handleForbiddenErrorResponse(
-        "Requested subscription is out of your scope",
-      );
+      return handleForbiddenErrorResponse("Role not authorized");
     }
     // TODO: add subscription ownerId check. To do that we need to fetch first the subscription in order to get its ownerId and then check equality with backofficeUser.parameters.userId
     let requestPayload;

--- a/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/[subscriptionId]/cidrs/route.ts
@@ -79,13 +79,7 @@ export const PUT = withJWTAuthHandler(
       params: { subscriptionId: string };
     },
   ): Promise<NextResponse<ResponseError | SubscriptionCIDRs>> => {
-    if (
-      !userAuthz(backofficeUser).isGroupAllowed(
-        params.subscriptionId.substring(
-          ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX.length,
-        ),
-      )
-    ) {
+    if (!userAuthz(backofficeUser).isAdmin()) {
       return handleForbiddenErrorResponse(
         "Requested subscription is out of your scope",
       );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[add auth check on update authorized cidr for admin](https://github.com/pagopa/io-services-cms/commit/440994bb6ecf3ef6f59eb33429d794df95dcd6a3)
<!--- Describe your changes in detail -->

#### Motivation and Context
The necessity to grant the invocation on update authorized cidrs operations only for the admin
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
