### PR TITLE
[IOPAE-2004] backoffice workaround override io organization name

### DIFF
--- a/.changeset/tough-donuts-cry.md
+++ b/.changeset/tough-donuts-cry.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+fix organization name override with temporary workaround

--- a/apps/backoffice/src/app/api/services/[serviceId]/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/services/[serviceId]/__tests__/route.test.ts
@@ -124,6 +124,39 @@ describe("Services API", () => {
         },
       );
     });
+
+    it("should forward request with request organization name modified if organization is PagoPA", async () => {
+      // given
+      const jsonBodyMock = aValidServicePayload;
+      parseBodyMock.mockResolvedValueOnce(aValidServicePayload);
+      backofficeUserMock.institution.role = SelfcareRoles.admin;
+      backofficeUserMock.institution.fiscalCode = "15376371009";
+      backofficeUserMock.institution.name = "org";
+      const params = { serviceId: faker.string.uuid() };
+      const request = new NextRequest(new URL("http://localhost"));
+
+      // when
+      const result = await PUT(request, { params });
+
+      // then
+      expect(result.status).toBe(200);
+      expect(forwardIoServicesCmsRequestMock).toHaveBeenCalledOnce();
+      expect(forwardIoServicesCmsRequestMock).toHaveBeenCalledWith(
+        "updateService",
+        {
+          nextRequest: request,
+          backofficeUser: backofficeUserMock,
+          jsonBody: {
+            ...jsonBodyMock,
+            organization: {
+              name: "IO - L'app dei servizi pubblici",
+              fiscal_code: backofficeUserMock.institution.fiscalCode,
+            },
+          },
+          pathParams: params,
+        },
+      );
+    });
   });
 
   describe("patchService", () => {

--- a/apps/backoffice/src/app/api/services/[serviceId]/route.ts
+++ b/apps/backoffice/src/app/api/services/[serviceId]/route.ts
@@ -11,7 +11,7 @@ import { groupExists } from "@/lib/be/institutions/business";
 import { parseBody } from "@/lib/be/req-res-utils";
 import { forwardIoServicesCmsRequest } from "@/lib/be/services/business";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
-import { renamePagoPAServicesOrganizationName } from "@/utils/rename-pagopa-organization";
+import { getServiceOrganizationName } from "@/utils/organization-name-utils";
 import { NextRequest } from "next/server";
 
 /**
@@ -65,10 +65,7 @@ export const PUT = withJWTAuthHandler(
           ...servicePayload,
           organization: {
             fiscal_code: backofficeUser.institution.fiscalCode,
-            name: renamePagoPAServicesOrganizationName(
-              backofficeUser.institution.fiscalCode,
-              backofficeUser.institution.name,
-            ),
+            name: getServiceOrganizationName(backofficeUser.institution),
           },
         },
         nextRequest,

--- a/apps/backoffice/src/app/api/services/[serviceId]/route.ts
+++ b/apps/backoffice/src/app/api/services/[serviceId]/route.ts
@@ -11,6 +11,7 @@ import { groupExists } from "@/lib/be/institutions/business";
 import { parseBody } from "@/lib/be/req-res-utils";
 import { forwardIoServicesCmsRequest } from "@/lib/be/services/business";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
+import { renamePagoPAServicesOrganizationName } from "@/utils/rename-pagopa-organization";
 import { NextRequest } from "next/server";
 
 /**
@@ -64,7 +65,10 @@ export const PUT = withJWTAuthHandler(
           ...servicePayload,
           organization: {
             fiscal_code: backofficeUser.institution.fiscalCode,
-            name: backofficeUser.institution.name,
+            name: renamePagoPAServicesOrganizationName(
+              backofficeUser.institution.fiscalCode,
+              backofficeUser.institution.name,
+            ),
           },
         },
         nextRequest,

--- a/apps/backoffice/src/app/api/services/route.ts
+++ b/apps/backoffice/src/app/api/services/route.ts
@@ -19,7 +19,7 @@ import {
   forwardIoServicesCmsRequest,
 } from "@/lib/be/services/business";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
-import { renamePagoPAServicesOrganizationName } from "@/utils/rename-pagopa-organization";
+import { getServiceOrganizationName } from "@/utils/organization-name-utils";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -78,10 +78,7 @@ export const POST = withJWTAuthHandler(
           ...servicePayload,
           organization: {
             fiscal_code: backofficeUser.institution.fiscalCode,
-            name: renamePagoPAServicesOrganizationName(
-              backofficeUser.institution.fiscalCode,
-              backofficeUser.institution.name,
-            ),
+            name: getServiceOrganizationName(backofficeUser.institution),
           },
         },
         nextRequest,

--- a/apps/backoffice/src/app/api/services/route.ts
+++ b/apps/backoffice/src/app/api/services/route.ts
@@ -19,6 +19,7 @@ import {
   forwardIoServicesCmsRequest,
 } from "@/lib/be/services/business";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
+import { renamePagoPAServicesOrganizationName } from "@/utils/rename-pagopa-organization";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -77,7 +78,10 @@ export const POST = withJWTAuthHandler(
           ...servicePayload,
           organization: {
             fiscal_code: backofficeUser.institution.fiscalCode,
-            name: backofficeUser.institution.name,
+            name: renamePagoPAServicesOrganizationName(
+              backofficeUser.institution.fiscalCode,
+              backofficeUser.institution.name,
+            ),
           },
         },
         nextRequest,

--- a/apps/backoffice/src/utils/organization-name-utils.ts
+++ b/apps/backoffice/src/utils/organization-name-utils.ts
@@ -1,12 +1,13 @@
+import { BackOfficeUserEnriched } from "@/lib/be/wrappers";
+
 //FIXME: remove this workaround for managing the creation and the update of services from pagopa
 //        where the name of the organization needs to be renamed into "IO - L'app dei servizi pubblici"
 const PAGOPA_ORGANIZATION_NAME = "IO - L'app dei servizi pubblici";
 const PAGOPA_ORGANIZATION_FISCAL_CODE = "15376371009";
 
-export const renamePagoPAServicesOrganizationName = (
-  fiscalCode: string,
-  organizationName: string,
+export const getServiceOrganizationName = (
+  institution: BackOfficeUserEnriched["institution"],
 ): string =>
-  fiscalCode === PAGOPA_ORGANIZATION_FISCAL_CODE
-    ? (PAGOPA_ORGANIZATION_NAME as string)
-    : (organizationName as string);
+  institution.fiscalCode === PAGOPA_ORGANIZATION_FISCAL_CODE
+    ? PAGOPA_ORGANIZATION_NAME
+    : institution.name;

--- a/apps/backoffice/src/utils/rename-pagopa-organization.ts
+++ b/apps/backoffice/src/utils/rename-pagopa-organization.ts
@@ -1,0 +1,12 @@
+//FIXME: remove this workaround for managing the creation and the update of services from pagopa
+//        where the name of the organization needs to be renamed into "IO - L'app dei servizi pubblici"
+const PAGOPA_ORGANIZATION_NAME = "IO - L'app dei servizi pubblici";
+const PAGOPA_ORGANIZATION_FISCAL_CODE = "15376371009";
+
+export const renamePagoPAServicesOrganizationName = (
+  fiscalCode: string,
+  organizationName: string,
+): string =>
+  fiscalCode === PAGOPA_ORGANIZATION_FISCAL_CODE
+    ? (PAGOPA_ORGANIZATION_NAME as string)
+    : (organizationName as string);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
[fix organization name override with temporary workaround](https://github.com/pagopa/io-services-cms/commit/4579775557a4478c271dbd25678adf8f7b1585b2)
<!--- Describe your changes in detail -->
When a service from the pagopa organization is updated or created the organazation name needs to be remapped


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local environment connected to prod resources and unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
