### PR TITLE
improve selfcare client error logging

### DIFF
--- a/.changeset/tender-beers-breathe.md
+++ b/.changeset/tender-beers-breathe.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+improve selfcare client error logging

--- a/apps/backoffice/src/app/api/institutions/route.ts
+++ b/apps/backoffice/src/app/api/institutions/route.ts
@@ -20,11 +20,15 @@ export const GET = withJWTAuthHandler(
       );
       return sanitizedNextResponseJson(institutionResponse);
     } catch (error) {
-      logger.error(
+      // logger.error(
+      //   `An Error has occurred while retrieving authorized institution for user having selfcareUserId: ${backofficeUser.id}, apimManageSubscriptionId: ${backofficeUser.parameters.subscriptionId}`,
+      //   { error },
+      // );
+      return handleInternalErrorResponse(
+        "InstitutionsRetrieveError",
+        error,
         `An Error has occurred while retrieving authorized institution for user having selfcareUserId: ${backofficeUser.id}, apimManageSubscriptionId: ${backofficeUser.parameters.subscriptionId}`,
-        { error },
       );
-      return handleInternalErrorResponse("InstitutionsRetrieveError", error);
     }
   },
 );

--- a/apps/backoffice/src/app/api/institutions/route.ts
+++ b/apps/backoffice/src/app/api/institutions/route.ts
@@ -20,10 +20,6 @@ export const GET = withJWTAuthHandler(
       );
       return sanitizedNextResponseJson(institutionResponse);
     } catch (error) {
-      // logger.error(
-      //   `An Error has occurred while retrieving authorized institution for user having selfcareUserId: ${backofficeUser.id}, apimManageSubscriptionId: ${backofficeUser.parameters.subscriptionId}`,
-      //   { error },
-      // );
       return handleInternalErrorResponse(
         "InstitutionsRetrieveError",
         error,

--- a/apps/backoffice/src/app/api/institutions/route.ts
+++ b/apps/backoffice/src/app/api/institutions/route.ts
@@ -1,6 +1,5 @@
 import { handleInternalErrorResponse } from "@/lib/be/errors";
 import { retrieveUserAuthorizedInstitutions } from "@/lib/be/institutions/business";
-import { logger } from "@/lib/be/logger";
 import { sanitizedNextResponseJson } from "@/lib/be/sanitize";
 import { BackOfficeUserEnriched, withJWTAuthHandler } from "@/lib/be/wrappers";
 import { NextRequest } from "next/server";

--- a/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
@@ -161,6 +161,7 @@ describe("Selfcare Client", () => {
           states: "ACTIVE",
           size: 10000,
         },
+        timeout: expect.any(Number),
       });
       expect(isAxiosError).not.toHaveBeenCalled();
     });
@@ -182,6 +183,7 @@ describe("Selfcare Client", () => {
           states: "ACTIVE",
           size: 10000,
         },
+        timeout: expect.any(Number),
       });
       expect(isAxiosError).toHaveBeenCalled();
       expect(E.isLeft(result)).toBeTruthy();
@@ -201,6 +203,7 @@ describe("Selfcare Client", () => {
           states: "ACTIVE",
           size: 10000,
         },
+        timeout: expect.any(Number),
       });
       expect(isAxiosError).not.toHaveBeenCalled();
       expect(E.isLeft(result)).toBeTruthy();

