### PR TITLE
[IOPID-3946] Format date in AggregatedInstitutionDownloadAlert component

### DIFF
--- a/.changeset/lovely-dragons-smell.md
+++ b/.changeset/lovely-dragons-smell.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Format date in AggregatedInstitutionDownloadAlert component

--- a/apps/backoffice/src/__tests__/components/aggregated-institution-download-alert.test.tsx
+++ b/apps/backoffice/src/__tests__/components/aggregated-institution-download-alert.test.tsx
@@ -89,7 +89,7 @@ describe("[AggregatedInstitutionDownloadAlert] Component", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "routes.aggregated-institutions.downloadAlert.success.description:15-04-2026",
+        "routes.aggregated-institutions.downloadAlert.success.description:15-04-2026, 10:00:00",
       ),
     ).toBeInTheDocument();
 

--- a/apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx
+++ b/apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx
@@ -100,10 +100,14 @@ export const AggregatedInstitutionDownloadAlert = ({
                   {
                     expirationDate: new Intl.DateTimeFormat(i18n.language, {
                       day: "2-digit",
+                      hour: "2-digit",
+                      hour12: false,
+                      minute: "2-digit",
                       month: "2-digit",
+                      second: "2-digit",
                       year: "numeric",
                     })
-                      .format(new Date(data.expirationDate ?? ""))
+                      .format(new Date(data.expirationDate))
                       .replace(/\//g, "-"),
                   },
                 )}


### PR DESCRIPTION
This PR makes a change to the `AggregatedInstitutionDownloadAlert` component to update the display of the expiration date. The date format now includes hours, minutes, and seconds and ensures that the time is displayed in 24-hour format.