### PR TITLE
[IOPAE-2004] workaround override io organization name

### DIFF
--- a/.changeset/chilled-jars-sparkle.md
+++ b/.changeset/chilled-jars-sparkle.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+fix organization name override with temporary workaround

--- a/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-lifecycle-converters.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-lifecycle-converters.test.ts
@@ -140,4 +140,56 @@ describe("test service-lifecycle-converters", () => {
     expect(result.data.metadata.custom_special_flow).toBeDefined();
     expect(result.data.metadata.custom_special_flow).toBe(aCustomSpecialFlow);
   });
+
+  test("Converting a service payload from PagoPA requires mapping the organization name", () => {
+    const aNewService = {
+      name: "a service",
+      description: "a description",
+      organization: {
+        name: "org",
+        fiscal_code: "15376371009",
+      },
+      metadata: {
+        scope: "LOCAL",
+        topic_id: 1,
+      },
+      authorized_recipients: [anAutorizedFiscalCode],
+    } as unknown as ServicePayload;
+
+    const result = payloadToItem(
+      "ffefefe" as NonEmptyString,
+      aNewService,
+      aSandboxFiscalCode as FiscalCode,
+    );
+    expect(result.data.metadata).toBeDefined();
+    expect(result.data.metadata.category).toBeDefined();
+    expect(result.data.organization.name).toBe(
+      "IO - L'app dei servizi pubblici",
+    );
+  });
+
+  test("converting a payload of a service that doesn't come from the organization PagoPA, the organization name must not be modified", () => {
+    const aNewService = {
+      name: "a service",
+      description: "a description",
+      organization: {
+        name: "org",
+        fiscal_code: "000000000000",
+      },
+      metadata: {
+        scope: "LOCAL",
+        topic_id: 1,
+      },
+      authorized_recipients: [anAutorizedFiscalCode],
+    } as unknown as ServicePayload;
+
+    const result = payloadToItem(
+      "ffefefe" as NonEmptyString,
+      aNewService,
+      aSandboxFiscalCode as FiscalCode,
+    );
+    expect(result.data.metadata).toBeDefined();
+    expect(result.data.metadata.category).toBeDefined();
+    expect(result.data.organization.name).toBe("org");
+  });
 });

--- a/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
@@ -3,6 +3,7 @@ import {
   IResponseErrorInternal,
   ResponseErrorInternal,
 } from "@pagopa/ts-commons/lib/responses";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
@@ -42,6 +43,13 @@ export const payloadToItem = (
     ),
     max_allowed_payment_amount,
     metadata: { ...metadata, category: toCategoryType(metadata.category) },
+    organization: {
+      ...data.organization,
+      name: renameIoAppServicesOrganizationName(
+        data.organization.fiscal_code,
+        data.organization.name,
+      ),
+    },
     require_secure_channel,
   },
   id,
@@ -110,6 +118,19 @@ const toServiceTopic =
           ),
         )
       : TE.right(undefined);
+
+//FIXME: remove this workaround for managing the creation and the update of services from pagopa
+//        where the name of the organization needs to be renamed into "IO - L'app dei servizi pubblici"
+const IO_APP_ORGANIZATION_NAME = "IO - L'app dei servizi pubblici";
+const PAGOPA_ORGANIZATION_FISCAL_CODE = "15376371009";
+
+const renameIoAppServicesOrganizationName = (
+  fiscalCode: string,
+  organizationName: string,
+): NonEmptyString =>
+  fiscalCode === PAGOPA_ORGANIZATION_FISCAL_CODE
+    ? (IO_APP_ORGANIZATION_NAME as NonEmptyString)
+    : (organizationName as NonEmptyString);
 
 export const toServiceStatus = (
   fsm: ServiceLifecycle.ItemType["fsm"],

--- a/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
@@ -45,7 +45,7 @@ export const payloadToItem = (
     metadata: { ...metadata, category: toCategoryType(metadata.category) },
     organization: {
       ...data.organization,
-      name: renameIoAppServicesOrganizationName(
+      name: renamePagoPAServicesOrganizationName(
         data.organization.fiscal_code,
         data.organization.name,
       ),
@@ -121,15 +121,15 @@ const toServiceTopic =
 
 //FIXME: remove this workaround for managing the creation and the update of services from pagopa
 //        where the name of the organization needs to be renamed into "IO - L'app dei servizi pubblici"
-const IO_APP_ORGANIZATION_NAME = "IO - L'app dei servizi pubblici";
+const PAGOPA_ORGANIZATION_NAME = "IO - L'app dei servizi pubblici";
 const PAGOPA_ORGANIZATION_FISCAL_CODE = "15376371009";
 
-const renameIoAppServicesOrganizationName = (
+const renamePagoPAServicesOrganizationName = (
   fiscalCode: string,
   organizationName: string,
 ): NonEmptyString =>
   fiscalCode === PAGOPA_ORGANIZATION_FISCAL_CODE
-    ? (IO_APP_ORGANIZATION_NAME as NonEmptyString)
+    ? (PAGOPA_ORGANIZATION_NAME as NonEmptyString)
     : (organizationName as NonEmptyString);
 
 export const toServiceStatus = (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[fix organization name override with temporary workaround](https://github.com/pagopa/io-services-cms/commit/23aa15bc9871aaecfa597973d7e5de1f637237ec)
<!--- Describe your changes in detail -->

#### Motivation and Context
When a service from the pagopa organization is updated or created the organazation name needs to be remapped 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local environment connected to prod resources
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
