### PR TITLE
add and handle isAggregate session's property

### DIFF
--- a/.changeset/perfect-ducks-smash.md
+++ b/.changeset/perfect-ducks-smash.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+add and handle new isAggregate field from user session

--- a/apps/backoffice/src/app/api/institutions/[institutionId]/aggregates/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/institutions/[institutionId]/aggregates/__tests__/route.test.ts
@@ -27,6 +27,7 @@ const userMock = {
     name: faker.company.name(),
     role: SelfcareRoles.admin,
     isAggregator: faker.datatype.boolean(),
+    isAggregate: faker.datatype.boolean(),
   },
   name: faker.person.fullName(),
   parameters: {
@@ -64,10 +65,10 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@/lib/be/req-res-utils", async () => {
-  const actual = await vi.importActual("@/lib/be/req-res-utils");
+vi.mock("@/lib/be/req-res-utils", async (importOriginal) => {
+  const original = (await importOriginal()) as any;
   return {
-    ...(actual as any),
+    ...original,
     parseBody: mocks.parseBody,
     parseQueryParam: mocks.parseQueryParam,
     parseLimitQueryParam: mocks.parseLimitQueryParam,

--- a/apps/backoffice/src/app/api/institutions/[institutionId]/products/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/institutions/[institutionId]/products/__tests__/route.test.ts
@@ -24,6 +24,7 @@ const userMock = {
     name: faker.company.name(),
     role: SelfcareRoles.admin,
     isAggregator: faker.datatype.boolean(),
+    isAggregate: faker.datatype.boolean(),
   },
   name: faker.person.fullName(),
   parameters: {
@@ -58,10 +59,10 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@/lib/be/req-res-utils", async () => {
-  const actual = await vi.importActual("@/lib/be/req-res-utils");
+vi.mock("@/lib/be/req-res-utils", async (importOriginal) => {
+  const original = (await importOriginal()) as any;
   return {
-    ...(actual as any),
+    ...original,
     parseBody: mocks.parseBody,
   };
 });

--- a/apps/backoffice/src/app/api/institutions/current/aggregates/subscriptions/keys/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/institutions/current/aggregates/subscriptions/keys/__tests__/route.test.ts
@@ -64,10 +64,10 @@ vi.mock("@/lib/be/subscriptions/business", () => ({
   generateApiKeysExportsDownloadLink: mocks.generateApiKeysExportsDownloadLink,
 }));
 
-vi.mock("@/lib/be/errors", async () => {
-  const actual = await vi.importActual("@/lib/be/errors");
+vi.mock("@/lib/be/errors", async (importOriginal) => {
+  const original = (await importOriginal()) as any;
   return {
-    ...(actual as any),
+    ...original,
   };
 });
 

--- a/apps/backoffice/src/app/api/keys/manage/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/keys/manage/__tests__/route.test.ts
@@ -1,42 +1,66 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { faker } from "@faker-js/faker/locale/it";
 import { NextRequest, NextResponse } from "next/server";
 import { BackOfficeUser } from "../../../../../../types/next-auth";
 import { SubscriptionKeys } from "../../../../../generated/api/SubscriptionKeys";
 import { BackOfficeUserEnriched } from "../../../../../lib/be/wrappers";
+import { SelfcareRoles } from "../../../../../types/auth";
 import { GET } from "../route";
 
-const mocks: {
-  apiKeys: SubscriptionKeys;
-  jwtMock: BackOfficeUserEnriched;
-} = vi.hoisted(() => ({
-  apiKeys: {
-    primary_key: "aPrimaryKey",
-    secondary_key: "aSecondaryKey"
+const userMock: BackOfficeUserEnriched = {
+  id: faker.string.uuid(),
+  institution: {
+    fiscalCode: faker.string.numeric(),
+    id: "institutionId",
+    logo_url: faker.image.url(),
+    name: faker.company.name(),
+    role: SelfcareRoles.admin,
+    isAggregator: faker.datatype.boolean(),
+    isAggregate: faker.datatype.boolean(),
+    selcSpecialGroups: [],
   },
-  jwtMock: ({
-    institution: { id: "institutionId" },
-    permissions: ["permission1", "permission2"],
-    parameters: {
-      userEmail: "anEmail@email.it",
-      userId: "anUserId",
-      subscriptionId: "aSubscriptionId"
-    }
-  } as unknown) as BackOfficeUser
-}));
+  parameters: {
+    subscriptionId: faker.string.uuid(),
+    userEmail: faker.internet.email(),
+    userId: faker.string.uuid(),
+  },
+  permissions: {
+    apimGroups: faker.helpers.multiple(faker.string.alpha),
+    selcGroups: [],
+  },
+};
 
-const { auth } = vi.hoisted(() => ({
-  auth: vi.fn(() => Promise.resolve({ user: mocks.jwtMock }))
-}));
+const mocks = vi.hoisted(() => {
+  const getUser = vi.fn(() => userMock);
+  return {
+    apiKeys: {
+      primary_key: "aPrimaryKey",
+      secondary_key: "aSecondaryKey",
+    } as SubscriptionKeys,
+    getManageSubscriptionKeysHandlerMock: vi.fn(),
+    withJWTAuthHandler: vi.fn(
+      (
+        handler: (
+          nextRequest: NextRequest,
+          context: { backofficeUser: BackOfficeUser; params: any },
+        ) => Promise<NextResponse> | Promise<Response>,
+      ) =>
+        async (nextRequest: NextRequest, { params }: { params: {} }) =>
+          handler(nextRequest, {
+            backofficeUser: getUser(),
+            params,
+          }),
+    ),
+  };
+});
 
-const { getManageSubscriptionKeysHandlerMock } = vi.hoisted(() => ({
-  getManageSubscriptionKeysHandlerMock: vi.fn()
+vi.mock("@/lib/be/wrappers", () => ({
+  withJWTAuthHandler: mocks.withJWTAuthHandler,
 }));
-
-vi.mock("@/auth", () => ({ auth }));
 
 vi.mock("../../../subscriptions/[subscriptionId]/keys/handler", () => ({
-  getManageSubscriptionKeysHandler: getManageSubscriptionKeysHandlerMock
+  getManageSubscriptionKeysHandler: mocks.getManageSubscriptionKeysHandlerMock,
 }));
 
 afterEach(() => {
@@ -46,8 +70,8 @@ afterEach(() => {
 describe("Retrieve Manage Keys API", () => {
   it("should forward request", async () => {
     // given
-    getManageSubscriptionKeysHandlerMock.mockResolvedValueOnce(
-      NextResponse.json(mocks.apiKeys, { status: 200 })
+    mocks.getManageSubscriptionKeysHandlerMock.mockResolvedValueOnce(
+      NextResponse.json(mocks.apiKeys, { status: 200 }),
     );
     const request = new NextRequest(new URL("http://localhost"));
 
@@ -58,10 +82,13 @@ describe("Retrieve Manage Keys API", () => {
     expect(result.status).toBe(200);
     const jsonResponse = await new Response(result.body).json();
     expect(jsonResponse).toStrictEqual(mocks.apiKeys);
-    expect(getManageSubscriptionKeysHandlerMock).toHaveBeenCalledOnce();
-    expect(getManageSubscriptionKeysHandlerMock).toHaveBeenCalledWith(request, {
-      backofficeUser: expect.anything(), // FIXME: we can be more specific here
-      params: { subscriptionId: mocks.jwtMock.parameters.subscriptionId }
-    });
+    expect(mocks.getManageSubscriptionKeysHandlerMock).toHaveBeenCalledOnce();
+    expect(mocks.getManageSubscriptionKeysHandlerMock).toHaveBeenCalledWith(
+      request,
+      {
+        backofficeUser: expect.anything(), // FIXME: we can be more specific here
+        params: { subscriptionId: userMock.parameters.subscriptionId },
+      },
+    );
   });
 });

--- a/apps/backoffice/src/app/api/services/list/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/services/list/__tests__/route.test.ts
@@ -9,15 +9,14 @@ import { GET } from "../route";
 
 const backofficeUserMock: BackOfficeUser = {
   id: faker.string.uuid(),
-  name: faker.person.fullName(),
-  email: faker.internet.email(),
   institution: {
     id: faker.string.uuid(),
     name: faker.company.name(),
     fiscalCode: faker.string.numeric(),
     role: faker.helpers.arrayElement(Object.values(SelfcareRoles)),
     logo_url: faker.image.url(),
-    isAggregator: false
+    isAggregator: false,
+    isAggregate: false,
   },
   permissions: { apimGroups: faker.helpers.multiple(faker.string.alpha) },
   parameters: {

--- a/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
@@ -4,7 +4,6 @@ import * as E from "fp-ts/lib/Either";
 import { NextRequest, NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BackOfficeUser } from "../../../../../types/next-auth";
-import { BackOfficeUserEnriched } from "../../../../lib/be/wrappers";
 import { CreateManageGroupSubscription } from "../../../../generated/api/CreateManageGroupSubscription";
 import {
   StateEnum,
@@ -16,19 +15,11 @@ import {
   ManagedInternalError,
   PreconditionFailedError,
 } from "../../../../lib/be/errors";
+import { BackOfficeUserEnriched } from "../../../../lib/be/wrappers";
 import { SelfcareRoles } from "../../../../types/auth";
 import { GET, PUT } from "../route";
 
-const userMock = {
-  authorizedInstitutions: [
-    {
-      id: faker.string.uuid(),
-      logo_url: faker.image.url(),
-      name: faker.company.name(),
-      role: SelfcareRoles.admin,
-    },
-  ],
-  email: faker.internet.email(),
+const userMock: BackOfficeUserEnriched = {
   id: faker.string.uuid(),
   institution: {
     fiscalCode: faker.string.numeric(),
@@ -40,7 +31,6 @@ const userMock = {
     isAggregate: faker.datatype.boolean(),
     selcSpecialGroups: [],
   },
-  name: faker.person.fullName(),
   parameters: {
     subscriptionId: faker.string.uuid(),
     userEmail: faker.internet.email(),
@@ -48,8 +38,9 @@ const userMock = {
   },
   permissions: {
     apimGroups: faker.helpers.multiple(faker.string.alpha),
+    selcGroups: [],
   },
-} as BackOfficeUserEnriched;
+};
 
 const stubs = { aGroup: { id: "aGroupId", name: "aGroupName" } };
 
@@ -80,10 +71,10 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@/lib/be/req-res-utils", async () => {
-  const actual = await vi.importActual("@/lib/be/req-res-utils");
+vi.mock("@/lib/be/req-res-utils", async (importOriginal) => {
+  const original = (await importOriginal()) as any;
   return {
-    ...(actual as any),
+    ...original,
     parseBody: mocks.parseBody,
     parseQueryParam: mocks.parseQueryParam,
     parseLimitQueryParam: mocks.parseLimitQueryParam,
@@ -462,7 +453,7 @@ describe("Subscription API", () => {
         apimUserId: userMock.parameters.userId,
         limit,
         offset,
-        userSelcGroups: undefined,
+        userSelcGroups: [],
         institutionSelcSpecialGroups: userMock.institution.selcSpecialGroups,
       });
     });

--- a/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/subscriptions/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import * as E from "fp-ts/lib/Either";
 import { NextRequest, NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BackOfficeUser } from "../../../../../types/next-auth";
+import { BackOfficeUserEnriched } from "../../../../lib/be/wrappers";
 import { CreateManageGroupSubscription } from "../../../../generated/api/CreateManageGroupSubscription";
 import {
   StateEnum,
@@ -36,6 +37,8 @@ const userMock = {
     name: faker.company.name(),
     role: SelfcareRoles.admin,
     isAggregator: faker.datatype.boolean(),
+    isAggregate: faker.datatype.boolean(),
+    selcSpecialGroups: [],
   },
   name: faker.person.fullName(),
   parameters: {
@@ -46,7 +49,7 @@ const userMock = {
   permissions: {
     apimGroups: faker.helpers.multiple(faker.string.alpha),
   },
-} as BackOfficeUser;
+} as BackOfficeUserEnriched;
 
 const stubs = { aGroup: { id: "aGroupId", name: "aGroupName" } };
 
@@ -454,23 +457,24 @@ describe("Subscription API", () => {
       expect(mocks.parseLimitQueryParam).toHaveBeenCalledOnce();
       expect(mocks.parseOffsetQueryParam).toHaveBeenCalledOnce();
       expect(mocks.getManageSubscriptions).toHaveBeenCalledOnce();
-      expect(mocks.getManageSubscriptions).toHaveBeenCalledWith(
-        kind,
-        userMock.parameters.userId,
+      expect(mocks.getManageSubscriptions).toHaveBeenCalledWith({
+        subscriptionType: kind,
+        apimUserId: userMock.parameters.userId,
         limit,
         offset,
-        undefined,
-      );
+        userSelcGroups: undefined,
+        institutionSelcSpecialGroups: userMock.institution.selcSpecialGroups,
+      });
     });
 
     it.each`
-      scenario                                 | userRole                  | selcGroups
+      scenario                                 | userRole                  | userSelcGroups
       ${"user is admin"}                       | ${SelfcareRoles.admin}    | ${undefined}
       ${"user is not admin and has no groups"} | ${SelfcareRoles.operator} | ${undefined}
       ${"user is not admin and has groups"}    | ${SelfcareRoles.operator} | ${["g1"]}
     `(
       "should return the subscriptions when getManageSubscriptions do not fails and $scenario",
-      async ({ userRole, selcGroups }) => {
+      async ({ userRole, userSelcGroups }) => {
         // given
         const kind = "MANAGE_ROOT";
         const limit = 10;
@@ -491,7 +495,7 @@ describe("Subscription API", () => {
           },
           permissions: {
             ...userMock.permissions,
-            selcGroups: selcGroups,
+            selcGroups: userSelcGroups,
           },
         }));
 
@@ -513,13 +517,14 @@ describe("Subscription API", () => {
         expect(mocks.parseLimitQueryParam).toHaveBeenCalledOnce();
         expect(mocks.parseOffsetQueryParam).toHaveBeenCalledOnce();
         expect(mocks.getManageSubscriptions).toHaveBeenCalledOnce();
-        expect(mocks.getManageSubscriptions).toHaveBeenCalledWith(
-          kind,
-          userMock.parameters.userId,
+        expect(mocks.getManageSubscriptions).toHaveBeenCalledWith({
+          subscriptionType: kind,
+          apimUserId: userMock.parameters.userId,
           limit,
           offset,
-          userRole === SelfcareRoles.admin ? undefined : selcGroups,
-        );
+          userSelcGroups,
+          institutionSelcSpecialGroups: userMock.institution.selcSpecialGroups,
+        });
       },
     );
   });

--- a/apps/backoffice/src/app/api/subscriptions/route.ts
+++ b/apps/backoffice/src/app/api/subscriptions/route.ts
@@ -121,15 +121,16 @@ export const GET = withJWTAuthHandler(
     }
 
     try {
-      const response = await getManageSubscriptions(
-        maybeKind.right,
-        backofficeUser.parameters.userId,
-        maybeLimit.right,
-        maybeOffset.right,
-        userAuthzUtils.isAdmin()
-          ? undefined
-          : backofficeUser.permissions.selcGroups,
-      );
+      const response = await getManageSubscriptions({
+        apimUserId: backofficeUser.parameters.userId,
+        institutionSelcSpecialGroups:
+          backofficeUser.institution.selcSpecialGroups,
+        limit: maybeLimit.right,
+        offset: maybeOffset.right,
+        subscriptionType: maybeKind.right,
+        // userSelcGroups is [] for admins (set by withJWTAuthHandler wrapper)
+        userSelcGroups: backofficeUser.permissions.selcGroups,
+      });
       return sanitizedNextResponseJson(
         buildPagination(response, maybeLimit.right, maybeOffset.right),
       );

--- a/apps/backoffice/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/backoffice/src/lib/auth/__tests__/auth.test.ts
@@ -88,6 +88,7 @@ const getExpectedUser = (
   apimUser: typeof aValidApimUser,
   manageSubscription: typeof aValidSubscription,
   institution: InstitutionResponse,
+  isAggregate = false,
   isAggregator = false,
 ) => ({
   id: jwtPayload.uid,
@@ -97,6 +98,7 @@ const getExpectedUser = (
     id: jwtPayload.organization.id,
     name: jwtPayload.organization.name,
     fiscalCode: jwtPayload.organization.fiscal_code,
+    isAggregate,
     isAggregator,
     role: jwtPayload.organization.roles[0].role,
     logo_url: institution.logo,
@@ -178,8 +180,13 @@ const { getInstitutionById } = vi.hoisted(() => ({
   getInstitutionById: vi.fn(),
 }));
 
+const { hasAggregators } = vi.hoisted(() => ({
+  hasAggregators: vi.fn(() => Promise.resolve(false)),
+}));
+
 vi.mock("@/lib/be/institutions/selfcare", () => ({
   getInstitutionById,
+  hasAggregators,
 }));
 
 afterEach(() => {
@@ -693,6 +700,45 @@ describe("Authorize", () => {
     expect(upsertSubscription).not.toHaveBeenCalled();
   });
 
+  it("should fail when retrieving institution has aggregators", async () => {
+    const errorMessage = "Rejected hasAggregators";
+    jwtVerify.mockResolvedValueOnce({
+      payload: aValidJwtPayload,
+    });
+    formatEmailForOrganization.mockReturnValueOnce(
+      `org.${aValidJwtPayload.organization.id}@selfcare.io.pagopa.it`,
+    );
+    getUserByEmail.mockImplementation(() => TE.right(O.some(aValidApimUser)));
+    getSubscription.mockReturnValueOnce(TE.right(aValidSubscription));
+    getInstitutionById.mockResolvedValueOnce(aValidInstitution);
+    hasAggregators.mockRejectedValueOnce(new Error(errorMessage));
+
+    await expect(() =>
+      authorize(mockConfig)({ identity_token: "identity_token" }, {}),
+    ).rejects.toThrowError(errorMessage);
+
+    expect(jwtVerify).toHaveBeenCalledOnce();
+    expect(getApimService).toHaveBeenCalledTimes(2);
+    expect(getUserByEmail).toHaveBeenCalledOnce();
+    expect(getUserByEmail).toHaveBeenCalledWith(
+      getExpectedUserEmailReqParam(aValidJwtPayload.organization),
+      true,
+    );
+    expect(getSubscription).toHaveBeenCalledOnce();
+    expect(getSubscription).toHaveBeenCalledWith(
+      `MANAGE-${aValidApimUser.name}`,
+    );
+    expect(getInstitutionById).toHaveBeenCalledOnce();
+    expect(getInstitutionById).toHaveBeenCalledWith(
+      aValidJwtPayload.organization.id,
+    );
+    expect(hasAggregators).toHaveBeenCalledOnce();
+    expect(hasAggregators).toHaveBeenCalledWith(aValidInstitution.id);
+    expect(createOrUpdateUser).not.toHaveBeenCalled();
+    expect(createGroupUser).not.toHaveBeenCalled();
+    expect(upsertSubscription).not.toHaveBeenCalled();
+  });
+
   it("should return a valid backoffice User when both APIM users and its manage subscription exists", async () => {
     jwtVerify.mockResolvedValueOnce({
       payload: aValidJwtPayload,
@@ -703,6 +749,7 @@ describe("Authorize", () => {
     getUserByEmail.mockImplementation(() => TE.right(O.some(aValidApimUser)));
     getSubscription.mockReturnValueOnce(TE.right(aValidSubscription));
     getInstitutionById.mockResolvedValueOnce(aValidInstitution);
+    hasAggregators.mockResolvedValueOnce(false);
 
     const user = await authorize(mockConfig)(
       { identity_token: "identity_token" },
@@ -715,6 +762,7 @@ describe("Authorize", () => {
         aValidApimUser,
         aValidSubscription,
         aValidInstitution,
+        false,
       ),
     );
     expect(jwtVerify).toHaveBeenCalledOnce();
@@ -729,6 +777,8 @@ describe("Authorize", () => {
     expect(getInstitutionById).toHaveBeenCalledWith(
       aValidJwtPayload.organization.id,
     );
+    expect(hasAggregators).toHaveBeenCalledOnce();
+    expect(hasAggregators).toHaveBeenCalledWith(aValidInstitution.id);
     expect(createOrUpdateUser).not.toHaveBeenCalled();
     expect(createGroupUser).not.toHaveBeenCalled();
     expect(upsertSubscription).not.toHaveBeenCalled();

--- a/apps/backoffice/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/backoffice/src/lib/auth/__tests__/auth.test.ts
@@ -5,8 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getMockInstitution } from "../../../../mocks/data/selfcare-data";
 import { Configuration } from "../../../config";
 import { InstitutionResponse } from "../../../generated/selfcare/InstitutionResponse";
-import { IdentityTokenPayload } from "../types";
 import { authorize } from "../auth";
+import { IdentityTokenPayload } from "../types";
 
 vi.hoisted(() => {
   const originalEnv = process.env;
@@ -149,15 +149,12 @@ vi.mock("@/lib/be/apim-service", () => ({
   upsertSubscription,
 }));
 
-vi.mock("@io-services-cms/external-clients", async () => {
-  const actual = await vi.importActual<
-    typeof import("@io-services-cms/external-clients")
-  >("@io-services-cms/external-clients");
-
+vi.mock("@io-services-cms/external-clients", async (importOriginal) => {
+  const original = (await importOriginal()) as any;
   return {
-    ...actual,
+    ...original,
     ApimUtils: {
-      ...actual.ApimUtils,
+      ...original.ApimUtils,
       formatEmailForOrganization: formatEmailForOrganization,
     },
   };
@@ -168,7 +165,7 @@ const { jwtVerify } = vi.hoisted(() => ({
 }));
 
 vi.mock("jose", async (importOriginal) => {
-  const mod = await importOriginal();
+  const mod = await importOriginal<typeof import("jose")>();
 
   return {
     ...(mod as any),

--- a/apps/backoffice/src/lib/auth/auth.ts
+++ b/apps/backoffice/src/lib/auth/auth.ts
@@ -9,7 +9,10 @@ import {
   extractTryCatchError,
   handlerErrorLog,
 } from "@/lib/be/errors";
-import { getInstitutionById } from "@/lib/be/institutions/selfcare";
+import {
+  getInstitutionById,
+  hasAggregators,
+} from "@/lib/be/institutions/selfcare";
 import { ApimUtils } from "@io-services-cms/external-clients";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
@@ -60,9 +63,24 @@ export const authorize =
         pipe(apimUser, retrieveOrCreateUserSubscriptionManage),
       ),
       TE.bindW("institution", ({ identityTokenPayload }) =>
-        TE.tryCatch(
-          () => pipe(identityTokenPayload.organization.id, getInstitutionById),
-          extractTryCatchError,
+        pipe(
+          TE.tryCatch(
+            () =>
+              pipe(identityTokenPayload.organization.id, getInstitutionById),
+            extractTryCatchError,
+          ),
+          TE.chain((institution) =>
+            pipe(
+              TE.tryCatch(
+                () => hasAggregators(institution.id),
+                extractTryCatchError,
+              ),
+              TE.map((hasAggregators) => ({
+                ...institution,
+                hasAggregators,
+              })),
+            ),
+          ),
         ),
       ),
       TE.map(toUser),
@@ -300,7 +318,7 @@ const toUser = ({
 }: {
   apimUser: ApimUser;
   identityTokenPayload: IdentityTokenPayload;
-  institution: InstitutionResponse;
+  institution: { hasAggregators: boolean } & InstitutionResponse;
   subscriptionManage: Subscription;
 }): User => ({
   email: identityTokenPayload.email,
@@ -308,6 +326,7 @@ const toUser = ({
   institution: {
     fiscalCode: identityTokenPayload.organization.fiscal_code,
     id: identityTokenPayload.organization.id,
+    isAggregate: institution.hasAggregators,
     isAggregator: isAggregator(institution),
     logo_url: institution.logo,
     name: identityTokenPayload.organization.name,

--- a/apps/backoffice/src/lib/be/__tests__/apim-service.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/apim-service.test.ts
@@ -26,10 +26,10 @@ const { getAzureAccessToken } = vi.hoisted(() => ({
   getAzureAccessToken: vi.fn().mockReturnValue(Promise.resolve("aToken")),
 }));
 
-vi.mock("axios", async () => {
-  const actual = await vi.importActual("axios");
+vi.mock("axios", async (importOriginal) => {
+  const original = await importOriginal<typeof import("axios")>();
   return {
-    ...(actual as any),
+    ...original,
     default: { create, isAxiosError },
   };
 });

--- a/apps/backoffice/src/lib/be/__tests__/institutions.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/institutions.test.ts
@@ -340,10 +340,11 @@ describe("Institutions", () => {
         retrieveUnboundInstitutionGroups(apimUserId, institutionId),
       ).rejects.toThrowError(error);
       expect(getManageSubscriptionsMock).toHaveBeenCalledOnce();
-      expect(getManageSubscriptionsMock).toHaveBeenCalledWith(
-        "MANAGE_GROUP",
+      expect(getManageSubscriptionsMock).toHaveBeenCalledWith({
+        subscriptionType: "MANAGE_GROUP",
         apimUserId,
-      );
+        institutionSelcSpecialGroups: [],
+      });
       expect(getInstitutionGroupsMock).toHaveBeenCalledOnce();
       expect(getInstitutionGroupsMock).toHaveBeenCalledWith({
         institutionId,
@@ -383,10 +384,11 @@ describe("Institutions", () => {
         },
       ]);
       expect(getManageSubscriptionsMock).toHaveBeenCalledOnce();
-      expect(getManageSubscriptionsMock).toHaveBeenCalledWith(
-        "MANAGE_GROUP",
+      expect(getManageSubscriptionsMock).toHaveBeenCalledWith({
+        subscriptionType: "MANAGE_GROUP",
         apimUserId,
-      );
+        institutionSelcSpecialGroups: [],
+      });
       expect(getInstitutionGroupsMock).toHaveBeenCalledOnce();
       expect(getInstitutionGroupsMock).toHaveBeenCalledWith({
         institutionId,

--- a/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
@@ -103,10 +103,10 @@ const { create, isAxiosError, getMock } = vi.hoisted(() => {
   };
 });
 
-vi.mock("axios", async () => {
-  const actual = await vi.importActual("axios");
+vi.mock("axios", async (importOriginal) => {
+  const original = await importOriginal<typeof import("axios")>();
   return {
-    ...(actual as any),
+    ...original,
     default: { create, isAxiosError },
   };
 });

--- a/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/selfcare-client.test.ts
@@ -1,6 +1,10 @@
 import * as E from "fp-ts/lib/Either";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getMockInstitutionProducts } from "../../../../mocks/data/selfcare-data";
+import {
+  DelegationInstitutionResponse,
+  DelegationTypeEnum,
+} from "../../../generated/selfcare/DelegationInstitutionResponse";
 import { TypeEnum } from "../../../generated/selfcare/DelegationResponse";
 import { DelegationWithPaginationResponse } from "../../../generated/selfcare/DelegationWithPaginationResponse";
 import { InstitutionResponse } from "../../../generated/selfcare/InstitutionResponse";
@@ -474,6 +478,105 @@ describe("Selfcare Client", () => {
         commonExpectation();
       },
     );
+
+    describe("getDelegateInstitutions", () => {
+      const institutionId = "institutionId";
+      const endpoint = `/delegations/delegates/${institutionId}`;
+      const delegateInstitutions = [
+        {
+          id: 1,
+          delegationId: "delegationId1",
+          delegationProductId: "productId1",
+          delegationType: DelegationTypeEnum.EA,
+          institution: mocks.institution,
+        },
+        {
+          id: 2,
+          delegationId: "delegationId2",
+          delegationProductId: "productId2",
+          delegationType: DelegationTypeEnum.PT,
+          institution: {
+            ...mocks.institution,
+            id: "institutionId2",
+          } as InstitutionResponse,
+        },
+      ] as DelegationInstitutionResponse[];
+
+      it("should return an error when received an error from selfcare", async () => {
+        // given
+        getMock.mockRejectedValueOnce({
+          message: "Received 400 response",
+          response: { status: 400 },
+        });
+        isAxiosError.mockReturnValueOnce(true);
+
+        // when
+        const result = await getSelfcareClient().getDelegateInstitutions({
+          institutionId,
+        })();
+
+        // then
+        expect(getMock).toHaveBeenCalledWith(endpoint, {
+          params: {
+            size: undefined,
+            type: undefined,
+          },
+        });
+        expect(isAxiosError).toHaveBeenCalled();
+        expect(E.isLeft(result)).toBeTruthy();
+        commonExpectation();
+      });
+
+      it("should return an error when received a bad response from selfcare", async () => {
+        // given
+        getMock.mockResolvedValueOnce({ status: 200, data: "" });
+
+        // when
+        const result = await getSelfcareClient().getDelegateInstitutions({
+          institutionId,
+        })();
+
+        // then
+        expect(getMock).toHaveBeenCalledWith(endpoint, {
+          params: {
+            size: undefined,
+            type: undefined,
+          },
+        });
+        expect(isAxiosError).not.toHaveBeenCalled();
+        expect(E.isLeft(result)).toBeTruthy();
+        commonExpectation();
+      });
+
+      it("should return the delegate institutions for the given institution", async () => {
+        // given
+        getMock.mockResolvedValueOnce({
+          status: 200,
+          data: delegateInstitutions,
+        });
+
+        // when
+        const result = await getSelfcareClient().getDelegateInstitutions({
+          institutionId,
+          size: 5,
+          type: DelegationTypeEnum.EA,
+        })();
+
+        // then
+        expect(getMock).toHaveBeenCalledWith(endpoint, {
+          params: {
+            size: 5,
+            type: DelegationTypeEnum.EA,
+          },
+        });
+        expect(isAxiosError).not.toHaveBeenCalled();
+        expect(E.isRight(result)).toBeTruthy();
+        if (E.isRight(result)) {
+          expect(result.right).toEqual(delegateInstitutions);
+        }
+        commonExpectation();
+      });
+    });
   });
 
   describe("getInstitutionProducts", () => {

--- a/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
@@ -7,7 +7,12 @@ const mocks: {
   jwtMock: BackOfficeUser;
 } = vi.hoisted(() => ({
   jwtMock: {
-    institution: { role: "admin", id: "institutionId", isAggregate: false },
+    institution: {
+      role: "admin",
+      id: "institutionId",
+      isAggregate: false,
+      selcSpecialGroups: [],
+    },
     permissions: { selcGroups: [] },
     parameters: {
       userEmail: "anEmail@email.it",
@@ -75,7 +80,6 @@ describe("withJWTAuthHandler", () => {
         ...jwtMock,
         institution: {
           ...jwtMock.institution,
-          selcSpecialGroups: [],
         },
       },
       params: {},
@@ -106,7 +110,6 @@ describe("withJWTAuthHandler", () => {
         ...jwtMock,
         institution: {
           ...jwtMock.institution,
-          selcSpecialGroups: [],
         },
         permissions: {
           ...jwtMock.permissions,
@@ -119,7 +122,45 @@ describe("withJWTAuthHandler", () => {
     expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
   });
 
-  it("valid token provided should end up in 200 response with selfcare groups detail when institution is aggregate", async () => {
+  it.each`
+    scenario                           | selcGroups
+    ${"selfcare groups are undefined"} | ${undefined}
+    ${"selfcare groups are empty"}     | ${[]}
+  `(
+    "valid token provided should end up in 200 response without selfcare groups detail when $scenario",
+    async ({ selcGroups }) => {
+      //given
+      mocks.jwtMock.permissions.selcGroups = selcGroups;
+      auth.mockResolvedValueOnce({ user: mocks.jwtMock });
+      const aMockedHandler = vi.fn(() =>
+        Promise.resolve(NextResponse.json({}, { status: 200 })),
+      );
+      const nextRequestMock = new NextRequest(new URL("http://localhost"));
+
+      //when
+      const result = await withJWTAuthHandler(aMockedHandler)(nextRequestMock, {
+        params: Promise.resolve({}),
+      });
+
+      //then
+      expect(aMockedHandler).toHaveBeenCalledWith(
+        nextRequestMock,
+        expect.objectContaining({
+          backofficeUser: {
+            ...mocks.jwtMock,
+            permissions: {
+              ...mocks.jwtMock.permissions,
+              selcGroups: [],
+            },
+          },
+        }),
+      );
+      expect(result.status).toBe(200);
+      expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
+    },
+  );
+
+  it("valid token provided should end up in 200 response with selfcare groups detail when is not an admin and has selcGroups", async () => {
     //given
     const jwtMock = structuredClone(mocks.jwtMock);
     jwtMock.institution.role = "admin";
@@ -143,20 +184,19 @@ describe("withJWTAuthHandler", () => {
     });
 
     //then
-    expect(aMockedHandler).toHaveBeenCalledWith(nextRequestMock, {
-      backofficeUser: {
-        ...jwtMock,
-        institution: {
-          ...jwtMock.institution,
-          selcSpecialGroups: [],
+    expect(aMockedHandler).toHaveBeenCalledWith(
+      nextRequestMock,
+      expect.objectContaining({
+        backofficeUser: {
+          ...jwtMock,
+          permissions: {
+            ...jwtMock.permissions,
+            selcGroups: [selcGroups[0]],
+          },
         },
-        permissions: {
-          ...jwtMock.permissions,
-          selcGroups: [selcGroups[0]],
-        },
-      },
-      params: {},
-    });
+        params: {},
+      }),
+    );
     expect(result.status).toBe(200);
     expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
     expect(retrieveInstitutionGroups).toHaveBeenCalledWith(

--- a/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
@@ -123,15 +123,17 @@ describe("withJWTAuthHandler", () => {
   });
 
   it.each`
-    scenario                           | selcGroups
-    ${"selfcare groups are undefined"} | ${undefined}
-    ${"selfcare groups are empty"}     | ${[]}
+    scenario                       | selcGroups
+    ${"selfcare groups are empty"} | ${[]}
   `(
-    "valid token provided should end up in 200 response without selfcare groups detail when $scenario",
+    "valid token provided should end up in 200 response without selfcare groups detail when user is not admin and $scenario",
     async ({ selcGroups }) => {
       //given
-      mocks.jwtMock.permissions.selcGroups = selcGroups;
-      auth.mockResolvedValueOnce({ user: mocks.jwtMock });
+      const jwtMock = structuredClone(mocks.jwtMock);
+      jwtMock.institution.role = "operator";
+      jwtMock.permissions.selcGroups = selcGroups;
+      auth.mockResolvedValueOnce({ user: jwtMock });
+      retrieveInstitutionGroups.mockResolvedValueOnce(selcGroups);
       const aMockedHandler = vi.fn(() =>
         Promise.resolve(NextResponse.json({}, { status: 200 })),
       );
@@ -147,23 +149,27 @@ describe("withJWTAuthHandler", () => {
         nextRequestMock,
         expect.objectContaining({
           backofficeUser: {
-            ...mocks.jwtMock,
+            ...jwtMock,
             permissions: {
-              ...mocks.jwtMock.permissions,
+              ...jwtMock.permissions,
               selcGroups: [],
             },
           },
         }),
       );
       expect(result.status).toBe(200);
-      expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
+      expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
+      expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
+        jwtMock.institution.id,
+        "*",
+      );
     },
   );
 
   it("valid token provided should end up in 200 response with selfcare groups detail when is not an admin and has selcGroups", async () => {
     //given
     const jwtMock = structuredClone(mocks.jwtMock);
-    jwtMock.institution.role = "admin";
+    jwtMock.institution.role = "operator";
     jwtMock.institution.isAggregate = true;
     jwtMock.permissions.selcGroups = ["id1"];
 
@@ -207,10 +213,10 @@ describe("withJWTAuthHandler", () => {
 
   it.each`
     scenario                           | selcGroups
-    ${"selfcare groups are undefined"} | ${undefined}
+    ${"selfcare groups are not empty"} | ${[{ id: "id1", name: "group1", state: "ACTIVE" }]}
     ${"selfcare groups are empty"}     | ${[]}
   `(
-    "valid token provided should end up in 200 response without selfcare groups detail when $scenario",
+    "valid token provided should end up in 200 response without selfcare groups detail when user is admin and $scenario",
     async ({ selcGroups }) => {
       //given
       const jwtMock = structuredClone(mocks.jwtMock);

--- a/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/wrappers.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BackOfficeUser } from "../../../../types/next-auth";
 import { withJWTAuthHandler } from "../wrappers";
 
@@ -7,7 +7,7 @@ const mocks: {
   jwtMock: BackOfficeUser;
 } = vi.hoisted(() => ({
   jwtMock: {
-    institution: { role: "admin", id: "institutionId" },
+    institution: { role: "admin", id: "institutionId", isAggregate: false },
     permissions: { selcGroups: [] },
     parameters: {
       userEmail: "anEmail@email.it",
@@ -33,6 +33,10 @@ vi.mock("../institutions/business", () => ({
   retrieveInstitutionGroups,
 }));
 
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("withJWTAuthHandler", () => {
   it("no token or invalid one provided should end up in 401 response", async () => {
     auth.mockResolvedValueOnce(null);
@@ -52,7 +56,9 @@ describe("withJWTAuthHandler", () => {
   });
 
   it("valid token provided should end up in 200 response", async () => {
-    auth.mockResolvedValueOnce({ user: mocks.jwtMock });
+    const jwtMock = structuredClone(mocks.jwtMock);
+
+    auth.mockResolvedValueOnce({ user: jwtMock });
 
     const nextRequestMock = new NextRequest(new URL("http://localhost"));
 
@@ -64,19 +70,26 @@ describe("withJWTAuthHandler", () => {
       params: Promise.resolve({}),
     });
 
-    expect(aMockedHandler).toHaveBeenCalledWith(
-      nextRequestMock,
-      expect.objectContaining({
-        backofficeUser: mocks.jwtMock,
-      }),
-    );
+    expect(aMockedHandler).toHaveBeenCalledWith(nextRequestMock, {
+      backofficeUser: {
+        ...jwtMock,
+        institution: {
+          ...jwtMock.institution,
+          selcSpecialGroups: [],
+        },
+      },
+      params: {},
+    });
     expect(result.status).toBe(200);
   });
 
   it("valid token provided should end up in 200 response without selfcare groups detail when user is an admin", async () => {
     //given
-    mocks.jwtMock.institution.role = "admin";
-    auth.mockResolvedValueOnce({ user: mocks.jwtMock });
+    const jwtMock = structuredClone(mocks.jwtMock);
+    jwtMock.institution.role = "admin";
+    jwtMock.institution.isAggregate = false;
+
+    auth.mockResolvedValueOnce({ user: jwtMock });
     const aMockedHandler = vi.fn(() =>
       Promise.resolve(NextResponse.json({}, { status: 200 })),
     );
@@ -88,65 +101,32 @@ describe("withJWTAuthHandler", () => {
     });
 
     //then
-    expect(aMockedHandler).toHaveBeenCalledWith(
-      nextRequestMock,
-      expect.objectContaining({
-        backofficeUser: {
-          ...mocks.jwtMock,
-          permissions: {
-            ...mocks.jwtMock.permissions,
-            selcGroups: [],
-          },
+    expect(aMockedHandler).toHaveBeenCalledWith(nextRequestMock, {
+      backofficeUser: {
+        ...jwtMock,
+        institution: {
+          ...jwtMock.institution,
+          selcSpecialGroups: [],
         },
-      }),
-    );
+        permissions: {
+          ...jwtMock.permissions,
+          selcGroups: [],
+        },
+      },
+      params: {},
+    });
     expect(result.status).toBe(200);
     expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
   });
 
-  it.each`
-    scenario                           | selcGroups
-    ${"selfcare groups are undefined"} | ${undefined}
-    ${"selfcare groups are empty"}     | ${[]}
-  `(
-    "valid token provided should end up in 200 response without selfcare groups detail when $scenario",
-    async ({ selcGroups }) => {
-      //given
-      mocks.jwtMock.permissions.selcGroups = selcGroups;
-      auth.mockResolvedValueOnce({ user: mocks.jwtMock });
-      const aMockedHandler = vi.fn(() =>
-        Promise.resolve(NextResponse.json({}, { status: 200 })),
-      );
-      const nextRequestMock = new NextRequest(new URL("http://localhost"));
-
-      //when
-      const result = await withJWTAuthHandler(aMockedHandler)(nextRequestMock, {
-        params: Promise.resolve({}),
-      });
-
-      //then
-      expect(aMockedHandler).toHaveBeenCalledWith(
-        nextRequestMock,
-        expect.objectContaining({
-          backofficeUser: {
-            ...mocks.jwtMock,
-            permissions: {
-              ...mocks.jwtMock.permissions,
-              selcGroups: [],
-            },
-          },
-        }),
-      );
-      expect(result.status).toBe(200);
-      expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
-    },
-  );
-
-  it("valid token provided should end up in 200 response with selfcare groups detail when is not an admin and has selcGroups", async () => {
+  it("valid token provided should end up in 200 response with selfcare groups detail when institution is aggregate", async () => {
     //given
-    mocks.jwtMock.institution.role = "operator";
-    mocks.jwtMock.permissions.selcGroups = ["id1"];
-    auth.mockResolvedValueOnce({ user: mocks.jwtMock });
+    const jwtMock = structuredClone(mocks.jwtMock);
+    jwtMock.institution.role = "admin";
+    jwtMock.institution.isAggregate = true;
+    jwtMock.permissions.selcGroups = ["id1"];
+
+    auth.mockResolvedValueOnce({ user: jwtMock });
     const aMockedHandler = vi.fn(() =>
       Promise.resolve(NextResponse.json({}, { status: 200 })),
     );
@@ -163,22 +143,114 @@ describe("withJWTAuthHandler", () => {
     });
 
     //then
-    expect(aMockedHandler).toHaveBeenCalledWith(
-      nextRequestMock,
-      expect.objectContaining({
-        backofficeUser: {
-          ...mocks.jwtMock,
-          permissions: {
-            ...mocks.jwtMock.permissions,
-            selcGroups: [selcGroups[0]],
-          },
+    expect(aMockedHandler).toHaveBeenCalledWith(nextRequestMock, {
+      backofficeUser: {
+        ...jwtMock,
+        institution: {
+          ...jwtMock.institution,
+          selcSpecialGroups: [],
         },
-      }),
-    );
+        permissions: {
+          ...jwtMock.permissions,
+          selcGroups: [selcGroups[0]],
+        },
+      },
+      params: {},
+    });
     expect(result.status).toBe(200);
     expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
     expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
-      mocks.jwtMock.institution.id,
+      jwtMock.institution.id,
+      "*",
+    );
+  });
+
+  it.each`
+    scenario                           | selcGroups
+    ${"selfcare groups are undefined"} | ${undefined}
+    ${"selfcare groups are empty"}     | ${[]}
+  `(
+    "valid token provided should end up in 200 response without selfcare groups detail when $scenario",
+    async ({ selcGroups }) => {
+      //given
+      const jwtMock = structuredClone(mocks.jwtMock);
+      jwtMock.institution.role = "admin";
+      jwtMock.institution.isAggregate = false;
+      jwtMock.permissions.selcGroups = selcGroups;
+
+      auth.mockResolvedValueOnce({ user: jwtMock });
+      const aMockedHandler = vi.fn(() =>
+        Promise.resolve(NextResponse.json({}, { status: 200 })),
+      );
+      const nextRequestMock = new NextRequest(new URL("http://localhost"));
+
+      //when
+      const result = await withJWTAuthHandler(aMockedHandler)(nextRequestMock, {
+        params: Promise.resolve({}),
+      });
+
+      //then
+      expect(aMockedHandler).toHaveBeenCalledWith(nextRequestMock, {
+        backofficeUser: {
+          ...jwtMock,
+          institution: {
+            ...jwtMock.institution,
+            selcSpecialGroups: [],
+          },
+          permissions: {
+            ...jwtMock.permissions,
+            selcGroups: [],
+          },
+        },
+        params: {},
+      });
+      expect(result.status).toBe(200);
+      expect(retrieveInstitutionGroups).not.toHaveBeenCalled();
+    },
+  );
+
+  it("valid token provided should end up in 200 response with selfcare groups detail when is not an admin and has selcGroups", async () => {
+    //given
+    const jwtMock = structuredClone(mocks.jwtMock);
+    jwtMock.institution.role = "operator";
+    jwtMock.institution.isAggregate = false;
+    jwtMock.permissions.selcGroups = ["id1"];
+
+    auth.mockResolvedValueOnce({ user: jwtMock });
+    const aMockedHandler = vi.fn(() =>
+      Promise.resolve(NextResponse.json({}, { status: 200 })),
+    );
+    const selcGroups = [
+      { id: "id1", name: "group1", state: "ACTIVE" },
+      { id: "id2", name: "group2", state: "ACTIVE" },
+    ];
+    retrieveInstitutionGroups.mockResolvedValueOnce(selcGroups);
+    const nextRequestMock = new NextRequest(new URL("http://localhost"));
+
+    //when
+    const result = await withJWTAuthHandler(aMockedHandler)(nextRequestMock, {
+      params: Promise.resolve({}),
+    });
+
+    //then
+    expect(aMockedHandler).toHaveBeenCalledWith(nextRequestMock, {
+      backofficeUser: {
+        ...jwtMock,
+        institution: {
+          ...jwtMock.institution,
+          selcSpecialGroups: [],
+        },
+        permissions: {
+          ...jwtMock.permissions,
+          selcGroups: [selcGroups[0]],
+        },
+      },
+      params: {},
+    });
+    expect(result.status).toBe(200);
+    expect(retrieveInstitutionGroups).toHaveBeenCalledOnce();
+    expect(retrieveInstitutionGroups).toHaveBeenCalledWith(
+      jwtMock.institution.id,
       "*",
     );
   });

--- a/apps/backoffice/src/lib/be/groups/institution-groups-util.ts
+++ b/apps/backoffice/src/lib/be/groups/institution-groups-util.ts
@@ -61,10 +61,9 @@ export const institutionGroupBaseHandler = async (
       switch (maybeFilter.right) {
         case GroupFilterTypeEnum.ALL:
           if (userAuthz.hasSelcGroups()) {
-            groups =
-              backofficeUser.permissions.selcGroups?.filter(
-                (group) => group.state === StateEnum.ACTIVE,
-              ) ?? [];
+            groups = backofficeUser.permissions.selcGroups.filter(
+              (group) => group.state === StateEnum.ACTIVE,
+            );
           } else {
             groups = await retrieveInstitutionGroups(params.institutionId);
           }

--- a/apps/backoffice/src/lib/be/institutions/__tests__/selfcare.test.ts
+++ b/apps/backoffice/src/lib/be/institutions/__tests__/selfcare.test.ts
@@ -2,32 +2,38 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
 import { getMockInstitutionProducts } from "../../../../../mocks/data/selfcare-data";
+import { DelegationTypeEnum } from "../../../../generated/selfcare/DelegationInstitutionResponse";
 import {
   getGroup,
   getInstitutionDelegations,
   getInstitutionGroups,
   getInstitutionProducts,
+  hasAggregators,
 } from "../selfcare";
 
 const mocks: {
   getSelfcareClient: Mock;
+  getDelegateInstitutions: Mock;
   getGroup: Mock;
   getInstitutionDelegations: Mock;
   getInstitutionProducts: Mock;
   getInstitutionGroups: Mock;
   isAxiosError: Mock;
 } = vi.hoisted(() => {
+  const getDelegateInstitutions = vi.fn();
   const getGroup = vi.fn();
   const getInstitutionDelegations = vi.fn();
   const getInstitutionProducts = vi.fn();
   const getInstitutionGroups = vi.fn();
   return {
     getSelfcareClient: vi.fn(() => ({
+      getDelegateInstitutions,
       getGroup,
       getInstitutionDelegations,
       getInstitutionProducts,
       getInstitutionGroups,
     })),
+    getDelegateInstitutions,
     getGroup,
     getInstitutionDelegations,
     getInstitutionProducts,
@@ -252,5 +258,58 @@ describe("Selfcare Institutions", () => {
         expect(mocks.isAxiosError).not.toHaveBeenCalled();
       },
     );
+  });
+
+  describe("hasAggregators", () => {
+    const institutionId = "institutionId";
+
+    it("should reject when getDelegateInstitutions fail", async () => {
+      // given
+      mocks.getDelegateInstitutions.mockReturnValueOnce(TE.left("error"));
+
+      // when and then
+      await expect(() => hasAggregators(institutionId)).rejects.toThrowError(
+        "Error calling selfcare getDelegateInstitutions API",
+      );
+      expect(mocks.getDelegateInstitutions).toHaveBeenCalledOnce();
+      expect(mocks.getDelegateInstitutions).toHaveBeenCalledWith({
+        institutionId,
+        size: 1,
+        type: DelegationTypeEnum.EA,
+      });
+      expect(mocks.isAxiosError).not.toHaveBeenCalled();
+    });
+
+    it("should return false when no delegate institutions are found", async () => {
+      // given
+      mocks.getDelegateInstitutions.mockReturnValueOnce(TE.right([]));
+
+      // when and then
+      await expect(hasAggregators(institutionId)).resolves.toBeFalsy();
+      expect(mocks.getDelegateInstitutions).toHaveBeenCalledOnce();
+      expect(mocks.getDelegateInstitutions).toHaveBeenCalledWith({
+        institutionId,
+        size: 1,
+        type: DelegationTypeEnum.EA,
+      });
+      expect(mocks.isAxiosError).not.toHaveBeenCalled();
+    });
+
+    it("should return true when delegate institutions are found", async () => {
+      // given
+      mocks.getDelegateInstitutions.mockReturnValueOnce(
+        TE.right([{ foo: "bar" }]),
+      );
+
+      // when and then
+      await expect(hasAggregators(institutionId)).resolves.toBeTruthy();
+      expect(mocks.getDelegateInstitutions).toHaveBeenCalledOnce();
+      expect(mocks.getDelegateInstitutions).toHaveBeenCalledWith({
+        institutionId,
+        size: 1,
+        type: DelegationTypeEnum.EA,
+      });
+      expect(mocks.isAxiosError).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/backoffice/src/lib/be/institutions/business.ts
+++ b/apps/backoffice/src/lib/be/institutions/business.ts
@@ -90,7 +90,11 @@ export const retrieveUnboundInstitutionGroups = async (
   institutionId: string,
 ): Promise<DomainGroup[]> => {
   const [subscriptions, groups] = await Promise.all([
-    getManageSubscriptions(SubscriptionTypeEnum.MANAGE_GROUP, apimUserId),
+    getManageSubscriptions({
+      apimUserId,
+      institutionSelcSpecialGroups: [],
+      subscriptionType: SubscriptionTypeEnum.MANAGE_GROUP,
+    }),
     retrieveInstitutionGroups(institutionId),
   ]);
   const subscriptionBoundGroupIds = subscriptions.reduce(

--- a/apps/backoffice/src/lib/be/institutions/selfcare.ts
+++ b/apps/backoffice/src/lib/be/institutions/selfcare.ts
@@ -1,4 +1,5 @@
 import { HTTP_STATUS_NOT_FOUND } from "@/config/constants";
+import { DelegationTypeEnum } from "@/generated/selfcare/DelegationInstitutionResponse";
 import { InstitutionResponse } from "@/generated/selfcare/InstitutionResponse";
 import { PageOfUserGroupResource } from "@/generated/selfcare/PageOfUserGroupResource";
 import {
@@ -179,4 +180,29 @@ export const getInstitutionProducts = async (
   }
 
   return apiResult.right;
+};
+
+/**
+ * Check if an institution has any aggregators.
+ * @param institutionId the institution id
+ * @returns a boolean indicating if the institution has aggregators
+ * @throws ManagedInternalError if the API call fails
+ */
+export const hasAggregators = async (
+  institutionId: string,
+): Promise<boolean> => {
+  const apiResult = await getSelfcareClient().getDelegateInstitutions({
+    institutionId,
+    size: 1,
+    type: DelegationTypeEnum.EA,
+  })();
+
+  if (E.isLeft(apiResult)) {
+    throw new ManagedInternalError(
+      "Error calling selfcare getDelegateInstitutions API",
+      apiResult.left.message,
+    );
+  }
+
+  return apiResult.right.length > 0;
 };

--- a/apps/backoffice/src/lib/be/selfcare-client.ts
+++ b/apps/backoffice/src/lib/be/selfcare-client.ts
@@ -133,67 +133,72 @@ const getAxiosInstance = (): AxiosInstance => {
   });
 };
 
-const buildSelfcareClient = (): SelfcareClient => {
-  const axiosInstance = getAxiosInstance();
-
-  const getUserAuthorizedInstitutions: SelfcareClient["getUserAuthorizedInstitutions"] =
-    (userId) =>
-      pipe(
-        TE.tryCatch(
-          () =>
-            axiosInstance.get(usersApi, {
-              params: {
-                size: 10000,
-                states: "ACTIVE",
-                userId,
-              },
-              timeout: 10000,
-            }),
-          identity,
-        ),
-        TE.mapLeft((e) => {
-          if (axios.isAxiosError(e)) {
-            return new Error(`Axios error catched ${e.message}`);
-          } else {
-            return new Error(
-              `Error calling selfcare getUserAuthorizedInstitutions API: ${e}`,
-            );
-          }
-        }),
-        TE.chainW((response) =>
-          pipe(
-            response.data,
-            UserInstitutions.decode,
-            E.mapLeft(flow(readableReport, E.toError)),
-            TE.fromEither,
-          ),
-        ),
-      );
-
-  const getInstitutionById: SelfcareClient["getInstitutionById"] = (id) =>
+const getUserAuthorizedInstitutions: (
+  axiosInstance: AxiosInstance,
+) => SelfcareClient["getUserAuthorizedInstitutions"] =
+  (axiosInstance) => (userId) =>
     pipe(
       TE.tryCatch(
-        () => axiosInstance.get(`${institutionsApi}/${id}`),
-        flow(
-          E.fromPredicate(
-            axios.isAxiosError,
-            (e) =>
-              new Error(`Error calling selfcare getInstitutionById API: ${e}`),
-          ),
-          E.toUnion,
-        ),
+        () =>
+          axiosInstance.get(usersApi, {
+            params: {
+              size: 10000,
+              states: "ACTIVE",
+              userId,
+            },
+            timeout: 10000,
+          }),
+        identity,
       ),
+      TE.mapLeft((e) => {
+        if (axios.isAxiosError(e)) {
+          return new Error(`Axios error catched ${e.message}`);
+        } else {
+          return new Error(
+            `Error calling selfcare getUserAuthorizedInstitutions API: ${e}`,
+          );
+        }
+      }),
       TE.chainW((response) =>
         pipe(
           response.data,
-          InstitutionResponse.decode,
+          UserInstitutions.decode,
           E.mapLeft(flow(readableReport, E.toError)),
           TE.fromEither,
         ),
       ),
     );
 
-  const getInstitutionGroups: SelfcareClient["getInstitutionGroups"] = ({
+const getInstitutionById: (
+  axiosInstance: AxiosInstance,
+) => SelfcareClient["getInstitutionById"] = (axiosInstance) => (id) =>
+  pipe(
+    TE.tryCatch(
+      () => axiosInstance.get(`${institutionsApi}/${id}`),
+      flow(
+        E.fromPredicate(
+          axios.isAxiosError,
+          (e) =>
+            new Error(`Error calling selfcare getInstitutionById API: ${e}`),
+        ),
+        E.toUnion,
+      ),
+    ),
+    TE.chainW((response) =>
+      pipe(
+        response.data,
+        InstitutionResponse.decode,
+        E.mapLeft(flow(readableReport, E.toError)),
+        TE.fromEither,
+      ),
+    ),
+  );
+
+const getInstitutionGroups: (
+  axiosInstance: AxiosInstance,
+) => SelfcareClient["getInstitutionGroups"] =
+  (axiosInstance) =>
+  ({
     institutionId,
     page,
     parentInstitutionId,
@@ -230,7 +235,8 @@ const buildSelfcareClient = (): SelfcareClient => {
       ),
     );
 
-  const getGroup: SelfcareClient["getGroup"] = (id) =>
+const getGroup: (axiosInstance: AxiosInstance) => SelfcareClient["getGroup"] =
+  (axiosInstance) => (id) =>
     pipe(
       TE.tryCatch(
         () => axiosInstance.get(`${groupsApi}/${id}`),
@@ -251,42 +257,43 @@ const buildSelfcareClient = (): SelfcareClient => {
       ),
     );
 
-  const getInstitutionDelegations: SelfcareClient["getInstitutionDelegations"] =
-    (institutionId, size, page, search) =>
-      pipe(
-        TE.tryCatch(
-          () =>
-            axiosInstance.get(`${delegationsApi}/delegations-with-pagination`, {
-              params: {
-                brokerId: institutionId,
-                order: "ASC",
-                page,
-                search,
-                size,
-              },
-            }),
-          flow(
-            E.fromPredicate(
-              axios.isAxiosError,
-              (e) =>
-                new Error(`Error calling selfcare getDelegations API: ${e}`),
-            ),
-            E.toUnion,
+const getInstitutionDelegations: (
+  axiosInstance: AxiosInstance,
+) => SelfcareClient["getInstitutionDelegations"] =
+  (axiosInstance) => (institutionId, size, page, search) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          axiosInstance.get(`${delegationsApi}/delegations-with-pagination`, {
+            params: {
+              brokerId: institutionId,
+              order: "ASC",
+              page,
+              search,
+              size,
+            },
+          }),
+        flow(
+          E.fromPredicate(
+            axios.isAxiosError,
+            (e) => new Error(`Error calling selfcare getDelegations API: ${e}`),
           ),
+          E.toUnion,
         ),
-        TE.chainEitherK((response) =>
-          pipe(
-            response.data,
-            DelegationWithPaginationResponseStrict.decode,
-            E.mapLeft((e) => pipe(e, readableReport, E.toError)),
-          ),
+      ),
+      TE.chainEitherK((response) =>
+        pipe(
+          response.data,
+          DelegationWithPaginationResponseStrict.decode,
+          E.mapLeft((e) => pipe(e, readableReport, E.toError)),
         ),
-      );
+      ),
+    );
 
-  const getInstitutionProducts: SelfcareClient["getInstitutionProducts"] = (
-    institutionId,
-    userId,
-  ) =>
+const getInstitutionProducts: (
+  axiosInstance: AxiosInstance,
+) => SelfcareClient["getInstitutionProducts"] =
+  (axiosInstance) => (institutionId, userId) =>
     pipe(
       TE.tryCatch(
         () =>
@@ -315,13 +322,16 @@ const buildSelfcareClient = (): SelfcareClient => {
       ),
     );
 
+const buildSelfcareClient = (): SelfcareClient => {
+  const axiosInstance = getAxiosInstance();
+
   return {
-    getGroup,
-    getInstitutionById,
-    getInstitutionDelegations,
-    getInstitutionGroups,
-    getInstitutionProducts,
-    getUserAuthorizedInstitutions,
+    getGroup: getGroup(axiosInstance),
+    getInstitutionById: getInstitutionById(axiosInstance),
+    getInstitutionDelegations: getInstitutionDelegations(axiosInstance),
+    getInstitutionGroups: getInstitutionGroups(axiosInstance),
+    getInstitutionProducts: getInstitutionProducts(axiosInstance),
+    getUserAuthorizedInstitutions: getUserAuthorizedInstitutions(axiosInstance),
   };
 };
 

--- a/apps/backoffice/src/lib/be/selfcare-client.ts
+++ b/apps/backoffice/src/lib/be/selfcare-client.ts
@@ -1,4 +1,8 @@
 import { StateEnum } from "@/generated/api/Group";
+import {
+  DelegationInstitutionResponse,
+  DelegationTypeEnum,
+} from "@/generated/selfcare/DelegationInstitutionResponse";
 import { DelegationResponse } from "@/generated/selfcare/DelegationResponse";
 import { DelegationWithPaginationResponse } from "@/generated/selfcare/DelegationWithPaginationResponse";
 import { PageOfUserGroupResource } from "@/generated/selfcare/PageOfUserGroupResource";
@@ -54,6 +58,19 @@ export type DelegationWithPaginationResponseStrict = t.TypeOf<
 >;
 
 export interface SelfcareClient {
+  /**
+   * Returns the list of institutions of all delegations created by the institution specified in the request path parameter.<br><br> Example: /delegations/delegates/A --> Returns institution details of B,C,D<br><br> <img src=\"https://img.plantuml.biz/plantuml/svg/SoWkIImgoStCIybDBE0goIzGACbNICelASdFLKZ9B4fDBidCp-FIKaWhoi-rKl3CAox9B2a5YIauScbf0HMZ2ZfX4tJ69kZ2vP0Aj1HgCG00\">
+   * @param params the parameters to filter the delegations
+   * - institutionId: the institution id for which retrieve the delegations
+   * - type: the delegation type to filter the delegations (PT, AOO, EA)
+   * - size: the maximum number of delegations to return
+   * @returns a task either containing an error or an array of delegation institution responses
+   */
+  getDelegateInstitutions: (params: {
+    institutionId: string;
+    size?: number;
+    type?: DelegationTypeEnum;
+  }) => TE.TaskEither<Error, DelegationInstitutionResponse[]>;
   getGroup: (
     id: NonEmptyString,
   ) => TE.TaskEither<AxiosError | Error, UserGroupResource>;
@@ -322,10 +339,45 @@ const getInstitutionProducts: (
       ),
     );
 
+const getDelegateInstitutions: (
+  axiosInstance: AxiosInstance,
+) => SelfcareClient["getDelegateInstitutions"] =
+  (axiosInstance) =>
+  ({ institutionId, size, type }) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          axiosInstance.get(`${delegationsApi}/delegates/${institutionId}`, {
+            params: {
+              size,
+              type,
+            },
+          }),
+        flow(
+          E.fromPredicate(
+            axios.isAxiosError,
+            (e) =>
+              new Error(
+                `Error calling selfcare getDelegateInstitutionsUsingGET API: ${e}`,
+              ),
+          ),
+          E.toUnion,
+        ),
+      ),
+      TE.chainEitherK((response) =>
+        pipe(
+          response.data,
+          t.array(DelegationInstitutionResponse).decode,
+          E.mapLeft((e) => pipe(e, readableReport, E.toError)),
+        ),
+      ),
+    );
+
 const buildSelfcareClient = (): SelfcareClient => {
   const axiosInstance = getAxiosInstance();
 
   return {
+    getDelegateInstitutions: getDelegateInstitutions(axiosInstance),
     getGroup: getGroup(axiosInstance),
     getInstitutionById: getInstitutionById(axiosInstance),
     getInstitutionDelegations: getInstitutionDelegations(axiosInstance),

--- a/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
@@ -271,7 +271,13 @@ describe("Subscriptions Business Logic", () => {
       );
 
       await expect(() =>
-        getManageSubscriptions(subscriptionType, ownerId, limit, offset),
+        getManageSubscriptions({
+          subscriptionType,
+          apimUserId: ownerId,
+          limit,
+          offset,
+          institutionSelcSpecialGroups: [],
+        }),
       ).rejects.toThrowError("Error retrieving manage group subscriptions");
 
       expect(mocks.getUserSubscriptions).toHaveBeenCalledOnce();
@@ -303,7 +309,13 @@ describe("Subscriptions Business Logic", () => {
       );
 
       await expect(
-        getManageSubscriptions(subscriptionType, ownerId, limit, offset),
+        getManageSubscriptions({
+          subscriptionType,
+          apimUserId: ownerId,
+          limit,
+          offset,
+          institutionSelcSpecialGroups: [],
+        }),
       ).resolves.toStrictEqual([{ id: name, name: displayName, state }]);
 
       expect(mocks.getUserSubscriptions).toHaveBeenCalledOnce();
@@ -323,9 +335,14 @@ describe("Subscriptions Business Logic", () => {
       mocks.getUserSubscriptions.mockReturnValueOnce(TE.right([]));
 
       await expect(
-        getManageSubscriptions(subscriptionType, ownerId, limit, offset, [
-          group,
-        ]),
+        getManageSubscriptions({
+          subscriptionType,
+          apimUserId: ownerId,
+          limit,
+          offset,
+          userSelcGroups: [group],
+          institutionSelcSpecialGroups: [],
+        }),
       ).resolves.toStrictEqual([]);
 
       expect(mocks.getUserSubscriptions).toHaveBeenCalledOnce();
@@ -337,13 +354,95 @@ describe("Subscriptions Business Logic", () => {
       );
     });
 
+    it("should return a filtered group manage special Subscriptions", async () => {
+      const ownerId = mocks.anOwnerId;
+      const limit = 5;
+      const offset = 0;
+      const group = { id: "gid1", name: "groupName", state: "ACTIVE" };
+      const specialGroup = {
+        id: "sg1",
+        name: "parentInstitutionId",
+        parentInstitutionId: "p1",
+      };
+      const name = "name";
+      const displayName = "displayName";
+      const state = "suspended";
+      const expectedResult = {
+        name,
+        displayName,
+        state,
+        foo: "foo",
+        bar: "bar",
+      };
+      mocks.getUserSubscriptions.mockReturnValueOnce(
+        TE.right([expectedResult]),
+      );
+
+      await expect(
+        getManageSubscriptions({
+          subscriptionType,
+          apimUserId: ownerId,
+          limit,
+          offset,
+          userSelcGroups: [group],
+          institutionSelcSpecialGroups: [specialGroup],
+        }),
+      ).resolves.toStrictEqual([{ id: name, name: displayName, state }]);
+
+      expect(mocks.getUserSubscriptions).toHaveBeenCalledOnce();
+      expect(mocks.getUserSubscriptions).toHaveBeenCalledWith(
+        ownerId,
+        offset,
+        limit,
+        `name eq 'MANAGE-GROUP-${group.id}'`,
+      );
+    });
+
+    it("should return a filtered group when no groups are provided", async () => {
+      const ownerId = mocks.anOwnerId;
+      const limit = 5;
+      const offset = 0;
+      const name = "name";
+      const displayName = "displayName";
+      const state = "suspended";
+      const expectedResult = {
+        name,
+        displayName,
+        state,
+        foo: "foo",
+        bar: "bar",
+      };
+      mocks.getUserSubscriptions.mockReturnValueOnce(
+        TE.right([expectedResult]),
+      );
+
+      await expect(
+        getManageSubscriptions({
+          subscriptionType,
+          apimUserId: ownerId,
+          limit,
+          offset,
+          userSelcGroups: [],
+          institutionSelcSpecialGroups: [],
+        }),
+      ).resolves.toStrictEqual([{ id: name, name: displayName, state }]);
+
+      expect(mocks.getUserSubscriptions).toHaveBeenCalledOnce();
+      expect(mocks.getUserSubscriptions).toHaveBeenCalledWith(
+        ownerId,
+        offset,
+        limit,
+        `startswith(name, 'MANAGE-GROUP-')`,
+      );
+    });
+
     it.each`
-      scenario                       | selcGroups
-      ${"selcGroups is not defined"} | ${undefined}
-      ${"selcGroups is empty"}       | ${[]}
+      scenario                           | userSelcGroups
+      ${"userSelcGroups is not defined"} | ${undefined}
+      ${"userSelcGroups is empty"}       | ${[]}
     `(
       "should return a single subscription when the root manage is requested and $scenario",
-      async ({ selcGroups }) => {
+      async ({ userSelcGroups }) => {
         const subscriptionType = "MANAGE_ROOT";
         const ownerId = mocks.anOwnerId;
         const limit = 5;
@@ -353,13 +452,14 @@ describe("Subscriptions Business Logic", () => {
         );
 
         await expect(
-          getManageSubscriptions(
+          getManageSubscriptions({
             subscriptionType,
-            ownerId,
+            apimUserId: ownerId,
             limit,
             offset,
-            selcGroups,
-          ),
+            userSelcGroups,
+            institutionSelcSpecialGroups: [],
+          }),
         ).resolves.toStrictEqual([
           {
             id: mocks.aSubscriptionContract.name,
@@ -378,24 +478,25 @@ describe("Subscriptions Business Logic", () => {
       },
     );
 
-    it("should return an empty array when the root manage is requested and selcGroups contains at least one item", async () => {
+    it("should return an empty array when the root manage is requested and userSelcGroups contains at least one item", async () => {
       const subscriptionType = "MANAGE_ROOT";
       const ownerId = mocks.anOwnerId;
       const limit = 5;
       const offset = 0;
-      const selcGroups = ["item"];
+      const userSelcGroups = ["item"];
       mocks.getUserSubscriptions.mockReturnValueOnce(
         TE.right([mocks.aSubscriptionContract]),
       );
 
       await expect(
-        getManageSubscriptions(
+        getManageSubscriptions({
           subscriptionType,
-          ownerId,
+          apimUserId: ownerId,
           limit,
           offset,
-          selcGroups,
-        ),
+          userSelcGroups,
+          institutionSelcSpecialGroups: [],
+        }),
       ).resolves.toStrictEqual([]);
 
       expect(mocks.getUserSubscriptions).not.toHaveBeenCalled();

--- a/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/__tests__/business.test.ts
@@ -5,8 +5,15 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
 import { Cidr } from "../../../../generated/api/Cidr";
 import { SubscriptionKeyTypeEnum } from "../../../../generated/api/SubscriptionKeyType";
 import {
+  ExportFileNotFoundError,
+  ExportFileNotReadyError,
+  ManagedInternalError,
+} from "../../errors";
+import { FileStateEnum } from "../api-keys-exports-port";
+import {
   deleteManageSubscription,
   generateApiKeysExports,
+  generateApiKeysExportsDownloadLink,
   getManageSubscriptions,
   regenerateInstitutionAggregateManageSubscriptionApiKeyByAggregator,
   regenerateManageSubscriptionApiKey,
@@ -14,16 +21,9 @@ import {
   retrieveInstitutionAggregateManageSubscriptionsKeys,
   retrieveManageSubscriptionApiKeys,
   retrieveManageSubscriptionAuthorizedCIDRs,
-  generateApiKeysExportsDownloadLink,
   upsertManageSubscription,
   upsertManageSubscriptionAuthorizedCIDRs,
 } from "../business";
-import {
-  ExportFileNotFoundError,
-  ExportFileNotReadyError,
-  ManagedInternalError,
-} from "../../errors";
-import { FileStateEnum } from "../api-keys-exports-port";
 
 const mocks: {
   anOwnerId: string;
@@ -102,15 +102,13 @@ vi.mock("@/lib/be/apim-service", () => ({
   }),
 }));
 
-vi.mock("@io-services-cms/external-clients", async () => {
-  const actual = await vi.importActual<
-    typeof import("@io-services-cms/external-clients")
-  >("@io-services-cms/external-clients");
-
+vi.mock("@io-services-cms/external-clients", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@io-services-cms/external-clients")>();
   return {
-    ...actual,
+    ...original,
     ApimUtils: {
-      ...actual.ApimUtils,
+      ...original.ApimUtils,
       formatEmailForOrganization: mocks.formatEmailForOrganization,
     },
   };

--- a/apps/backoffice/src/lib/be/subscriptions/business.ts
+++ b/apps/backoffice/src/lib/be/subscriptions/business.ts
@@ -42,6 +42,7 @@ import {
   getInstitutionDelegations,
   getInstitutionGroups,
 } from "../institutions/selfcare";
+import { SpecialGroup } from "../wrappers";
 import { ApiKeysExportsPort, FileStateEnum } from "./api-keys-exports-port";
 import { listSubscriptionSecrets, regenerateSubscriptionKey } from "./apim";
 import {
@@ -186,20 +187,29 @@ export async function upsertManageSubscription(
  * @param apimUserId The id of the user to check the subscription ownership for
  * @param limit The maximum number of subscriptions to retrieve
  * @param offset The number of subscriptions to skip
- * @param selcGroups The groups to filter the subscriptions by (only for GROUP subscriptions)
+ * @param userSelcGroups The groups to filter the subscriptions by (only for GROUP subscriptions)
+ * @param institutionSelcSpecialGroups The special groups to exclude from subscriptions listing
  * @returns The list of manage subscriptions for the user
  */
-export async function getManageSubscriptions(
-  subscriptionType: SubscriptionType,
-  apimUserId: string,
-  limit?: number,
-  offset?: number,
-  selcGroups?: Group[],
-): Promise<Subscription[]> {
+export async function getManageSubscriptions({
+  apimUserId,
+  institutionSelcSpecialGroups,
+  limit,
+  offset,
+  subscriptionType,
+  userSelcGroups,
+}: {
+  apimUserId: string;
+  institutionSelcSpecialGroups: SpecialGroup[];
+  limit?: number;
+  offset?: number;
+  subscriptionType: SubscriptionType;
+  userSelcGroups?: Group[];
+}): Promise<Subscription[]> {
   let filter;
   switch (subscriptionType) {
     case SubscriptionTypeEnum.MANAGE_ROOT:
-      if (selcGroups && selcGroups.length > 0) {
+      if (userSelcGroups && userSelcGroups.length > 0) {
         // Non-admin users who have at least one group are not allowed to retrieve "ROOT MANAGE" subscription
         return Promise.resolve([]);
       }
@@ -207,7 +217,8 @@ export async function getManageSubscriptions(
       break;
     case SubscriptionTypeEnum.MANAGE_GROUP:
       filter = ApimUtils.apim_filters.manageGroupSubscriptionsFilter(
-        selcGroups?.map((group) => group.id),
+        userSelcGroups?.map((group) => group.id) ?? [],
+        institutionSelcSpecialGroups.map((group) => group.id),
       );
       break;
     default:

--- a/apps/backoffice/src/lib/be/wrappers.ts
+++ b/apps/backoffice/src/lib/be/wrappers.ts
@@ -29,46 +29,58 @@ export const withJWTAuthHandler =
     if (!session?.user) {
       return handleUnauthorizedErrorResponse("No Authentication provided");
     }
-    const authenticationDetails = session.user;
 
-    let backofficeUser: BackOfficeUserEnriched;
-    const userAuth = userAuthz(authenticationDetails);
-    if (userAuth.isAdmin() || !userAuth.hasSelcGroups()) {
-      backofficeUser = {
-        ...authenticationDetails,
-        permissions: {
-          ...authenticationDetails.permissions,
-          selcGroups: [],
-        },
-      };
-    } else {
+    const userAuth = userAuthz(session.user);
+    let selcGroups: DomainGroup[] = [];
+    let selcSpecialGroups: SpecialGroup[] = [];
+
+    if (
+      session.user.institution.isAggregate ||
+      (!userAuth.isAdmin() && userAuth.hasSelcGroups())
+    ) {
       const institutionGroups = await retrieveInstitutionGroups(
-        authenticationDetails.institution.id,
+        session.user.institution.id,
         "*",
       );
-      backofficeUser = {
-        ...authenticationDetails,
-        permissions: {
-          ...authenticationDetails.permissions,
-          selcGroups: institutionGroups.filter((institutionGroup) =>
-            authenticationDetails.permissions.selcGroups?.includes(
-              institutionGroup.id,
-            ),
-          ),
-        },
-      };
+      selcSpecialGroups = institutionGroups.filter(
+        (institutionGroup): institutionGroup is SpecialGroup =>
+          !!institutionGroup.parentInstitutionId,
+      );
+      selcGroups = institutionGroups.filter((institutionGroup) =>
+        session.user.permissions.selcGroups?.includes(institutionGroup.id),
+      );
     }
 
-    const resolvedParams = await params;
-    // chiamo l'handler finale "iniettando" il payload contenuto nel token
+    // call the final handler "injecting" the payload contained in the token
     return handler(nextRequest, {
-      backofficeUser,
-      params: resolvedParams,
+      backofficeUser: {
+        ...session.user,
+        institution: {
+          ...session.user.institution,
+          selcSpecialGroups,
+        },
+        permissions: {
+          ...session.user.permissions,
+          selcGroups,
+        },
+      },
+      params: await params,
     });
   };
 
+export type SpecialGroup = { parentInstitutionId: string } & DomainGroup;
+
 export type BackOfficeUserEnriched = {
+  institution: {
+    /**
+     * if selcSpecialGroups is empty, it means that there are no visibility restrictions for the user over "special" groups
+     */
+    selcSpecialGroups: SpecialGroup[];
+  } & BackOfficeUser["institution"];
   permissions: {
+    /**
+     * if selcGroups is undefined or empty, it means that there are no visibility restrictions for the user over "regular" groups
+     */
     selcGroups?: DomainGroup[];
   } & Omit<BackOfficeUserPermissions, "selcGroups">;
 } & Omit<BackOfficeUser, "permissions">;

--- a/apps/backoffice/src/lib/be/wrappers.ts
+++ b/apps/backoffice/src/lib/be/wrappers.ts
@@ -1,11 +1,11 @@
 import { auth } from "@/auth";
 import { NextRequest, NextResponse } from "next/server";
 
+import { SelfcareRoles } from "@/types/auth";
 import {
   BackOfficeUser,
   BackOfficeUserPermissions,
 } from "../../../types/next-auth";
-import { userAuthz } from "./authz";
 import { handleUnauthorizedErrorResponse } from "./errors";
 import {
   DomainGroup,
@@ -30,25 +30,28 @@ export const withJWTAuthHandler =
       return handleUnauthorizedErrorResponse("No Authentication provided");
     }
 
-    const userAuth = userAuthz(session.user);
-    let selcGroups: DomainGroup[] = [];
-    let selcSpecialGroups: SpecialGroup[] = [];
+    let selcGroups: DomainGroup[];
+    let institutionSpecialGroups: SpecialGroup[] = [];
+    let institutionGroups: DomainGroup[] | undefined;
 
-    if (
-      session.user.institution.isAggregate ||
-      (!userAuth.isAdmin() && userAuth.hasSelcGroups())
-    ) {
-      const institutionGroups = await retrieveInstitutionGroups(
-        session.user.institution.id,
-        "*",
+    if (session.user.institution.role === SelfcareRoles.admin) {
+      selcGroups = [];
+    } else {
+      institutionGroups =
+        institutionGroups ??
+        (await retrieveInstitutionGroups(session.user.institution.id, "*"));
+      selcGroups = institutionGroups.filter(
+        (institutionGroup) =>
+          session.user.permissions.selcGroups?.includes(institutionGroup.id) ??
+          false,
       );
-      selcSpecialGroups = institutionGroups.filter(
-        (institutionGroup): institutionGroup is SpecialGroup =>
-          !!institutionGroup.parentInstitutionId,
-      );
-      selcGroups = institutionGroups.filter((institutionGroup) =>
-        session.user.permissions.selcGroups?.includes(institutionGroup.id),
-      );
+    }
+
+    if (session.user.institution.isAggregate) {
+      institutionGroups =
+        institutionGroups ??
+        (await retrieveInstitutionGroups(session.user.institution.id, "*"));
+      institutionSpecialGroups = institutionGroups.filter(isSpecialGroup);
     }
 
     // call the final handler "injecting" the payload contained in the token
@@ -57,7 +60,7 @@ export const withJWTAuthHandler =
         ...session.user,
         institution: {
           ...session.user.institution,
-          selcSpecialGroups,
+          selcSpecialGroups: institutionSpecialGroups,
         },
         permissions: {
           ...session.user.permissions,
@@ -73,14 +76,17 @@ export type SpecialGroup = { parentInstitutionId: string } & DomainGroup;
 export type BackOfficeUserEnriched = {
   institution: {
     /**
-     * if selcSpecialGroups is empty, it means that there are no visibility restrictions for the user over "special" groups
+     * if selcSpecialGroups is empty, it means that institution has no "special" groups
      */
     selcSpecialGroups: SpecialGroup[];
   } & BackOfficeUser["institution"];
   permissions: {
     /**
-     * if selcGroups is undefined or empty, it means that there are no visibility restrictions for the user over "regular" groups
+     * if selcGroups is empty, it means that the user is not a member of any group (or is an admin) and there are no visibility restrictions for the user over groups
      */
-    selcGroups?: DomainGroup[];
+    selcGroups: DomainGroup[];
   } & Omit<BackOfficeUserPermissions, "selcGroups">;
 } & Omit<BackOfficeUser, "permissions">;
+
+const isSpecialGroup = (group: DomainGroup): group is SpecialGroup =>
+  group.parentInstitutionId !== undefined;

--- a/apps/backoffice/src/lib/be/wrappers.ts
+++ b/apps/backoffice/src/lib/be/wrappers.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/auth";
+import { SelfcareRoles } from "@/types/auth";
 import { NextRequest, NextResponse } from "next/server";
 
-import { SelfcareRoles } from "@/types/auth";
 import {
   BackOfficeUser,
   BackOfficeUserPermissions,

--- a/apps/backoffice/types/next-auth.d.ts
+++ b/apps/backoffice/types/next-auth.d.ts
@@ -4,6 +4,7 @@ export interface Institution {
   fiscalCode: string;
   id: string;
   isAggregator: boolean;
+  isAggregate: boolean;
   logo_url?: string;
   name: string;
   role: string;

--- a/apps/io-services-cms-webapp/src/__tests__/main.test.ts
+++ b/apps/io-services-cms-webapp/src/__tests__/main.test.ts
@@ -178,7 +178,7 @@ vi.mock("../lib/azure/cosmos", () => ({
 }));
 
 vi.mock("../lib/azure/misc", async (importOriginal) => {
-  const actual = (await importOriginal()) as any;
+  const actual = await importOriginal<typeof import("../lib/azure/misc")>();
   return {
     ...actual,
     processBatchOf: mocks.processBatchOf,
@@ -187,7 +187,7 @@ vi.mock("../lib/azure/misc", async (importOriginal) => {
 });
 
 vi.mock("../lib/azure/adapters", async (importOriginal) => {
-  const actual = (await importOriginal()) as any;
+  const actual = await importOriginal<typeof import("../lib/azure/adapters")>();
   return {
     ...actual,
     toAzureFunctionHandler: mocks.toAzureFunctionHandler,
@@ -195,7 +195,8 @@ vi.mock("../lib/azure/adapters", async (importOriginal) => {
 });
 
 vi.mock("../utils/cosmos-helper", async (importOriginal) => {
-  const actual = (await importOriginal()) as any;
+  const actual =
+    await importOriginal<typeof import("../utils/cosmos-helper")>();
   return {
     ...actual,
     makeCosmosHelper: mocks.makeCosmosHelper,

--- a/apps/io-services-cms-webapp/src/utils/__tests__/azure-user-attributes-manage-middleware-wrapper.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/__tests__/azure-user-attributes-manage-middleware-wrapper.test.ts
@@ -24,12 +24,13 @@ const { AzureUserAttributesManageMiddleware } = vi.hoisted(() => ({
 
 vi.mock(
   "../../lib/middlewares/azure_user_attributes_manage-middleware",
-  async () => {
-    const actual = await vi.importActual(
-      "../../lib/middlewares/azure_user_attributes_manage-middleware",
-    );
+  async (importOriginal) => {
+    const original =
+      await importOriginal<
+        typeof import("../../lib/middlewares/azure_user_attributes_manage-middleware")
+      >();
     return {
-      ...(actual as any),
+      ...original,
       AzureUserAttributesManageMiddleware,
     };
   },

--- a/apps/io-services-cms-webapp/src/utils/selfcare-group-change/__tests__/sync-subscription.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/selfcare-group-change/__tests__/sync-subscription.test.ts
@@ -12,11 +12,10 @@ const mocks = vi.hoisted(() => ({
   updateSubscription: vi.fn(),
 }));
 
-vi.mock("../utils", async () => {
-  const actual = await vi.importActual<typeof import("../utils")>("../utils");
-
+vi.mock("../utils", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../utils")>();
   return {
-    ...actual,
+    ...original,
     getSubscription: mocks.getSubscription,
     updateSubscription: mocks.updateSubscription,
   };
@@ -56,7 +55,9 @@ describe("syncSubscription", () => {
     if (E.isLeft(result)) {
       expect(result.left).toStrictEqual(expectedError);
     }
-    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(deps.apimService);
+    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(
+      deps.apimService,
+    );
     expect(mockedGetSubscriptionTask).toHaveBeenCalledExactlyOnceWith(
       ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX + item.id,
     );
@@ -85,7 +86,9 @@ describe("syncSubscription", () => {
     if (E.isRight(result)) {
       expect(result.right).toBeUndefined();
     }
-    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(deps.apimService);
+    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(
+      deps.apimService,
+    );
     expect(mockedGetSubscriptionTask).toHaveBeenCalledExactlyOnceWith(
       ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX + item.id,
     );
@@ -133,14 +136,18 @@ describe("syncSubscription", () => {
       if (E.isLeft(result)) {
         expect(result.left).toStrictEqual(expectedError);
       }
-      expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(deps.apimService);
+      expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(
+        deps.apimService,
+      );
       expect(mockedGetSubscriptionTask).toHaveBeenCalledExactlyOnceWith(
         ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX + item.id,
       );
       expect(mocks.updateSubscription).toHaveBeenCalledExactlyOnceWith(
         deps.apimService,
       );
-      expect(mockedUpdateSubscriptionTask).toHaveBeenCalledExactlyOnceWith(item);
+      expect(mockedUpdateSubscriptionTask).toHaveBeenCalledExactlyOnceWith(
+        item,
+      );
     },
   );
 
@@ -171,7 +178,9 @@ describe("syncSubscription", () => {
     if (E.isRight(result)) {
       expect(result.right).toBeUndefined();
     }
-    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(deps.apimService);
+    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(
+      deps.apimService,
+    );
     expect(mockedGetSubscriptionTask).toHaveBeenCalledExactlyOnceWith(
       ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX + item.id,
     );
@@ -209,11 +218,15 @@ describe("syncSubscription", () => {
     if (E.isRight(result)) {
       expect(result.right).toBeUndefined();
     }
-    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(deps.apimService);
+    expect(mocks.getSubscription).toHaveBeenCalledExactlyOnceWith(
+      deps.apimService,
+    );
     expect(mockedGetSubscriptionTask).toHaveBeenCalledExactlyOnceWith(
       ApimUtils.SUBSCRIPTION_MANAGE_GROUP_PREFIX + item.id,
     );
-    expect(mocks.updateSubscription).toHaveBeenCalledExactlyOnceWith(deps.apimService);
+    expect(mocks.updateSubscription).toHaveBeenCalledExactlyOnceWith(
+      deps.apimService,
+    );
     expect(mockedUpdateSubscriptionTask).toHaveBeenCalledExactlyOnceWith(item);
   });
 });

--- a/packages/external-clients/src/apim-client/__tests__/apim-filters.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/apim-filters.test.ts
@@ -179,20 +179,14 @@ describe("subscriptionsExceptManageOneApimFilter", () => {
 
 describe("manageGroupSubscriptionsFilter", () => {
   it("should return a MANAGE-GROUP- filter when no groups are provided", () => {
-    const res = manageGroupSubscriptionsFilter();
+    const res = manageGroupSubscriptionsFilter([], []);
 
     expect(res).toEqual("startswith(name, 'MANAGE-GROUP-')");
   });
 
-  it("should return an empty filter when empty array is provided", () => {
-    const res = manageGroupSubscriptionsFilter([]);
-
-    expect(res).toEqual("");
-  });
-
   it("should return a single MANAGE-GROUP- filter when a single group id provided", () => {
     const groupId = "g1";
-    const res = manageGroupSubscriptionsFilter([groupId]);
+    const res = manageGroupSubscriptionsFilter([groupId], []);
 
     expect(res).toEqual(`name eq 'MANAGE-GROUP-${groupId}'`);
   });
@@ -202,12 +196,73 @@ describe("manageGroupSubscriptionsFilter", () => {
     for (let index = 0; index < groupids.length; index++) {
       groupids[index] = "id" + index;
     }
-    const res = manageGroupSubscriptionsFilter(groupids);
+    const res = manageGroupSubscriptionsFilter(groupids, []);
 
     const expectedRes = groupids
       .map((groupId) => `name eq 'MANAGE-GROUP-${groupId}'`)
       .join(" or ");
     expect(res).toEqual(expectedRes);
+  });
+
+  it("should return a MANAGE-GROUP- startsWith filter with special group exclusion when no group ids are provided", () => {
+    const specialGroupId = "sg1";
+    const res = manageGroupSubscriptionsFilter([], [specialGroupId]);
+
+    expect(res).toEqual(
+      `startswith(name, 'MANAGE-GROUP-') and not(name eq 'MANAGE-GROUP-${specialGroupId}')`,
+    );
+  });
+
+  it("should return a MANAGE-GROUP- startsWith filter with multiple special group exclusions when no group ids are provided", () => {
+    const specialGroupId = "sg1";
+    const specialGroupId2 = "sg2";
+    const res = manageGroupSubscriptionsFilter(
+      [],
+      [specialGroupId, specialGroupId2],
+    );
+
+    expect(res).toEqual(
+      `startswith(name, 'MANAGE-GROUP-') and not(name eq 'MANAGE-GROUP-${specialGroupId}' or name eq 'MANAGE-GROUP-${specialGroupId2}')`,
+    );
+  });
+
+  it("should return a single MANAGE-GROUP- name eq filter when the only group id is itself a special group", () => {
+    const specialGroupId = "sg1";
+    const res = manageGroupSubscriptionsFilter(
+      [specialGroupId],
+      [specialGroupId],
+    );
+
+    expect(res).toEqual(`name eq 'MANAGE-GROUP-${specialGroupId}'`);
+  });
+
+  it("should return concat MANAGE-GROUP- name eq filters when group ids include multiple special groups", () => {
+    const groupId = "g1";
+    const specialGroupId = "sg1";
+    const specialGroupId2 = "sg2";
+    const res = manageGroupSubscriptionsFilter(
+      [groupId, specialGroupId, specialGroupId2],
+      [specialGroupId, specialGroupId2],
+    );
+
+    expect(res).toEqual(
+      `name eq 'MANAGE-GROUP-${groupId}' or name eq 'MANAGE-GROUP-${specialGroupId}' or name eq 'MANAGE-GROUP-${specialGroupId2}'`,
+    );
+  });
+
+  it("should return concat MANAGE-GROUP- name eq filters ignoring special groups exclusion when multiple group ids include special groups", () => {
+    const groupId = "g1";
+    const groupId2 = "g2";
+    const specialGroupId = "sg1";
+    const specialGroupId2 = "sg2";
+    const res = manageGroupSubscriptionsFilter(
+      [groupId, groupId2, specialGroupId, specialGroupId2],
+      [specialGroupId, specialGroupId2],
+    );
+
+    expect(res).toEqual(
+      `name eq 'MANAGE-GROUP-${groupId}' or name eq 'MANAGE-GROUP-${groupId2}' or name eq 'MANAGE-GROUP-${specialGroupId}' or name eq 'MANAGE-GROUP-${specialGroupId2}'`,
+    );
   });
 });
 

--- a/packages/external-clients/src/apim-client/apim-filters.ts
+++ b/packages/external-clients/src/apim-client/apim-filters.ts
@@ -217,14 +217,28 @@ export const subscriptionsExceptManageOneApimFilter = () =>
   );
 
 /**
- * User Subscription list filtered by name startswith 'MANAGE-GROUP-'
+ * User Subscription list filtered by 'MANAGE-GROUP-'
+ *  NOTE:
+ * 1. selcGroup also contains special groups except for ADMIN that always has selcGroup forced to empty array
+ * 2. excludeManageGroupSpecialFilter is applied only when groupIds array is empty
+ *    (APIM filter with startsWith clause)
+ * the following table show samples with only one special group
+ * | groupIds  | specialGroupsIds | role     | APIM filter                    |
+ * | --------- | ---------------- | -------- | ------------------------------ |
+ * | []        | [gs1]            | ADMIN    | startsWith() + exclusionFilter |
+ * | [gs1]     | [gs1]            | ADMIN_EA | name eq gs1                    |
+ * | []        | [gs1]            | OPERATOR | startsWith() + exclusionFilter |
+ * | [gs1]     | [gs1]            | OPERATOR | name eq gs1                    |
  *
  * @returns API Management `$filter` property
  */
-export const manageGroupSubscriptionsFilter = (groupIds?: string[]): string =>
+export const manageGroupSubscriptionsFilter = (
+  groupIds: string[],
+  specialGroupsIds: string[],
+): string =>
   pipe(
     groupIds,
-    O.fromNullable,
+    O.fromPredicate(RA.isNonEmpty),
     O.map(
       flow(
         RA.mapWithIndex((i, groupId) =>
@@ -243,7 +257,7 @@ export const manageGroupSubscriptionsFilter = (groupIds?: string[]): string =>
         (groupIdFilters) => groupIdFilters.join(" "),
       ),
     ),
-    O.getOrElse(() =>
+    O.orElse(() =>
       pipe(
         buildApimFilter({
           composeFilter: FilterCompositionEnum.none,
@@ -252,9 +266,42 @@ export const manageGroupSubscriptionsFilter = (groupIds?: string[]): string =>
           inverse: false,
           value: SUBSCRIPTION_MANAGE_GROUP_PREFIX,
         }),
-        O.getOrElse(() => ""),
+        O.chain((startWithFilter) =>
+          pipe(
+            specialGroupsIds,
+            O.fromPredicate(RA.isNonEmpty),
+            O.map(
+              flow(
+                RA.mapWithIndex((i, specialGroupId) =>
+                  pipe(
+                    // to shorten the overall filter length
+                    // instead of using multiple not eq operators
+                    // we construct an unique predicate with OR
+                    // and prepend NOT after in the chain
+                    buildApimFilter({
+                      composeFilter:
+                        i === 0
+                          ? FilterCompositionEnum.none
+                          : FilterCompositionEnum.or,
+                      field: FilterFieldEnum.name,
+                      filterType: FilterSupportedOperatorsEnum.eq,
+                      inverse: false,
+                      value: SUBSCRIPTION_MANAGE_GROUP_PREFIX + specialGroupId,
+                    }),
+                    O.getOrElse(() => ""),
+                  ),
+                ),
+                (exclusionFilters) => exclusionFilters.join(" "),
+                (exclusionFilter) =>
+                  `${startWithFilter} ${FilterCompositionEnum.and}not(${exclusionFilter})`,
+              ),
+            ),
+            O.orElse(() => O.some(startWithFilter)),
+          ),
+        ),
       ),
     ),
+    O.getOrElse(() => ""),
   );
 
 /**

--- a/packages/external-clients/src/selfcare-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/selfcare-client/__tests__/index.test.ts
@@ -1,14 +1,12 @@
+import { HttpAgentConfig } from "@io-services-cms/fetch-utils";
 import * as E from "fp-ts/lib/Either";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMockInstitutionProducts } from "../mocks/data/selfcare-data";
 import { TypeEnum } from "../../generated/selfcare/DelegationResponse";
 import { DelegationWithPaginationResponse } from "../../generated/selfcare/DelegationWithPaginationResponse";
 import { InstitutionResponse } from "../../generated/selfcare/InstitutionResponse";
 import { PageOfUserGroupResource } from "../../generated/selfcare/PageOfUserGroupResource";
-import { ProductResource } from "../../generated/selfcare/ProductResource";
 import { StatusEnum } from "../../generated/selfcare/UserGroupResource";
 import { getSelfcareClient, resetInstance, UserInstitutions } from "../index";
-import { HttpAgentConfig } from "@io-services-cms/fetch-utils";
 
 const mocks: {
   institution: InstitutionResponse;
@@ -96,10 +94,10 @@ const { create, isAxiosError, getMock } = vi.hoisted(() => {
   };
 });
 
-vi.mock("axios", async () => {
-  const actual = await vi.importActual("axios");
+vi.mock("axios", async (importOriginal) => {
+  const original = await importOriginal<typeof import("axios")>();
   return {
-    ...(actual as any),
+    ...original,
     default: { create, isAxiosError },
   };
 });


### PR DESCRIPTION
This pull request introduces support for an `isAggregate` field in the user session and improves the handling and testing of aggregate institutions throughout the authentication and authorization flow. It also adds comprehensive tests for new and existing behaviors, especially around aggregate institutions and their permissions.

Key changes include:

**Support for aggregate institutions in authentication and authorization:**

* The `authorize` function in `auth.ts` now retrieves and attaches a new `isAggregate` property (based on the result of `hasAggregators`) to the institution object in the user session. This allows downstream logic to distinguish between aggregate and non-aggregate institutions. [[1]](diffhunk://#diff-0e1144cb93346ba7fe3d4f20a8d2ebb2ccdaee10d872a976f9b36ba31b1c0e65R66-R84) [[2]](diffhunk://#diff-0e1144cb93346ba7fe3d4f20a8d2ebb2ccdaee10d872a976f9b36ba31b1c0e65L303-R329)
* The `getExpectedUser` test helper and related tests are updated to handle the new `isAggregate` field, ensuring that test coverage reflects the new session structure. [[1]](diffhunk://#diff-116f9c61df2913a941e05eb674d577506f921a39e3aa942a7351d098b1e1a67eR91) [[2]](diffhunk://#diff-116f9c61df2913a941e05eb674d577506f921a39e3aa942a7351d098b1e1a67eR101)
* New test cases verify that errors in retrieving aggregator status are handled correctly and that the `authorize` flow works as expected for both aggregate and non-aggregate institutions. [[1]](diffhunk://#diff-116f9c61df2913a941e05eb674d577506f921a39e3aa942a7351d098b1e1a67eR703-R741) [[2]](diffhunk://#diff-116f9c61df2913a941e05eb674d577506f921a39e3aa942a7351d098b1e1a67eR752) [[3]](diffhunk://#diff-116f9c61df2913a941e05eb674d577506f921a39e3aa942a7351d098b1e1a67eR765) [[4]](diffhunk://#diff-116f9c61df2913a941e05eb674d577506f921a39e3aa942a7351d098b1e1a67eR780-R781)

**Enhancements to institution and delegation handling:**

* The selfcare client adds and tests a new `getDelegateInstitutions` method, including error handling and response validation, to retrieve delegate institution information. [[1]](diffhunk://#diff-7a57b730f978f471114795a5d7ae330b9ec40a2d4c27073b897a5e98ac45ad27R4-R7) [[2]](diffhunk://#diff-7a57b730f978f471114795a5d7ae330b9ec40a2d4c27073b897a5e98ac45ad27R481-R579)

**Improvements and expanded test coverage for authentication wrappers:**

* The `withJWTAuthHandler` tests are extended to cover scenarios involving the new `isAggregate` field, ensuring correct permission and group handling for both aggregate and non-aggregate institutions, and for different user roles. [[1]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L2-R10) [[2]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91R36-R39) [[3]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L55-R61) [[4]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L67-R92) [[5]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L91-R167) [[6]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L115-R181) [[7]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L128-R219) [[8]](diffhunk://#diff-fe1bbf0f44e97610f0d620aca2eeaa98ca50f6359f3943da834caf637d77ca91L166-R253)

**Changelog update:**

* A changeset is added to document the addition and handling of the new `isAggregate` field from the user session.