### PR TITLE
test: [IOPID-3940] Add event tracking for EA file download success and error

### DIFF
--- a/.changeset/heavy-mangos-kick.md
+++ b/.changeset/heavy-mangos-kick.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": minor
+---
+
+Added event tracking for EA file download success and error

--- a/apps/backoffice/src/__tests__/components/aggregated-institution-download-alert.test.tsx
+++ b/apps/backoffice/src/__tests__/components/aggregated-institution-download-alert.test.tsx
@@ -5,8 +5,10 @@ import { AggregatedInstitutionDownloadAlert } from "../../components/aggregated-
 import { StateEnum as NotReadyStateEnum } from "../../generated/api/AggregatedInstitutionsManageKeysExportFileMetadataNotReady";
 import { StateEnum as ReadyStateEnum } from "../../generated/api/AggregatedInstitutionsManageKeysExportFileMetadataReady";
 import {
+  trackEaFileDownloadErrorEvent,
+  trackEaFileDownloadSuccessEvent,
   trackEaFileGenerateCompletedEvent,
-  // trackEaFileGenerateDownloadEvent,
+  trackEaFileGenerateDownloadEvent,
   trackEaFileGenerateEndEvent,
   trackEaFileGenerateErrorEvent,
   trackEaFileGenerateProgressEvent,
@@ -39,6 +41,8 @@ vi.mock("@/hooks/use-fetch", () => ({
 }));
 
 vi.mock("../../utils/mix-panel", () => ({
+  trackEaFileDownloadErrorEvent: vi.fn(),
+  trackEaFileDownloadSuccessEvent: vi.fn(),
   trackEaFileGenerateCompletedEvent: vi.fn(),
   trackEaFileGenerateDownloadEvent: vi.fn(),
   trackEaFileGenerateEndEvent: vi.fn(),
@@ -132,6 +136,13 @@ describe("[AggregatedInstitutionDownloadAlert] Component", () => {
         expect.anything(),
         { notify: "errors" },
       );
+      expect(vi.mocked(trackEaFileGenerateDownloadEvent)).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(vi.mocked(trackEaFileDownloadSuccessEvent)).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(vi.mocked(trackEaFileDownloadErrorEvent)).not.toHaveBeenCalled();
       expect(anchorClickSpy).toHaveBeenCalledOnce();
     });
 
@@ -165,6 +176,49 @@ describe("[AggregatedInstitutionDownloadAlert] Component", () => {
 
     await waitFor(() => {
       expect(mockFetchDownloadLink).toHaveBeenCalledOnce();
+      expect(vi.mocked(trackEaFileGenerateDownloadEvent)).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(vi.mocked(trackEaFileDownloadErrorEvent)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(trackEaFileDownloadSuccessEvent)).not.toHaveBeenCalled();
+      expect(anchorClickSpy).not.toHaveBeenCalled();
+    });
+
+    anchorClickSpy.mockRestore();
+  });
+
+  it("should track download error when fetchDownloadLink succeeds without link", async () => {
+    const anchorClickSpy = vi
+      .spyOn(HTMLElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    mockFetchDownloadLink.mockResolvedValueOnce({
+      data: {},
+      success: true,
+    });
+
+    render(
+      <AggregatedInstitutionDownloadAlert
+        data={{
+          expirationDate: "2026-04-15T10:00:00",
+          state: ReadyStateEnum.DONE,
+        }}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "routes.aggregated-institutions.downloadAlert.success.action",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchDownloadLink).toHaveBeenCalledOnce();
+      expect(vi.mocked(trackEaFileGenerateDownloadEvent)).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(vi.mocked(trackEaFileDownloadErrorEvent)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(trackEaFileDownloadSuccessEvent)).not.toHaveBeenCalled();
       expect(anchorClickSpy).not.toHaveBeenCalled();
     });
 
@@ -262,26 +316,31 @@ describe("[AggregatedInstitutionDownloadAlert] Tracking events", () => {
     expect(vi.mocked(trackEaFileGenerateRefreshEvent)).not.toHaveBeenCalled();
   });
 
-  // it("should fire completedEvent and endEvent(success) when state is DONE", () => {
-  //   render(
-  //     <AggregatedInstitutionDownloadAlert
-  //       data={{
-  //         expirationDate: "2026-04-15T10:00:00",
-  //         state: ReadyStateEnum.DONE,
-  //       }}
-  //       onRefresh={vi.fn()}
-  //     />,
-  //   );
+  it("should fire completedEvent and endEvent(success) when state is DONE", () => {
+    mockFetchDownloadLink.mockResolvedValueOnce({
+      data: {},
+      success: true,
+    });
 
-  //   expect(vi.mocked(trackEaFileGenerateCompletedEvent)).toHaveBeenCalledTimes(
-  //     1,
-  //   );
-  //   expect(vi.mocked(trackEaFileGenerateEndEvent)).toHaveBeenCalledWith(
-  //     "success",
-  //   );
-  //   expect(vi.mocked(trackEaFileGenerateProgressEvent)).not.toHaveBeenCalled();
-  //   expect(vi.mocked(trackEaFileGenerateErrorEvent)).not.toHaveBeenCalled();
-  // });
+    render(
+      <AggregatedInstitutionDownloadAlert
+        data={{
+          expirationDate: "2026-04-15T10:00:00",
+          state: ReadyStateEnum.DONE,
+        }}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(vi.mocked(trackEaFileGenerateCompletedEvent)).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(vi.mocked(trackEaFileGenerateEndEvent)).toHaveBeenCalledWith(
+      "success",
+    );
+    expect(vi.mocked(trackEaFileGenerateProgressEvent)).not.toHaveBeenCalled();
+    expect(vi.mocked(trackEaFileGenerateErrorEvent)).not.toHaveBeenCalled();
+  });
 
   it("should fire errorEvent and endEvent(error) when state is FAILED", () => {
     render(
@@ -299,27 +358,27 @@ describe("[AggregatedInstitutionDownloadAlert] Tracking events", () => {
     expect(vi.mocked(trackEaFileGenerateProgressEvent)).not.toHaveBeenCalled();
   });
 
-  // it("should fire downloadEvent when the download link is clicked", () => {
-  //   render(
-  //     <AggregatedInstitutionDownloadAlert
-  //       data={{
-  //         expirationDate: "2026-04-15T10:00:00",
-  //         state: ReadyStateEnum.DONE,
-  //       }}
-  //       onRefresh={vi.fn()}
-  //     />,
-  //   );
+  it("should fire downloadEvent when the download link is clicked", () => {
+    render(
+      <AggregatedInstitutionDownloadAlert
+        data={{
+          expirationDate: "2026-04-15T10:00:00",
+          state: ReadyStateEnum.DONE,
+        }}
+        onRefresh={vi.fn()}
+      />,
+    );
 
-  //   fireEvent.click(
-  //     screen.getByRole("button", {
-  //       name: "routes.aggregated-institutions.downloadAlert.success.action",
-  //     }),
-  //   );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "routes.aggregated-institutions.downloadAlert.success.action",
+      }),
+    );
 
-  //   expect(vi.mocked(trackEaFileGenerateDownloadEvent)).toHaveBeenCalledTimes(
-  //     1,
-  //   );
-  // });
+    expect(vi.mocked(trackEaFileGenerateDownloadEvent)).toHaveBeenCalledTimes(
+      1,
+    );
+  });
 
   it("should fire refreshEvent when the refresh button is clicked", () => {
     render(

--- a/apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx
+++ b/apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx
@@ -2,6 +2,8 @@ import { AggregatedInstitutionsManageKeysExportFileDownloadLink } from "@/genera
 import { AggregatedInstitutionsManageKeysExportFileMetadata } from "@/generated/api/AggregatedInstitutionsManageKeysExportFileMetadata";
 import useFetch from "@/hooks/use-fetch";
 import {
+  trackEaFileDownloadErrorEvent,
+  trackEaFileDownloadSuccessEvent,
   trackEaFileGenerateCompletedEvent,
   trackEaFileGenerateEndEvent,
   trackEaFileGenerateErrorEvent,
@@ -41,6 +43,8 @@ export const AggregatedInstitutionDownloadAlert = ({
       { notify: "errors" },
     );
     if (result.success && result.data?.downloadLink) {
+      trackEaFileDownloadSuccessEvent();
+
       const link = document.createElement("a");
       link.href = result.data.downloadLink;
       link.setAttribute(
@@ -52,6 +56,8 @@ export const AggregatedInstitutionDownloadAlert = ({
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+    } else {
+      trackEaFileDownloadErrorEvent();
     }
   }, [fetchDownloadLink, t]);
 

--- a/apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx
+++ b/apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx
@@ -5,6 +5,7 @@ import {
   trackEaFileDownloadErrorEvent,
   trackEaFileDownloadSuccessEvent,
   trackEaFileGenerateCompletedEvent,
+  trackEaFileGenerateDownloadEvent,
   trackEaFileGenerateEndEvent,
   trackEaFileGenerateErrorEvent,
   trackEaFileGenerateProgressEvent,
@@ -36,6 +37,7 @@ export const AggregatedInstitutionDownloadAlert = ({
     useFetch<AggregatedInstitutionsManageKeysExportFileDownloadLink>();
 
   const handleDownloadClick = useCallback(async () => {
+    trackEaFileGenerateDownloadEvent();
     const result = await fetchDownloadLink(
       "generateDirectDownloadLinkForAggregatedInstitutionsManageKeys",
       {},

--- a/apps/backoffice/src/utils/mix-panel.ts
+++ b/apps/backoffice/src/utils/mix-panel.ts
@@ -107,6 +107,8 @@ interface MixPanelEventsStructure {
   readonly IO_BO_EA_FILE_GENERATE_END: { result: TechEventResult };
   readonly IO_BO_EA_FILE_GENERATE_COMPLETED: Record<string, unknown>;
   readonly IO_BO_EA_FILE_DOWNLOAD: Record<string, unknown>;
+  readonly IO_BO_EA_FILE_DOWNLOAD_SUCCESS: Record<string, never>;
+  readonly IO_BO_EA_FILE_DOWNLOAD_ERROR: Record<string, never>;
   readonly IO_BO_EA_FILE_GENERATE_ERROR: Record<string, unknown>;
 }
 
@@ -506,4 +508,12 @@ export const trackEaFileGenerateDownloadEvent = () => {
 
 export const trackEaFileGenerateErrorEvent = () => {
   logToMixpanel("IO_BO_EA_FILE_GENERATE_ERROR", "KO", {}, "screen_view");
+};
+
+export const trackEaFileDownloadSuccessEvent = () => {
+  logToMixpanel("IO_BO_EA_FILE_DOWNLOAD_SUCCESS", "TECH", {});
+};
+
+export const trackEaFileDownloadErrorEvent = () => {
+  logToMixpanel("IO_BO_EA_FILE_DOWNLOAD_ERROR", "TECH", {});
 };


### PR DESCRIPTION
## Short description
This PR adds implements the tracking strategy for the EA file download operation. It also restores the `trackEaFileGenerateDownloadEvent` and its tests.

## List of changes
- Added and implemented the `IO_BO_EA_FILE_DOWNLOAD_SUCCESS` and the `IO_BO_EA_FILE_DOWNLOAD_ERROR` events
- Restored the `IO_BO_EA_FILE_DOWNLOAD` event dispatch and related tests in `apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx`
- Updated `apps/backoffice/src/components/aggregated-institutions/aggregated-institution-download-alert/index.tsx` to include the newly added events

## How to test
Run the backoffice and ensure all new events are properly dispatched.