### PR TITLE
[IOPAE-1877] Added admin control to enable keys rotate and cidrs update actions

### DIFF
--- a/.changeset/poor-spoons-cover.md
+++ b/.changeset/poor-spoons-cover.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added admin control to enable keys rotate and cidrs update actions

--- a/apps/backoffice/src/components/__tests__/access-control.test.tsx
+++ b/apps/backoffice/src/components/__tests__/access-control.test.tsx
@@ -10,8 +10,20 @@ const mockUseSession = useSession as Mock;
 
 let requiredPermissions = [""];
 let requiredRole: any;
-let checkFunction: () => boolean;
+let checkFunction: any;
 let renderNoAccess: any;
+
+const resetVariables = () => {
+  requiredPermissions = [];
+  requiredRole = undefined;
+  checkFunction = undefined;
+  renderNoAccess = undefined;
+};
+
+const reset = () => {
+  cleanup();
+  resetVariables();
+}
 
 /** a test `AccessControl` component */
 const getAccessControlComponent = () => (
@@ -37,8 +49,8 @@ beforeAll(() => {
   });
 });
 
-// needed to clean document (react dom)
-afterEach(cleanup);
+// needed to clean document (react dom) and variables
+afterEach(reset);
 
 describe("[AccessControl] Component", () => {
   it("should render wrapped children if requiredPermissions is a subset of session.user permissions", () => {

--- a/apps/backoffice/src/components/__tests__/access-control.test.tsx
+++ b/apps/backoffice/src/components/__tests__/access-control.test.tsx
@@ -10,11 +10,13 @@ const mockUseSession = useSession as Mock;
 
 let requiredPermissions = [""];
 let requiredRole: any;
+let checkFunction: () => boolean;
 let renderNoAccess: any;
 
 /** a test `AccessControl` component */
 const getAccessControlComponent = () => (
   <AccessControl
+    checkFn={checkFunction}
     requiredPermissions={requiredPermissions}
     requiredRole={requiredRole}
     renderNoAccess={renderNoAccess}
@@ -29,9 +31,9 @@ beforeAll(() => {
     data: {
       user: {
         permissions: { apimGroups: ["permission1", "permission2"] },
-        institution: { role: "aRole" }
-      }
-    }
+        institution: { role: "aRole" },
+      },
+    },
   });
 });
 
@@ -96,5 +98,19 @@ describe("[AccessControl] Component", () => {
 
     expect(document.getElementById("ac-test")).not.toBeInTheDocument();
     expect(document.getElementById("alternative-content")).toBeVisible();
+  });
+
+  it("should render wrapped children if checkFn returns true", () => {
+    checkFunction = () => true;
+    render(getAccessControlComponent());
+
+    expect(document.getElementById("ac-test")).toBeInTheDocument();
+  });
+
+  it("should NOT render wrapped children if checkFn returns false", () => {
+    checkFunction = () => false;
+    render(getAccessControlComponent());
+
+    expect(document.getElementById("ac-test")).not.toBeInTheDocument();
   });
 });

