### PR TITLE
APIM user ID fix

### DIFF
--- a/.changeset/witty-ladybugs-fix.md
+++ b/.changeset/witty-ladybugs-fix.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Fix aggregate's APIM user ID parsing the ID from the full path

--- a/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
@@ -799,7 +799,7 @@ describe("Manage Keys", () => {
             mocks.getUserByEmail.mockReturnValueOnce(
               TE.right(
                 O.some({
-                  id: apimAggregateInstitutionId,
+                  id: "/subscriptions/subid/resourceGroups/RESOURCE_GROUP/providers/Microsoft.ApiManagement/service/APIM_SERVICE/users/" + apimAggregateInstitutionId,
                 }),
               ),
             );
@@ -857,7 +857,7 @@ describe("Manage Keys", () => {
           mocks.getUserByEmail.mockReturnValueOnce(
             TE.right(
               O.some({
-                id: apimAggregateInstitutionId,
+                id: "/subscriptions/subid/resourceGroups/RESOURCE_GROUP/providers/Microsoft.ApiManagement/service/APIM_SERVICE/users/" + apimAggregateInstitutionId,
               }),
             ),
           );
@@ -929,7 +929,7 @@ describe("Manage Keys", () => {
           mocks.getUserByEmail.mockReturnValueOnce(
             TE.right(
               O.some({
-                id: apimAggregateInstitutionId,
+                id: "/subscriptions/subid/resourceGroups/RESOURCE_GROUP/providers/Microsoft.ApiManagement/service/APIM_SERVICE/users/" + apimAggregateInstitutionId,
               }),
             ),
           );
@@ -959,7 +959,7 @@ describe("Manage Keys", () => {
           mocks.getUserByEmail.mockReturnValueOnce(
             TE.right(
               O.some({
-                id: apimAggregateInstitutionId,
+                id: "/subscriptions/subid/resourceGroups/RESOURCE_GROUP/providers/Microsoft.ApiManagement/service/APIM_SERVICE/users/" + apimAggregateInstitutionId,
               }),
             ),
           );
@@ -997,7 +997,7 @@ describe("Manage Keys", () => {
       mocks.getUserByEmail.mockReturnValueOnce(
         TE.right(
           O.some({
-            id: apimAggregateInstitutionId,
+            id: "/subscriptions/subid/resourceGroups/RESOURCE_GROUP/providers/Microsoft.ApiManagement/service/APIM_SERVICE/users/" + apimAggregateInstitutionId,
           }),
         ),
       );

--- a/apps/backoffice/src/lib/be/subscriptions/business.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/business.ts
@@ -10,6 +10,7 @@ import {
 import { getApimService, upsertSubscription } from "@/lib/be/apim-service";
 import { SubscriptionState } from "@azure/arm-apimanagement";
 import { ApimUtils } from "@io-services-cms/external-clients";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -26,7 +27,6 @@ import {
   getSubscriptionAuthorizedCIDRs,
   upsertSubscriptionAuthorizedCIDRs,
 } from "./cosmos";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 // Type utility to extract the right side of a TaskEither
 type RightType<T> = T extends TE.TaskEither<unknown, infer R> ? R : never; // TODO: move to an Utils monorepo package

--- a/apps/backoffice/src/lib/be/subscriptions/business.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/business.ts
@@ -26,6 +26,7 @@ import {
   getSubscriptionAuthorizedCIDRs,
   upsertSubscriptionAuthorizedCIDRs,
 } from "./cosmos";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 // Type utility to extract the right side of a TaskEither
 type RightType<T> = T extends TE.TaskEither<unknown, infer R> ? R : never; // TODO: move to an Utils monorepo package
@@ -400,14 +401,18 @@ export const regenerateInstitutionAggregateManageSubscriptionApiKeyByAggregator 
       );
     }
 
-    const aggregateApimUserId = maybeAggregateApimUser.value.id;
+    const aggregateApimUserFullPathId = maybeAggregateApimUser.value.id;
 
-    if (!aggregateApimUserId) {
+    if (!aggregateApimUserFullPathId) {
       throw new ManagedInternalError(
         "Data inconsistency",
         `APIM user for aggregate '${aggregateId}' does not have an id`,
       );
     }
+
+    const aggregateApimUserId = ApimUtils.parseIdFromFullPath(
+      aggregateApimUserFullPathId as NonEmptyString,
+    );
 
     const { primary_key: primaryKey, secondary_key: secondaryKey } =
       await regenerateManageSubscriptionApiKey(


### PR DESCRIPTION
Call `parseIdFromFullPath` on the full path to extract the correct user id.

Fixes bug introduced in https://github.com/pagopa/io-services-cms/pull/1505 related to [IOPID-3812](https://pagopa.atlassian.net/browse/IOPID-3812)