### PR TITLE
Fix switch to Reserved Area forcing BackOffice IO logout

### DIFF
--- a/.changeset/pink-carpets-refuse.md
+++ b/.changeset/pink-carpets-refuse.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix switch to Reserved Area

--- a/apps/backoffice/src/components/headers/header.tsx
+++ b/apps/backoffice/src/components/headers/header.tsx
@@ -62,7 +62,9 @@ export const Header = () => {
     // navigate to product url (i.e.: SelfCare)
     else if (product.id === SELFCARE_ID) {
       setSelectedProductId(product.id);
-      window.location.href = product.productUrl;
+      signOut({
+        callbackUrl: product.productUrl,
+      });
     }
     // otherwise perform token-exchange to change product backoffice
     else {


### PR DESCRIPTION
Fix the switch to Reserved Area, forcing BackOffice IO logout.

This PR addresses a bug that occurred when a user switched from the BackOffice IO to the Reserved Area, changed their institution, and then returned to the BackOffice.
Previously, this sequence of actions could lead to the incorrect institution being displayed.
This fix resolves the issue by forcing a BackOffice IO logout whenever a user switches to the Reserved Area, ensuring that the correct entity is always shown upon their return.

Closes IOPAE-2155 Resolves IOPAE-2156