--- a/apps/backoffice/src/components/access-control/index.tsx
+++ b/apps/backoffice/src/components/access-control/index.tsx
@@ -4,6 +4,8 @@ import { useSession } from "next-auth/react";
 import { ReactNode, useState } from "react";
 
 export type AccessControlProps = {
+  /** Define a boolean function that can be passed as render check function */
+  checkFn?: () => boolean;
   /** Wrapped component that need access control based on user permissions */
   children: ReactNode;
   /** Optional element to show in case of unmatched permissions.
@@ -13,6 +15,7 @@ export type AccessControlProps = {
 
 /** Wrapper for content rendering based on user permissions/role match */
 export const AccessControl = ({
+  checkFn,
   children,
   renderNoAccess,
   requiredPermissions,
@@ -24,7 +27,7 @@ export const AccessControl = ({
     hasRequiredAuthorizations(session, {
       requiredPermissions,
       requiredRole,
-    }),
+    }) && (checkFn !== undefined ? checkFn() : true),
   );
 
   if (show) return <>{children}</>;

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group.tsx
@@ -1,7 +1,9 @@
 import { AccessControl } from "@/components/access-control";
+import { getConfiguration } from "@/config";
 import { StateEnum } from "@/generated/api/Subscription";
 import { SubscriptionKeyTypeEnum } from "@/generated/api/SubscriptionKeyType";
 import { SelfcareRoles } from "@/types/auth";
+import { isAdmin } from "@/utils/auth-util";
 import { Delete, ExpandMore, Warning } from "@mui/icons-material";
 import {
   Accordion,
@@ -12,6 +14,7 @@ import {
   CircularProgress,
   Stack,
 } from "@mui/material";
+import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 
 import { ApiKeyTag } from "../api-key-tag";
@@ -35,6 +38,7 @@ interface ApiKeyGroupProps {
 }
 
 const borderStyle = "1px solid #E3E7EB";
+const { GROUP_APIKEY_ENABLED } = getConfiguration();
 
 /** ApiKeyGroup component */
 export const ApiKeyGroup = ({
@@ -47,6 +51,7 @@ export const ApiKeyGroup = ({
   subscriptionId,
 }: ApiKeyGroupProps) => {
   const { t } = useTranslation();
+  const { data: session } = useSession();
 
   const isApiKeySuspended = () => apiKey.state === StateEnum.suspended;
   const canBeExpanded = () => apiKey.state === StateEnum.active;
@@ -134,7 +139,7 @@ export const ApiKeyGroup = ({
             <AuthorizedCidrs
               cidrs={apiKey.cidrs as unknown as string[]}
               description="routes.keys.authorizedCidrs.description"
-              editable={true}
+              editable={!(GROUP_APIKEY_ENABLED && !isAdmin(session))}
               onSaveClick={(cidrs) => onUpdateCidrs(cidrs, subscriptionId)}
             />
           </AccordionDetails>

--- a/apps/backoffice/src/components/api-keys/api-single-key.tsx
+++ b/apps/backoffice/src/components/api-keys/api-single-key.tsx
@@ -1,4 +1,6 @@
+import { getConfiguration } from "@/config";
 import { SubscriptionKeyTypeEnum } from "@/generated/services-cms/SubscriptionKeyType";
+import { isAdmin } from "@/utils/auth-util";
 import { Sync, Visibility, VisibilityOff } from "@mui/icons-material";
 import {
   Box,
@@ -8,10 +10,14 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
 
 import { ApiKeyValue } from ".";
+import { AccessControl } from "../access-control";
+
+const { GROUP_APIKEY_ENABLED } = getConfiguration();
 
 export interface ApiSingleKeyProps {
   keyType: SubscriptionKeyTypeEnum;
@@ -31,7 +37,11 @@ export const ApiSingleKey = ({
   onRotateClick,
 }: ApiSingleKeyProps) => {
   const { t } = useTranslation();
+  const { data: session } = useSession();
   const [isVisible, setIsVisible] = useState(false);
+
+  const handleEnableRotateAction = () =>
+    !GROUP_APIKEY_ENABLED || (GROUP_APIKEY_ENABLED && isAdmin(session));
 
   return (
     <Grid columnSpacing={4} container rowSpacing={3}>
@@ -73,14 +83,16 @@ export const ApiSingleKey = ({
           justifyContent="flex-start"
           spacing={2}
         >
-          <Button
-            onClick={() => onRotateClick(keyType)}
-            size="small"
-            startIcon={<Sync fontSize="inherit" />}
-            variant="outlined"
-          >
-            {t("keys.rotate.button")}
-          </Button>
+          <AccessControl checkFn={handleEnableRotateAction}>
+            <Button
+              onClick={() => onRotateClick(keyType)}
+              size="small"
+              startIcon={<Sync fontSize="inherit" />}
+              variant="outlined"
+            >
+              {t("keys.rotate.button")}
+            </Button>
+          </AccessControl>
           {/* <Button //TODO not yet implemented
             variant="outlined"
             size="small"

--- a/apps/backoffice/src/pages/keys/index.tsx
+++ b/apps/backoffice/src/pages/keys/index.tsx
@@ -8,7 +8,11 @@ import { SubscriptionKeyTypeEnum } from "@/generated/api/SubscriptionKeyType";
 import { SubscriptionKeys } from "@/generated/api/SubscriptionKeys";
 import useFetch from "@/hooks/use-fetch";
 import { AppLayout, PageLayout } from "@/layouts";
-import { hasManageKeyGroup, hasManageKeyRoot } from "@/utils/auth-util";
+import {
+  hasManageKeyGroup,
+  hasManageKeyRoot,
+  isAdmin,
+} from "@/utils/auth-util";
 import { trackApiKeyPageEvent } from "@/utils/mix-panel";
 import { Stack } from "@mui/material";
 import { useRouter } from "next/router";
@@ -76,7 +80,7 @@ export default function Keys() {
           <AuthorizedCidrs
             cidrs={acData?.cidrs as unknown as string[]}
             description="routes.keys.authorizedCidrs.description"
-            editable={true}
+            editable={!(GROUP_APIKEY_ENABLED && !isAdmin(session))}
             onSaveClick={handleUpdateCidrs}
           />
         </Stack>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
With this PR  a user control has been added, in this case `admin`, to enable the _**Key Rotation**_ and **_CIDRs update_** features.

**Note:** this restriction is related to the activation of the Group ApiKeys feature flag (`GROUP_APIKEY_ENABLED`).

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
Need to check admin role to enable some critical actions.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
