### PR TITLE
[IOPAE-1899] Added suspended group name interpolation in tooltips for ServiceGroupTag and ApiKeysGroupTag

### DIFF
--- a/.changeset/hip-cups-cry.md
+++ b/.changeset/hip-cups-cry.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+show the name of the suspended group in the tooltipAdded tooltip logic with group name interpolation in ServiceGroupTag and ApiKeysGroupTag.Cleaned up the code by handling safe fallback when the group name is missing.Kept the current structure with separate components without introducing a generic component, to avoid extensive refactoring.

--- a/.changeset/hip-cups-cry.md
+++ b/.changeset/hip-cups-cry.md
@@ -2,4 +2,4 @@
 "io-services-cms-backoffice": patch
 ---
 
-show the name of the suspended group in the tooltipAdded tooltip logic with group name interpolation in ServiceGroupTag and ApiKeysGroupTag.Cleaned up the code by handling safe fallback when the group name is missing.Kept the current structure with separate components without introducing a generic component, to avoid extensive refactoring.
+Added group name interpolation in tooltips for ServiceGroupTag and ApiKeysGroupTag.

--- a/.changeset/hip-cups-cry.md
+++ b/.changeset/hip-cups-cry.md
@@ -2,4 +2,4 @@
 "io-services-cms-backoffice": patch
 ---
 
-Added group name interpolation in tooltips for ServiceGroupTag and ApiKeysGroupTag.
+Added suspended group name interpolation in tooltips for ServiceGroupTag and ApiKeysGroupTag.

--- a/apps/backoffice/public/locales/en/common.json
+++ b/apps/backoffice/public/locales/en/common.json
@@ -479,7 +479,7 @@
           "state": {
             "suspended": {
               "label": "Group API Keys are suspended",
-              "tooltip": "The group has been suspended in the Reserved Area and its API Keys are blocked."
+              "tooltip": "The group {{name}} has been suspended in the Reserved Area and its API Keys are blocked."
             }
           }
         }

--- a/apps/backoffice/public/locales/it/common.json
+++ b/apps/backoffice/public/locales/it/common.json
@@ -479,7 +479,7 @@
           "state": {
             "suspended": {
               "label": "API Key del gruppo sospese",
-              "tooltip": "Il gruppo è stato sospeso in Area Riservata e le relative API Key sono bloccate."
+              "tooltip": "Il gruppo {{name}} è stato sospeso in Area Riservata e le relative API Key sono bloccate."
             }
           }
         }

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group-tag.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group-tag.tsx
@@ -1,5 +1,6 @@
 import { StateEnum, Subscription } from "@/generated/api/Subscription";
 import { Warning } from "@mui/icons-material";
+import { useTranslation } from "next-i18next";
 
 import { ApiKeyTag } from "../api-key-tag";
 
@@ -20,11 +21,20 @@ export const ApiKeysGroupTag = ({
   onClick,
   value,
 }: ApiKeysGroupTagProps) => {
+  const { t } = useTranslation();
   const shouldBeDisabled = () =>
     value.state !== StateEnum.active && value.state !== StateEnum.suspended;
 
   const handleOnClick = () =>
     !shouldBeDisabled() && onClick ? onClick() : undefined;
+  const tooltip =
+    value.state === StateEnum.suspended
+      ? t("routes.keys.manage.group.state.suspended.tooltip", {
+          name: value?.name ?? "",
+        })
+      : noWrap
+        ? (value?.name ?? "")
+        : "";
 
   return (
     <ApiKeyTag
@@ -35,13 +45,7 @@ export const ApiKeysGroupTag = ({
       label={value.name}
       noWrap={noWrap}
       onClick={handleOnClick}
-      tooltip={
-        value.state === StateEnum.suspended
-          ? "routes.keys.manage.group.state.suspended.tooltip"
-          : noWrap
-            ? value.name
-            : ""
-      }
+      tooltip={tooltip}
     />
   );
 };

--- a/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group.tsx
+++ b/apps/backoffice/src/components/api-keys/api-keys-groups/api-keys-group.tsx
@@ -94,7 +94,9 @@ export const ApiKeyGroup = ({
                 color="warning"
                 icon={<Warning />}
                 label="routes.keys.manage.group.state.suspended.label"
-                tooltip="routes.keys.manage.group.state.suspended.tooltip"
+                tooltip={t("routes.keys.manage.group.state.suspended.tooltip", {
+                  name: apiKey.name,
+                })}
               />
             )}
           </Stack>

--- a/apps/backoffice/src/components/services/service-group-tag.tsx
+++ b/apps/backoffice/src/components/services/service-group-tag.tsx
@@ -1,5 +1,6 @@
 import { Group, StateEnum } from "@/generated/api/Group";
 import { Warning } from "@mui/icons-material";
+import { useTranslation } from "next-i18next";
 
 import { ApiKeyTag } from "../api-keys/api-key-tag";
 
@@ -15,20 +16,25 @@ export const ServiceGroupTag = ({
   id,
   noWrap,
   value,
-}: ServiceGroupTagProps) => (
-  <ApiKeyTag
-    color={value.state === StateEnum.SUSPENDED ? "warning" : "default"}
-    disabled={value.state === StateEnum.DELETED}
-    icon={value.state === StateEnum.SUSPENDED ? <Warning /> : undefined}
-    id={id}
-    label={value.name}
-    noWrap={noWrap}
-    tooltip={
-      value.state === StateEnum.SUSPENDED
-        ? "routes.keys.manage.group.state.suspended.tooltip"
-        : noWrap
-          ? value.name
-          : ""
-    }
-  />
-);
+}: ServiceGroupTagProps) => {
+  const { t } = useTranslation();
+  const tooltip =
+    value.state === StateEnum.SUSPENDED
+      ? t("routes.keys.manage.group.state.suspended.tooltip", {
+          name: value?.name ?? "",
+        })
+      : noWrap
+        ? (value?.name ?? "")
+        : "";
+  return (
+    <ApiKeyTag
+      color={value.state === StateEnum.SUSPENDED ? "warning" : "default"}
+      disabled={value.state === StateEnum.DELETED}
+      icon={value.state === StateEnum.SUSPENDED ? <Warning /> : undefined}
+      id={id}
+      label={value.name}
+      noWrap={noWrap}
+      tooltip={tooltip}
+    />
+  );
+};


### PR DESCRIPTION
Added suspended group name interpolation in tooltips for `ServiceGroupTag` and `ApiKeysGroupTag`.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Group name interpolation in tooltips: Added tooltip logic with group name interpolation in **ServiceGroupTag** and **ApiKeysGroupTag**, using the `{{name}}` syntax directly in the translation JSON files.

#### Motivation and Context
Need to display the name of the suspended group where this is wrapped with text ellipsis.

#### How Has This Been Tested?
tested in local environment with mock data

#### Screenshots (if appropriate):

https://github.com/user-attachments/assets/c7234033-5ed2-4707-9177-e4b40dd81f46

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
