### PR TITLE
[IOPAE-2034, IOPAE-2035] Updated mixpanel service create/update abort event, added new login error event

### DIFF
--- a/.changeset/rotten-ladybugs-mix.md
+++ b/.changeset/rotten-ladybugs-mix.md
@@ -1,0 +1,6 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Added mixpanel custom stepIndex prop on IO_BO_SERVICE_CREATE_ABORT and on IO_BO_SERVICE_EDIT_ABORT.
+Added mixpanel new IO_BO_LOGIN_ERROR event for auth error page

--- a/apps/backoffice/src/components/create-update-process/create-update-process.tsx
+++ b/apps/backoffice/src/components/create-update-process/create-update-process.tsx
@@ -40,14 +40,20 @@ export interface ConfirmButtonLabelsType {
 export interface CreateUpdateProcessProps<T> {
   /** Label for final confirm button _(in both modes `create` and `update`)_ */
   confirmButtonLabels: ConfirmButtonLabelsType;
-  /** item for which to carry out the creation or modification process */
+  /** Item for which to carry out the creation or modification process */
   itemToCreateUpdate: DefaultValues<T>;
   /** Process mode: `create` or `update` */
   mode: CreateUpdateMode;
-  /** event triggered on process exit */
+  /** Event triggered on process exit */
   onCancel: () => void;
-  /** event triggered on process completed, with result item of `T` */
+  /** Event triggered on process completed, with result item of `T` */
   onConfirm: (value: T) => void;
+  /**
+   * Event triggered on form step index change
+   * @param index step index
+   * @returns
+   */
+  onStepChange?: (index: number) => void;
   /** list of step that make up the process */
   steps: BuilderStep[];
 }
@@ -59,6 +65,7 @@ export function CreateUpdateProcess<T extends FieldValues>({
   mode,
   onCancel,
   onConfirm,
+  onStepChange,
   steps,
 }: CreateUpdateProcessProps<T>) {
   const { t } = useTranslation();
@@ -84,10 +91,12 @@ export function CreateUpdateProcess<T extends FieldValues>({
   const decreaseStep = () => {
     clearErrors();
     setCurrentStep(currentStepIndex - 1);
+    onStepChange?.(currentStepIndex - 1);
   };
   const increaseStep = () => {
     clearErrors();
     setCurrentStep(currentStepIndex + 1);
+    onStepChange?.(currentStepIndex + 1);
   };
 
   const handleShowMore = () => {

--- a/apps/backoffice/src/pages/auth/error.tsx
+++ b/apps/backoffice/src/pages/auth/error.tsx
@@ -1,10 +1,19 @@
 import { LoaderFullscreen } from "@/components/loaders";
+import { trackLoginErrorEvent } from "@/utils/mix-panel";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useEffect } from "react";
 
 export default function ErrorPage() {
   const router = useRouter();
   const error = router.query.error as string;
+
+  useEffect(() => {
+    if (router.isReady) {
+      trackLoginErrorEvent(error);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]);
 
   return (
     <LoaderFullscreen content={error} loading={false} title="auth.error" />

--- a/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
+++ b/apps/backoffice/src/pages/services/[serviceId]/edit-service.tsx
@@ -9,7 +9,10 @@ import { ServiceLifecycle } from "@/generated/api/ServiceLifecycle";
 import useFetch from "@/hooks/use-fetch";
 import { AppLayout, PageLayout } from "@/layouts";
 import { ServiceCreateUpdatePayload } from "@/types/service";
-import { trackServiceEditEndEvent } from "@/utils/mix-panel";
+import {
+  trackServiceEditAbortEvent,
+  trackServiceEditEndEvent,
+} from "@/utils/mix-panel";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import * as E from "fp-ts/lib/Either";
 import { useRouter } from "next/router";
@@ -17,7 +20,6 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useSnackbar } from "notistack";
 import { ReactElement, useEffect, useState } from "react";
-import React from "react";
 
 const pageTitleLocaleKey = "routes.edit-service.title";
 const pageDescriptionLocaleKey = "routes.edit-service.description";
@@ -33,6 +35,7 @@ export default function EditService() {
     useFetch<ServiceLifecycle>();
   const [serviceCreateUpdatePayload, setServiceCreateUpdatePayload] =
     useState<ServiceCreateUpdatePayload>();
+  const [stepIndex, setStepIndex] = useState(0);
 
   const handleConfirm = async (service: ServiceCreateUpdatePayload) => {
     const maybeApiServicePayload =
@@ -66,6 +69,11 @@ export default function EditService() {
     router.push(`${SERVICES_ROUTE_PATH}/${serviceId}`);
   };
 
+  const handleAbort = () => {
+    trackServiceEditAbortEvent(stepIndex);
+    router.push(`${SERVICES_ROUTE_PATH}/${serviceId}`);
+  };
+
   useEffect(() => {
     serviceFetchData("getService", { serviceId }, ServiceLifecycle, {
       notify: "errors",
@@ -87,13 +95,15 @@ export default function EditService() {
       <PageHeader
         description={pageDescriptionLocaleKey}
         hideBreadcrumbs
-        onExitClick={() => router.push(`${SERVICES_ROUTE_PATH}/${serviceId}`)}
+        onExitClick={handleAbort}
         showExit
         title={pageTitleLocaleKey}
       />
       <ServiceCreateUpdate
         mode="update"
+        onCancel={handleAbort}
         onConfirm={handleConfirm}
+        onStepChange={setStepIndex}
         service={serviceCreateUpdatePayload}
       />
     </>

--- a/apps/backoffice/src/pages/services/new-service.tsx
+++ b/apps/backoffice/src/pages/services/new-service.tsx
@@ -6,14 +6,17 @@ import { ServiceLifecycle } from "@/generated/api/ServiceLifecycle";
 import useFetch from "@/hooks/use-fetch";
 import { AppLayout, PageLayout } from "@/layouts";
 import { ServiceCreateUpdatePayload } from "@/types/service";
-import { trackServiceCreateEndEvent } from "@/utils/mix-panel";
+import {
+  trackServiceCreateAbortEvent,
+  trackServiceCreateEndEvent,
+} from "@/utils/mix-panel";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import * as E from "fp-ts/lib/Either";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useSnackbar } from "notistack";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 
 const pageTitleLocaleKey = "routes.new-service.title";
 const pageDescriptionLocaleKey = "routes.new-service.description";
@@ -25,6 +28,7 @@ export default function NewService() {
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
   const { fetchData: serviceFetchData } = useFetch<ServiceLifecycle>();
+  const [stepIndex, setStepIndex] = useState(0);
 
   const handleConfirm = async (service: ServiceCreateUpdatePayload) => {
     const maybeServicePayload =
@@ -57,16 +61,26 @@ export default function NewService() {
     router.push(SERVICES_ROUTE_PATH);
   };
 
+  const handleAbort = () => {
+    trackServiceCreateAbortEvent(stepIndex);
+    router.push(SERVICES_ROUTE_PATH);
+  };
+
   return (
     <>
       <PageHeader
         description={pageDescriptionLocaleKey}
         hideBreadcrumbs
-        onExitClick={() => router.push(SERVICES_ROUTE_PATH)}
+        onExitClick={handleAbort}
         showExit
         title={pageTitleLocaleKey}
       />
-      <ServiceCreateUpdate mode="create" onConfirm={handleConfirm} />
+      <ServiceCreateUpdate
+        mode="create"
+        onCancel={handleAbort}
+        onConfirm={handleConfirm}
+        onStepChange={setStepIndex}
+      />
     </>
   );
 }

--- a/apps/backoffice/src/utils/mix-panel.ts
+++ b/apps/backoffice/src/utils/mix-panel.ts
@@ -13,6 +13,7 @@ interface MixPanelEventsStructure {
     switchToInstitutionId: string;
   };
   readonly IO_BO_LOGIN: Record<string, never>;
+  readonly IO_BO_LOGIN_ERROR: { reason: string };
   readonly IO_BO_MANAGE_KEY_COPY: {
     entryPoint: string;
     keyType: ApiKeyType;
@@ -22,7 +23,7 @@ interface MixPanelEventsStructure {
   };
   readonly IO_BO_OVERVIEW_PAGE: Record<string, never>;
   readonly IO_BO_PRODUCT_SWITCH: { productId: string };
-  readonly IO_BO_SERVICE_CREATE_ABORT: Record<string, never>;
+  readonly IO_BO_SERVICE_CREATE_ABORT: { stepIndex: number };
   readonly IO_BO_SERVICE_CREATE_END: {
     result: TechEventResult;
     serviceId?: string;
@@ -33,7 +34,7 @@ interface MixPanelEventsStructure {
     serviceId: string;
     serviceName: string;
   };
-  readonly IO_BO_SERVICE_EDIT_ABORT: Record<string, never>;
+  readonly IO_BO_SERVICE_EDIT_ABORT: { stepIndex: number };
   readonly IO_BO_SERVICE_EDIT_END: {
     result: TechEventResult;
     serviceId: string;
@@ -117,6 +118,10 @@ export const trackLoginEvent = () => {
   logToMixpanel("IO_BO_LOGIN", "UX", {}, "screen_view");
 };
 
+export const trackLoginErrorEvent = (reason: string) => {
+  logToMixpanel("IO_BO_LOGIN_ERROR", "UX", { reason }, "screen_view");
+};
+
 export const trackManageKeyCopyEvent = (
   entryPoint: string,
   keyType: ApiKeyType,
@@ -158,8 +163,8 @@ export const trackProductSwitchEvent = (productId: string) => {
   );
 };
 
-export const trackServiceCreateAbortEvent = () => {
-  logToMixpanel("IO_BO_SERVICE_CREATE_ABORT", "UX", {}, "action");
+export const trackServiceCreateAbortEvent = (stepIndex: number) => {
+  logToMixpanel("IO_BO_SERVICE_CREATE_ABORT", "UX", { stepIndex }, "action");
 };
 
 export const trackServiceCreateEndEvent = (
@@ -202,8 +207,8 @@ export const trackServiceDetailsPageEvent = (
   );
 };
 
-export const trackServiceEditAbortEvent = () => {
-  logToMixpanel("IO_BO_SERVICE_EDIT_ABORT", "UX", {}, "action");
+export const trackServiceEditAbortEvent = (stepIndex: number) => {
+  logToMixpanel("IO_BO_SERVICE_EDIT_ABORT", "UX", { stepIndex }, "action");
 };
 
 export const trackServiceEditEndEvent = (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR improve mixpanel tracking on BackOffice IO.

#### List of Changes
- Updated mixpanel **_IO_BO_SERVICE_CREATE_ABORT_**, _**IO_BO_SERVICE_EDIT_ABORT**_ events with new `stepIndex` custom property.
- Added mixpanel new IO_BO_LOGIN_ERROR event for auth error page<!--- Describe your changes in detail -->

#### Motivation and Context
Need to track user drop-off point within the service creation/modification funnel.
Need to track user authentication error.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local `dev` mode with `msw` mocks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