--- a/apps/backoffice/src/lib/be/institutions/selfcare.ts
+++ b/apps/backoffice/src/lib/be/institutions/selfcare.ts
@@ -27,8 +27,8 @@ export const getUserAuthorizedInstitutions = async (
   // errore validazione parametri chiamata
   if (E.isLeft(apiResult)) {
     throw new ManagedInternalError(
-      "Error calling selfcare getInstitutionsUsingGET API",
-      apiResult.left,
+      "Error calling selfcare getUserAuthorizedInstitutions API",
+      apiResult.left.message,
     );
   }
 
@@ -53,7 +53,7 @@ export const getInstitutionById = async (
 
     throw new ManagedInternalError(
       "Error calling selfcare getInstitution API",
-      apiResult.left,
+      apiResult.left.message,
     );
   }
 
@@ -78,7 +78,7 @@ export const getInstitutionGroups = async (params: {
   if (E.isLeft(apiResult)) {
     throw new ManagedInternalError(
       "Error calling selfcare getInstitutionGroups API",
-      apiResult.left,
+      apiResult.left.message,
     );
   }
 
@@ -110,7 +110,7 @@ export const getGroup = async (
 
     throw new ManagedInternalError(
       "Error calling selfcare getGroup API",
-      apiResult.left,
+      apiResult.left.message,
     );
   }
 
@@ -145,7 +145,7 @@ export const getInstitutionDelegations = async (
   if (E.isLeft(apiResult)) {
     throw new ManagedInternalError(
       "Error calling selfcare getDelegatedInstitutions API",
-      apiResult.left,
+      apiResult.left.message,
     );
   }
 
@@ -174,7 +174,7 @@ export const getInstitutionProducts = async (
   if (E.isLeft(apiResult)) {
     throw new ManagedInternalError(
       "Error calling selfcare getInstitutionProducts API",
-      apiResult.left,
+      apiResult.left.message,
     );
   }
 

--- a/apps/backoffice/src/lib/be/selfcare-client.ts
+++ b/apps/backoffice/src/lib/be/selfcare-client.ts
@@ -147,6 +147,7 @@ const buildSelfcareClient = (): SelfcareClient => {
                 states: "ACTIVE",
                 userId,
               },
+              timeout: 10000,
             }),
           identity,
         ),


### PR DESCRIPTION
This pull request focuses on improving error handling and request management in the Selfcare integration, as well as updating related tests to reflect these changes. The main updates include providing more descriptive error messages, setting explicit timeouts for API calls, and ensuring the tests properly verify these behaviors.

**Error handling improvements:**

* Updated all `ManagedInternalError` instances in `selfcare.ts` to use the error message (`apiResult.left.message`) instead of the raw error object for clearer and more consistent error reporting. [[1]](diffhunk://#diff-cc6885d0a1bf08dca95bc08b461f52aa5f43b86983aa3213a241bd64000d1633L30-R31) [[2]](diffhunk://#diff-cc6885d0a1bf08dca95bc08b461f52aa5f43b86983aa3213a241bd64000d1633L56-R56) [[3]](diffhunk://#diff-cc6885d0a1bf08dca95bc08b461f52aa5f43b86983aa3213a241bd64000d1633L81-R81) [[4]](diffhunk://#diff-cc6885d0a1bf08dca95bc08b461f52aa5f43b86983aa3213a241bd64000d1633L113-R113) [[5]](diffhunk://#diff-cc6885d0a1bf08dca95bc08b461f52aa5f43b86983aa3213a241bd64000d1633L148-R148) [[6]](diffhunk://#diff-cc6885d0a1bf08dca95bc08b461f52aa5f43b86983aa3213a241bd64000d1633L177-R177)
* Modified the error handling in the `GET` handler of `institutions/route.ts` to comment out the logger and include more details in the error response.

**API request management:**

* Added a `timeout` parameter (set to 10 seconds) to Selfcare API requests to prevent hanging requests and improve reliability.

**Test updates:**

* Updated tests in `selfcare-client.test.ts` to expect the new `timeout` parameter in API calls, ensuring the tests match the updated client behavior. [[1]](diffhunk://#diff-7a57b730f978f471114795a5d7ae330b9ec40a2d4c27073b897a5e98ac45ad27R164) [[2]](diffhunk://#diff-7a57b730f978f471114795a5d7ae330b9ec40a2d4c27073b897a5e98ac45ad27R186) [[3]](diffhunk://#diff-7a57b730f978f471114795a5d7ae330b9ec40a2d4c27073b897a5e98ac45ad27R206)