### PR TITLE
Fix: [IOPAE-1971] Fix create service form reset

### DIFF
--- a/.changeset/five-dogs-joke.md
+++ b/.changeset/five-dogs-joke.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Service create form: fixed issue where form would reset and lose data when changing browser tabs

--- a/apps/backoffice/src/components/services/service-create-update/service-create-update.tsx
+++ b/apps/backoffice/src/components/services/service-create-update/service-create-update.tsx
@@ -23,7 +23,7 @@ import {
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import {
   ServiceBuilderStep1,
@@ -70,33 +70,37 @@ export const ServiceCreateUpdate = ({
       ? session.user.permissions.selcGroups[0]
       : "";
 
-  const serviceDefaultData: ServiceCreateUpdatePayload = {
-    authorized_cidrs: [],
-    authorized_recipients: [],
-    description: "",
-    max_allowed_payment_amount: 0,
-    metadata: {
-      address: "",
-      app_android: "",
-      app_ios: "",
-      assistanceChannels: [{ type: "email", value: "" }],
-      category: "",
-      cta: {
-        text: "",
-        url: "",
+  const serviceDefaultData: ServiceCreateUpdatePayload = useMemo(
+    () => ({
+      authorized_cidrs: [],
+      authorized_recipients: [],
+      description: "",
+      max_allowed_payment_amount: 0,
+      metadata: {
+        address: "",
+        app_android: "",
+        app_ios: "",
+        assistanceChannels: [{ type: "email", value: "" }],
+        category: "",
+        cta: {
+          text: "",
+          url: "",
+        },
+        custom_special_flow: "",
+        group_id: handleOperatorWithSingleGroup(),
+        privacy_url: "",
+        scope: ScopeEnum.LOCAL,
+        token_name: "",
+        topic_id: "",
+        tos_url: "",
+        web_url: "",
       },
-      custom_special_flow: "",
-      group_id: handleOperatorWithSingleGroup(),
-      privacy_url: "",
-      scope: ScopeEnum.LOCAL,
-      token_name: "",
-      topic_id: "",
-      tos_url: "",
-      web_url: "",
-    },
-    name: "",
-    require_secure_channel: false,
-  };
+      name: "",
+      require_secure_channel: false,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   const handleCancel = async () => {
     const confirmed = await showDialog({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
**Fix:** Prevent form fields from resetting on tab focus change due to `next-auth` session refetch.

**Details:**
Refactored the form initialization to memoize _defaultValues_ using `useMemo`, ensuring that `react-hook-form` does not reset field values when the component re-renders _(e.g., during automatic session refresh triggered by next-auth when switching browser tabs)._

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
