### PR TITLE
chore: [IOPID-3902] Replace `ApiKeyAuth` with `Bearer`

### DIFF
--- a/.changeset/witty-tools-explain.md
+++ b/.changeset/witty-tools-explain.md
@@ -1,0 +1,5 @@
+---
+"io-services-app-backend": minor
+---
+
+Replace ApiKeyAuth with Bearer token authentication in external OpenAPI spec

--- a/apps/app-backend/api/external.yaml
+++ b/apps/app-backend/api/external.yaml
@@ -12,8 +12,7 @@ tags:
   - name: featured
     description: Retrieve featured Lists
 security:
-  - ApiKeyAuth: []
-    Bearer: []
+  - Bearer: []
 paths:
   /institutions:
     get:
@@ -242,10 +241,6 @@ paths:
           description: Gateway timeout
 components:
   securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-Functions-Key
     Bearer:
       type: apiKey
       name: Authorization

--- a/apps/app-backend/api/external.yaml
+++ b/apps/app-backend/api/external.yaml
@@ -13,6 +13,7 @@ tags:
     description: Retrieve featured Lists
 security:
   - ApiKeyAuth: []
+    Bearer: []
 paths:
   /institutions:
     get:
@@ -245,6 +246,10 @@ components:
       type: apiKey
       in: header
       name: X-Functions-Key
+    Bearer:
+      type: apiKey
+      name: Authorization
+      in: header
   schemas:
     InstitutionsResource:
       allOf:

--- a/apps/app-backend/api/external.yaml.template
+++ b/apps/app-backend/api/external.yaml.template
@@ -12,8 +12,7 @@ tags:
   - name: featured
     description: Retrieve featured Lists
 security:
-  - ApiKeyAuth: []
-    Bearer: []
+  - Bearer: []
 paths:
   /institutions:
     get:
@@ -242,10 +241,6 @@ paths:
           description: Gateway timeout
 components:
   securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-Functions-Key
     Bearer:
       type: apiKey
       name: Authorization

--- a/apps/app-backend/api/external.yaml.template
+++ b/apps/app-backend/api/external.yaml.template
@@ -13,6 +13,7 @@ tags:
     description: Retrieve featured Lists
 security:
   - ApiKeyAuth: []
+    Bearer: []
 paths:
   /institutions:
     get:
@@ -245,6 +246,10 @@ components:
       type: apiKey
       in: header
       name: X-Functions-Key
+    Bearer:
+      type: apiKey
+      name: Authorization
+      in: header
   schemas:
     InstitutionsResource:
       allOf:


### PR DESCRIPTION
This PR replaces `ApiKeyAuth` with `Bearer` token in the external OpenApi file