### PR TITLE
[IOPAE-1886] Added control to allow USE apikey rotation for all user types

### DIFF
--- a/.changeset/yellow-turtles-sniff.md
+++ b/.changeset/yellow-turtles-sniff.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added control to allow USE apikey rotation for all user types

--- a/apps/backoffice/src/components/api-keys/api-keys-couple.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-couple.tsx
@@ -70,6 +70,7 @@ export const ApiKeysCouple = ({
           handleCopyEventMixpanel(SubscriptionKeyTypeEnum.primary);
         }}
         onRotateClick={handleRotate}
+        type={type}
       />
       <Divider sx={{ marginTop: 3 }} />
       <ApiSingleKey
@@ -80,6 +81,7 @@ export const ApiKeysCouple = ({
           handleCopyEventMixpanel(SubscriptionKeyTypeEnum.secondary);
         }}
         onRotateClick={handleRotate}
+        type={type}
       />
     </>
   );

--- a/apps/backoffice/src/components/api-keys/api-single-key.tsx
+++ b/apps/backoffice/src/components/api-keys/api-single-key.tsx
@@ -25,6 +25,7 @@ export interface ApiSingleKeyProps {
   onBlockClick: (keyType: SubscriptionKeyTypeEnum) => void;
   onCopyClick?: () => void;
   onRotateClick: (keyType: SubscriptionKeyTypeEnum) => void;
+  type: "manage" | "use";
 }
 
 /** Single API Key component */
@@ -35,13 +36,16 @@ export const ApiSingleKey = ({
   onBlockClick,
   onCopyClick,
   onRotateClick,
+  type,
 }: ApiSingleKeyProps) => {
   const { t } = useTranslation();
   const { data: session } = useSession();
   const [isVisible, setIsVisible] = useState(false);
 
   const handleEnableRotateAction = () =>
-    !GROUP_APIKEY_ENABLED || (GROUP_APIKEY_ENABLED && isAdmin(session));
+    type === "use" ||
+    !GROUP_APIKEY_ENABLED ||
+    (GROUP_APIKEY_ENABLED && isAdmin(session));
 
   return (
     <Grid columnSpacing={4} container rowSpacing={3}>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added control to allow USE apikey rotation for all user types.

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
Both admin and operator role must have USE apikey rotation capability.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
