### PR TITLE
[#IOPID-3909] manual retry capability for APIM listSecrets AbortError

### DIFF
--- a/.changeset/fuzzy-rules-visit.md
+++ b/.changeset/fuzzy-rules-visit.md
@@ -1,0 +1,6 @@
+---
+"@io-services-cms/external-clients": minor
+"io-services-cms-backoffice": patch
+---
+
+Introduced manual retries for listSecrets APIM utility

--- a/apps/backoffice/src/lib/be/apim-service.ts
+++ b/apps/backoffice/src/lib/be/apim-service.ts
@@ -80,15 +80,24 @@ const getApimConfig = (): Config => {
 const buildApimService: () => ApimUtils.ApimService = () => {
   // Apim Service, used to operates on Apim resources
   const apimConfig = getApimConfig();
-  const apimClient = ApimUtils.getApimClient(
-    apimConfig.AZURE_SUBSCRIPTION_ID,
-    {},
-  );
+  // SDK-level retries: the Azure APIM client uses @azure/core-rest-pipeline's
+  // built-in exponential retry policy, which handles HTTP-level errors (408,
+  // 5xx) for all APIM operations automatically.
+  const apimClient = ApimUtils.getApimClient(apimConfig.AZURE_SUBSCRIPTION_ID, {
+    retryOptions: {
+      maxRetries: apimConfig.AZURE_APIM_CLIENT_MAX_RETRIES,
+      maxRetryDelayInMs: apimConfig.AZURE_APIM_CLIENT_MAX_RETRY_DELAY_MS,
+      retryDelayInMs: apimConfig.AZURE_APIM_CLIENT_RETRY_DELAY_MS,
+    },
+  });
   return ApimUtils.getApimService(
     apimClient,
     apimConfig.AZURE_APIM_RESOURCE_GROUP,
     apimConfig.AZURE_APIM,
     apimConfig.AZURE_APIM_PRODUCT_NAME,
+    // Application-level timeout retries for listSecrets: the SDK does not retry
+    // timed-out requests (AbortError is thrown before retry strategies run),
+    // so this fills the gap specifically for that operation.
     {
       initialDelayMs: apimConfig.AZURE_APIM_CLIENT_RETRY_DELAY_MS,
       maxDelayMs: apimConfig.AZURE_APIM_CLIENT_MAX_RETRY_DELAY_MS,

--- a/apps/backoffice/src/lib/be/apim-service.ts
+++ b/apps/backoffice/src/lib/be/apim-service.ts
@@ -80,18 +80,20 @@ const getApimConfig = (): Config => {
 const buildApimService: () => ApimUtils.ApimService = () => {
   // Apim Service, used to operates on Apim resources
   const apimConfig = getApimConfig();
-  const apimClient = ApimUtils.getApimClient(apimConfig.AZURE_SUBSCRIPTION_ID, {
-    retryOptions: {
-      maxRetries: apimConfig.AZURE_APIM_CLIENT_MAX_RETRIES,
-      maxRetryDelayInMs: apimConfig.AZURE_APIM_CLIENT_MAX_RETRY_DELAY_MS,
-      retryDelayInMs: apimConfig.AZURE_APIM_CLIENT_RETRY_DELAY_MS,
-    },
-  });
+  const apimClient = ApimUtils.getApimClient(
+    apimConfig.AZURE_SUBSCRIPTION_ID,
+    {},
+  );
   return ApimUtils.getApimService(
     apimClient,
     apimConfig.AZURE_APIM_RESOURCE_GROUP,
     apimConfig.AZURE_APIM,
     apimConfig.AZURE_APIM_PRODUCT_NAME,
+    {
+      initialDelayMs: apimConfig.AZURE_APIM_CLIENT_RETRY_DELAY_MS,
+      maxDelayMs: apimConfig.AZURE_APIM_CLIENT_MAX_RETRY_DELAY_MS,
+      maxRetries: apimConfig.AZURE_APIM_CLIENT_MAX_RETRIES,
+    },
   );
 };
 

--- a/apps/backoffice/src/lib/be/apim-service.ts
+++ b/apps/backoffice/src/lib/be/apim-service.ts
@@ -95,9 +95,9 @@ const buildApimService: () => ApimUtils.ApimService = () => {
     apimConfig.AZURE_APIM_RESOURCE_GROUP,
     apimConfig.AZURE_APIM,
     apimConfig.AZURE_APIM_PRODUCT_NAME,
-    // Application-level timeout retries for listSecrets: the SDK does not retry
+    // Application-level timeout retries: the SDK does not retry
     // timed-out requests (AbortError is thrown before retry strategies run),
-    // so this fills the gap specifically for that operation.
+    // so this fills the gap specifically for some operations.
     {
       initialDelayMs: apimConfig.AZURE_APIM_CLIENT_RETRY_DELAY_MS,
       maxDelayMs: apimConfig.AZURE_APIM_CLIENT_MAX_RETRY_DELAY_MS,

--- a/packages/external-clients/src/apim-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/index.test.ts
@@ -8,7 +8,6 @@ import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  ApimClientTimeoutRetryOptions,
   ApimRestError,
   formatEmailForOrganization,
   getApimClient,
@@ -16,6 +15,7 @@ import {
   parseIdFromFullPath,
 } from "..";
 import { SubscriptionKeyTypeEnum } from "../../generated/api/SubscriptionKeyType";
+import { RetryOptions } from "../../utils/retries";
 
 vi.mock("@azure/identity", () => ({
   DefaultAzureCredential: vi.fn(),
@@ -597,10 +597,7 @@ describe("ApimService Test", () => {
       }
     });
 
-    it.each([
-      { name: "AbortError" },
-      { code: "ETIMEDOUT" },
-    ])(
+    it.each([{ name: "AbortError" }, { code: "ETIMEDOUT" }])(
       "should retry on timeout error %o when retryOptions are provided",
       async (timeoutError) => {
         const secrets = {
@@ -616,7 +613,7 @@ describe("ApimService Test", () => {
           subscription: { listSecrets: mockListSecrets },
         } as unknown as ApiManagementClient;
 
-        const retryOptions: ApimClientTimeoutRetryOptions = {
+        const retryOptions: RetryOptions = {
           initialDelayMs: 0,
           maxDelayMs: 0,
           maxRetries: 2,
@@ -660,7 +657,7 @@ describe("ApimService Test", () => {
         subscription: { listSecrets: mockListSecrets },
       } as unknown as ApiManagementClient;
 
-      const retryOptions: ApimClientTimeoutRetryOptions = {
+      const retryOptions: RetryOptions = {
         initialDelayMs: 0,
         maxDelayMs: 0,
         maxRetries: 3,
@@ -687,7 +684,7 @@ describe("ApimService Test", () => {
         subscription: { listSecrets: mockListSecrets },
       } as unknown as ApiManagementClient;
 
-      const retryOptions: ApimClientTimeoutRetryOptions = {
+      const retryOptions: RetryOptions = {
         initialDelayMs: 0,
         maxDelayMs: 0,
         maxRetries: 3,

--- a/packages/external-clients/src/apim-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  ApimClientCustomRetryOptions,
   ApimRestError,
   formatEmailForOrganization,
   getApimClient,
@@ -594,6 +595,84 @@ describe("ApimService Test", () => {
           secondaryKey: aSecondaryKey,
         });
       }
+    });
+
+    it("should retry on timeout errors when retryOptions are provided", async () => {
+      const timeoutError = { name: "AbortError" };
+      const secrets = {
+        _etag: "_etag",
+        primaryKey: aPrimaryKey,
+        secondaryKey: aSecondaryKey,
+      };
+      const mockListSecrets = vi
+        .fn()
+        .mockRejectedValueOnce(timeoutError)
+        .mockResolvedValueOnce(secrets);
+      const mockApimClient = {
+        subscription: { listSecrets: mockListSecrets },
+      } as unknown as ApiManagementClient;
+
+      const retryOptions: ApimClientCustomRetryOptions = {
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        maxRetries: 2,
+      };
+      const apimService = getApimService(
+        mockApimClient,
+        anApimResourceGroup,
+        anApimServiceName,
+        anApimProductName,
+        retryOptions,
+      );
+
+      const resultPromise = apimService.listSecrets(aServiceId)();
+      const result = await resultPromise;
+
+      expect(E.isRight(result)).toBeTruthy();
+      expect(mockListSecrets).toHaveBeenCalledTimes(2);
+    });
+
+    it("should use default retry config when retryOptions are not provided", async () => {
+      const timeoutError = { code: "ETIMEOUT" };
+      const mockListSecrets = vi.fn().mockRejectedValue(timeoutError);
+      const mockApimClient = {
+        subscription: { listSecrets: mockListSecrets },
+      } as unknown as ApiManagementClient;
+
+      const apimService = mockApimService(mockApimClient);
+
+      const resultPromise = apimService.listSecrets(aServiceId)();
+      const result = await resultPromise;
+
+      expect(E.isLeft(result)).toBeTruthy();
+      expect(mockListSecrets).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not retry on non-retriable errors", async () => {
+      const nonRetriableError = { statusCode: 400 };
+      const mockListSecrets = vi.fn().mockRejectedValue(nonRetriableError);
+      const mockApimClient = {
+        subscription: { listSecrets: mockListSecrets },
+      } as unknown as ApiManagementClient;
+
+      const retryOptions: ApimClientCustomRetryOptions = {
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        maxRetries: 3,
+      };
+      const apimService = getApimService(
+        mockApimClient,
+        anApimResourceGroup,
+        anApimServiceName,
+        anApimProductName,
+        retryOptions,
+      );
+
+      const resultPromise = apimService.listSecrets(aServiceId)();
+      const result = await resultPromise;
+
+      expect(E.isLeft(result)).toBeTruthy();
+      expect(mockListSecrets).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/external-clients/src/apim-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/index.test.ts
@@ -8,7 +8,7 @@ import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  ApimClientCustomRetryOptions,
+  ApimClientTimeoutRetryOptions,
   ApimRestError,
   formatEmailForOrganization,
   getApimClient,
@@ -612,7 +612,7 @@ describe("ApimService Test", () => {
         subscription: { listSecrets: mockListSecrets },
       } as unknown as ApiManagementClient;
 
-      const retryOptions: ApimClientCustomRetryOptions = {
+      const retryOptions: ApimClientTimeoutRetryOptions = {
         initialDelayMs: 0,
         maxDelayMs: 0,
         maxRetries: 2,
@@ -648,6 +648,34 @@ describe("ApimService Test", () => {
       expect(mockListSecrets).toHaveBeenCalledTimes(1);
     });
 
+    // SDK level retries will handle this
+    it("should not retry on server errors (5xx)", async () => {
+      const serverError = { statusCode: 500 };
+      const mockListSecrets = vi.fn().mockRejectedValue(serverError);
+      const mockApimClient = {
+        subscription: { listSecrets: mockListSecrets },
+      } as unknown as ApiManagementClient;
+
+      const retryOptions: ApimClientTimeoutRetryOptions = {
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        maxRetries: 3,
+      };
+      const apimService = getApimService(
+        mockApimClient,
+        anApimResourceGroup,
+        anApimServiceName,
+        anApimProductName,
+        retryOptions,
+      );
+
+      const resultPromise = apimService.listSecrets(aServiceId)();
+      const result = await resultPromise;
+
+      expect(E.isLeft(result)).toBeTruthy();
+      expect(mockListSecrets).toHaveBeenCalledTimes(1);
+    });
+
     it("should not retry on non-retriable errors", async () => {
       const nonRetriableError = { statusCode: 400 };
       const mockListSecrets = vi.fn().mockRejectedValue(nonRetriableError);
@@ -655,7 +683,7 @@ describe("ApimService Test", () => {
         subscription: { listSecrets: mockListSecrets },
       } as unknown as ApiManagementClient;
 
-      const retryOptions: ApimClientCustomRetryOptions = {
+      const retryOptions: ApimClientTimeoutRetryOptions = {
         initialDelayMs: 0,
         maxDelayMs: 0,
         maxRetries: 3,

--- a/packages/external-clients/src/apim-client/__tests__/index.test.ts
+++ b/packages/external-clients/src/apim-client/__tests__/index.test.ts
@@ -597,43 +597,47 @@ describe("ApimService Test", () => {
       }
     });
 
-    it("should retry on timeout errors when retryOptions are provided", async () => {
-      const timeoutError = { name: "AbortError" };
-      const secrets = {
-        _etag: "_etag",
-        primaryKey: aPrimaryKey,
-        secondaryKey: aSecondaryKey,
-      };
-      const mockListSecrets = vi
-        .fn()
-        .mockRejectedValueOnce(timeoutError)
-        .mockResolvedValueOnce(secrets);
-      const mockApimClient = {
-        subscription: { listSecrets: mockListSecrets },
-      } as unknown as ApiManagementClient;
+    it.each([
+      { name: "AbortError" },
+      { code: "ETIMEDOUT" },
+    ])(
+      "should retry on timeout error %o when retryOptions are provided",
+      async (timeoutError) => {
+        const secrets = {
+          _etag: "_etag",
+          primaryKey: aPrimaryKey,
+          secondaryKey: aSecondaryKey,
+        };
+        const mockListSecrets = vi
+          .fn()
+          .mockRejectedValueOnce(timeoutError)
+          .mockResolvedValueOnce(secrets);
+        const mockApimClient = {
+          subscription: { listSecrets: mockListSecrets },
+        } as unknown as ApiManagementClient;
 
-      const retryOptions: ApimClientTimeoutRetryOptions = {
-        initialDelayMs: 0,
-        maxDelayMs: 0,
-        maxRetries: 2,
-      };
-      const apimService = getApimService(
-        mockApimClient,
-        anApimResourceGroup,
-        anApimServiceName,
-        anApimProductName,
-        retryOptions,
-      );
+        const retryOptions: ApimClientTimeoutRetryOptions = {
+          initialDelayMs: 0,
+          maxDelayMs: 0,
+          maxRetries: 2,
+        };
+        const apimService = getApimService(
+          mockApimClient,
+          anApimResourceGroup,
+          anApimServiceName,
+          anApimProductName,
+          retryOptions,
+        );
 
-      const resultPromise = apimService.listSecrets(aServiceId)();
-      const result = await resultPromise;
+        const result = await apimService.listSecrets(aServiceId)();
 
-      expect(E.isRight(result)).toBeTruthy();
-      expect(mockListSecrets).toHaveBeenCalledTimes(2);
-    });
+        expect(E.isRight(result)).toBeTruthy();
+        expect(mockListSecrets).toHaveBeenCalledTimes(2);
+      },
+    );
 
     it("should use default retry config when retryOptions are not provided", async () => {
-      const timeoutError = { code: "ETIMEOUT" };
+      const timeoutError = { code: "ETIMEDOUT" };
       const mockListSecrets = vi.fn().mockRejectedValue(timeoutError);
       const mockApimClient = {
         subscription: { listSecrets: mockListSecrets },

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -34,9 +34,17 @@ import {
   SubscriptionKeyType,
   SubscriptionKeyTypeEnum,
 } from "../generated/api/SubscriptionKeyType";
+import { retryTaskEither } from "../utils/retries";
 import { subscriptionsExceptManageOneApimFilter } from "./apim-filters";
 
 export type ApimMappedErrors = IResponseErrorInternal | IResponseErrorNotFound;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ApimClientCustomRetryOptions = {
+  readonly initialDelayMs?: number;
+  readonly maxDelayMs?: number;
+  readonly maxRetries?: number;
+};
 
 export const ApimRestError = t.intersection([
   t.type({
@@ -183,6 +191,7 @@ export const getApimService = (
   apimResourceGroup: string,
   apimServiceName: string,
   apimProductName: NonEmptyString,
+  retryOptions?: ApimClientCustomRetryOptions,
 ): ApimService => ({
   createGroupUser: (groupId, userId) =>
     createGroupUser(
@@ -272,6 +281,7 @@ export const getApimService = (
       apimServiceName,
       subscriptionId,
       requestTimeoutInMs,
+      retryOptions,
     ),
   regenerateSubscriptionKey: (subscriptionId, keyType) =>
     regenerateSubscriptionKey(
@@ -449,21 +459,36 @@ const listSecrets = (
   apimServiceName: string,
   subscriptionId: string,
   requestTimeoutInMs?: number,
+  retryOptions?: ApimClientCustomRetryOptions,
 ) =>
   pipe(
-    TE.tryCatch(
-      () =>
-        apimClient.subscription.listSecrets(
-          apimResourceGroup,
-          apimServiceName,
-          subscriptionId,
-          {
-            requestOptions: {
-              timeout: requestTimeoutInMs,
+    retryTaskEither(
+      TE.tryCatch(
+        () =>
+          apimClient.subscription.listSecrets(
+            apimResourceGroup,
+            apimServiceName,
+            subscriptionId,
+            {
+              requestOptions: {
+                timeout: requestTimeoutInMs,
+              },
             },
-          },
-        ),
-      identity,
+          ),
+        identity,
+      ),
+      retryOptions?.maxRetries ?? 0,
+      retryOptions?.initialDelayMs ?? 0,
+      retryOptions?.maxDelayMs ?? 0,
+      (error: unknown) => {
+        if (typeof error !== "object" || error === null) {
+          return false;
+        }
+        const e = error as Record<string, unknown>;
+        const isTimeout = e.name === "AbortError" || e.code === "ETIMEOUT";
+        const isServerError = e.statusCode === 500 || e.statusCode === 504;
+        return isTimeout || isServerError;
+      },
     ),
     chainApimMappedError,
   );

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -34,26 +34,10 @@ import {
   SubscriptionKeyType,
   SubscriptionKeyTypeEnum,
 } from "../generated/api/SubscriptionKeyType";
-import { retryTaskEither } from "../utils/retries";
+import { RetryOptions, retryTaskEither } from "../utils/retries";
 import { subscriptionsExceptManageOneApimFilter } from "./apim-filters";
 
 export type ApimMappedErrors = IResponseErrorInternal | IResponseErrorNotFound;
-
-/**
- * Retry options for timeout-triggered failures on APIM operations.
- *
- * The Azure SDK (@azure/core-rest-pipeline) handles HTTP-level errors (e.g. 500,
- * 503) via its built-in exponential retry policy, but it does NOT retry requests
- * that are aborted by a client-side timeout: when a request times out, the SDK
- * throws an AbortError immediately and skips all retry strategies. These options
- * configure an application-level retry layer to fill that gap.
- */
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type ApimClientTimeoutRetryOptions = {
-  readonly initialDelayMs?: number;
-  readonly maxDelayMs?: number;
-  readonly maxRetries?: number;
-};
 
 export const ApimRestError = t.intersection([
   t.type({
@@ -195,12 +179,20 @@ export interface ApimService {
   ) => TE.TaskEither<ApimRestError | Error, SubscriptionContract>;
 }
 
+/**
+ * @param apimClient - The Azure API Management client.
+ * @param apimResourceGroup - The resource group containing the APIM instance.
+ * @param apimServiceName - The name of the APIM service.
+ * @param apimProductName - The APIM product name.
+ * @param timeoutRetryOptions - Optional application-level retry for operations
+ *   that are subject to timeouts.
+ */
 export const getApimService = (
   apimClient: ApiManagementClient,
   apimResourceGroup: string,
   apimServiceName: string,
   apimProductName: NonEmptyString,
-  retryOptions?: ApimClientTimeoutRetryOptions,
+  timeoutRetryOptions?: RetryOptions,
 ): ApimService => ({
   createGroupUser: (groupId, userId) =>
     createGroupUser(
@@ -290,7 +282,7 @@ export const getApimService = (
       apimServiceName,
       subscriptionId,
       requestTimeoutInMs,
-      retryOptions,
+      timeoutRetryOptions,
     ),
   regenerateSubscriptionKey: (subscriptionId, keyType) =>
     regenerateSubscriptionKey(
@@ -468,35 +460,32 @@ const listSecrets = (
   apimServiceName: string,
   subscriptionId: string,
   requestTimeoutInMs?: number,
-  retryOptions?: ApimClientTimeoutRetryOptions,
+  timeoutRetryOptions?: RetryOptions,
 ) =>
   pipe(
-    retryTaskEither(
-      TE.tryCatch(
-        () =>
-          apimClient.subscription.listSecrets(
-            apimResourceGroup,
-            apimServiceName,
-            subscriptionId,
-            {
-              requestOptions: {
-                timeout: requestTimeoutInMs,
-              },
+    TE.tryCatch(
+      () =>
+        apimClient.subscription.listSecrets(
+          apimResourceGroup,
+          apimServiceName,
+          subscriptionId,
+          {
+            requestOptions: {
+              timeout: requestTimeoutInMs,
             },
-          ),
-        identity,
-      ),
-      retryOptions?.maxRetries ?? 0,
-      retryOptions?.initialDelayMs ?? 0,
-      retryOptions?.maxDelayMs ?? 0,
-      (error: unknown) => {
-        if (typeof error !== "object" || error === null) {
-          return false;
-        }
-        const e = error as Record<string, unknown>;
-        return e.name === "AbortError" || e.code === "ETIMEOUT";
-      },
+          },
+        ),
+      identity,
     ),
+    timeoutRetryOptions
+      ? retryTaskEither(timeoutRetryOptions, (error: unknown) => {
+          if (typeof error !== "object" || error === null) {
+            return false;
+          }
+          const e = error as Record<string, unknown>;
+          return e.name === "AbortError" || e.code === "ETIMEDOUT";
+        })
+      : identity,
     chainApimMappedError,
   );
 

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -40,7 +40,16 @@ import { subscriptionsExceptManageOneApimFilter } from "./apim-filters";
 export type ApimMappedErrors = IResponseErrorInternal | IResponseErrorNotFound;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type ApimClientCustomRetryOptions = {
+/**
+ * Retry options for timeout-triggered failures on APIM operations.
+ *
+ * The Azure SDK (@azure/core-rest-pipeline) handles HTTP-level errors (e.g. 500,
+ * 503) via its built-in exponential retry policy, but it does NOT retry requests
+ * that are aborted by a client-side timeout: when a request times out, the SDK
+ * throws an AbortError immediately and skips all retry strategies. These options
+ * configure an application-level retry layer to fill that gap.
+ */
+export type ApimClientTimeoutRetryOptions = {
   readonly initialDelayMs?: number;
   readonly maxDelayMs?: number;
   readonly maxRetries?: number;
@@ -191,7 +200,7 @@ export const getApimService = (
   apimResourceGroup: string,
   apimServiceName: string,
   apimProductName: NonEmptyString,
-  retryOptions?: ApimClientCustomRetryOptions,
+  retryOptions?: ApimClientTimeoutRetryOptions,
 ): ApimService => ({
   createGroupUser: (groupId, userId) =>
     createGroupUser(
@@ -459,7 +468,7 @@ const listSecrets = (
   apimServiceName: string,
   subscriptionId: string,
   requestTimeoutInMs?: number,
-  retryOptions?: ApimClientCustomRetryOptions,
+  retryOptions?: ApimClientTimeoutRetryOptions,
 ) =>
   pipe(
     retryTaskEither(
@@ -485,9 +494,7 @@ const listSecrets = (
           return false;
         }
         const e = error as Record<string, unknown>;
-        const isTimeout = e.name === "AbortError" || e.code === "ETIMEOUT";
-        const isServerError = e.statusCode === 500 || e.statusCode === 504;
-        return isTimeout || isServerError;
+        return e.name === "AbortError" || e.code === "ETIMEOUT";
       },
     ),
     chainApimMappedError,

--- a/packages/external-clients/src/apim-client/index.ts
+++ b/packages/external-clients/src/apim-client/index.ts
@@ -39,7 +39,6 @@ import { subscriptionsExceptManageOneApimFilter } from "./apim-filters";
 
 export type ApimMappedErrors = IResponseErrorInternal | IResponseErrorNotFound;
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 /**
  * Retry options for timeout-triggered failures on APIM operations.
  *
@@ -49,6 +48,7 @@ export type ApimMappedErrors = IResponseErrorInternal | IResponseErrorNotFound;
  * throws an AbortError immediately and skips all retry strategies. These options
  * configure an application-level retry layer to fill that gap.
  */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ApimClientTimeoutRetryOptions = {
   readonly initialDelayMs?: number;
   readonly maxDelayMs?: number;

--- a/packages/external-clients/src/utils/__tests__/retries.test.ts
+++ b/packages/external-clients/src/utils/__tests__/retries.test.ts
@@ -1,0 +1,171 @@
+import * as TE from "fp-ts/lib/TaskEither";
+import * as E from "fp-ts/lib/Either";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { retryTaskEither } from "../retries";
+
+const alwaysRetry = () => true;
+const neverRetry = () => false;
+
+describe("retryTaskEither", () => {
+  it("should return right immediately when action succeeds on the first attempt", async () => {
+    const action = TE.right("success");
+
+    const result = await retryTaskEither(action, 3, 100, 500, alwaysRetry)();
+
+    expect(result).toEqual(E.right("success"));
+  });
+
+  it("should retry and succeed after the first attempt fails", async () => {
+    let counter = 0;
+    const action = vi.fn(async () => {
+      counter++;
+      if (counter === 1) throw new Error("fail");
+      return "success";
+    });
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      3,
+      100,
+      500,
+      alwaysRetry,
+    )();
+
+    const result = await resultPromise;
+
+    expect(result).toEqual(E.right("success"));
+    expect(counter).toBe(2);
+  });
+
+  it("should return left after exhausting all retries", async () => {
+    const error = new Error("persistent failure");
+    const action = vi.fn(() => Promise.reject(error));
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      3,
+      100,
+      500,
+      alwaysRetry,
+    )();
+
+    const result = await resultPromise;
+
+    expect(result).toEqual(E.left(error));
+    expect(action).toHaveBeenCalledTimes(4);
+  });
+
+  it("should not retry when shouldRetry returns false", async () => {
+    const error = new Error("non-retriable");
+    const action = vi.fn(() => Promise.reject(error));
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      3,
+      100,
+      500,
+      neverRetry,
+    )();
+
+    const result = await resultPromise;
+
+    expect(result).toEqual(E.left(error));
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not retry at all when maxRetries is 0", async () => {
+    const error = new Error("fail");
+    const action = vi.fn(() => Promise.reject(error));
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      0,
+      100,
+      500,
+      alwaysRetry,
+    )();
+
+    const result = await resultPromise;
+
+    expect(result).toEqual(E.left(error));
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("should apply exponential backoff delays between retries", async () => {
+    const delays: number[] = [];
+    let lastTime = Date.now();
+
+    const action = vi.fn(async () => {
+      const now = Date.now();
+      if (delays.length > 0 || action.mock.calls.length > 1) {
+        delays.push(now - lastTime);
+      }
+      lastTime = now;
+      throw new Error("fail");
+    });
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      3,
+      100,
+      500,
+      alwaysRetry,
+    )();
+
+    await resultPromise;
+
+    expect(delays[0]).toBeGreaterThanOrEqual(100);
+    expect(delays[1]).toBeGreaterThanOrEqual(150);
+    expect(delays[2]).toBeGreaterThanOrEqual(225);
+  });
+
+  it("should cap delay at maxDelayMs", async () => {
+    const timestamps: number[] = [];
+
+    const action = vi.fn(async () => {
+      timestamps.push(Date.now());
+      throw new Error("fail");
+    });
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      4,
+      100,
+      150,
+      alwaysRetry,
+    )();
+
+    await resultPromise;
+
+    const measuredDelays = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+    expect(measuredDelays[1]).toBeLessThanOrEqual(160);
+    expect(measuredDelays[2]).toBeLessThanOrEqual(160);
+    expect(measuredDelays[3]).toBeLessThanOrEqual(160);
+  });
+
+  it("should stop retrying as soon as shouldRetry returns false for an error", async () => {
+    const retriableError = new Error("retriable");
+    const nonRetriableError = new Error("non-retriable");
+    let counter = 0;
+    const action = vi.fn(async () => {
+      counter++;
+      if (counter === 1) throw retriableError;
+      throw nonRetriableError;
+    });
+
+    const shouldRetry = vi.fn((e: Error) => e === retriableError);
+
+    const resultPromise = retryTaskEither(
+      TE.tryCatch(action, (e) => e as Error),
+      3,
+      100,
+      500,
+      shouldRetry,
+    )();
+
+    const result = await resultPromise;
+
+    expect(result).toEqual(E.left(nonRetriableError));
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/external-clients/src/utils/__tests__/retries.test.ts
+++ b/packages/external-clients/src/utils/__tests__/retries.test.ts
@@ -1,6 +1,6 @@
 import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/lib/Either";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { retryTaskEither } from "../retries";
 
 const alwaysRetry = () => true;

--- a/packages/external-clients/src/utils/__tests__/retries.test.ts
+++ b/packages/external-clients/src/utils/__tests__/retries.test.ts
@@ -10,7 +10,10 @@ describe("retryTaskEither", () => {
   it("should return right immediately when action succeeds on the first attempt", async () => {
     const action = TE.right("success");
 
-    const result = await retryTaskEither(action, 3, 100, 500, alwaysRetry)();
+    const result = await retryTaskEither(
+      { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 500 },
+      alwaysRetry,
+    )(action)();
 
     expect(result).toEqual(E.right("success"));
   });
@@ -23,15 +26,10 @@ describe("retryTaskEither", () => {
       return "success";
     });
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      3,
-      100,
-      500,
+    const result = await retryTaskEither(
+      { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 500 },
       alwaysRetry,
-    )();
-
-    const result = await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     expect(result).toEqual(E.right("success"));
     expect(counter).toBe(2);
@@ -41,15 +39,10 @@ describe("retryTaskEither", () => {
     const error = new Error("persistent failure");
     const action = vi.fn(() => Promise.reject(error));
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      3,
-      100,
-      500,
+    const result = await retryTaskEither(
+      { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 500 },
       alwaysRetry,
-    )();
-
-    const result = await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     expect(result).toEqual(E.left(error));
     expect(action).toHaveBeenCalledTimes(4);
@@ -59,15 +52,10 @@ describe("retryTaskEither", () => {
     const error = new Error("non-retriable");
     const action = vi.fn(() => Promise.reject(error));
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      3,
-      100,
-      500,
+    const result = await retryTaskEither(
+      { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 500 },
       neverRetry,
-    )();
-
-    const result = await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     expect(result).toEqual(E.left(error));
     expect(action).toHaveBeenCalledTimes(1);
@@ -77,15 +65,10 @@ describe("retryTaskEither", () => {
     const error = new Error("fail");
     const action = vi.fn(() => Promise.reject(error));
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      0,
-      100,
-      500,
+    const result = await retryTaskEither(
+      { maxRetries: 0, initialDelayMs: 100, maxDelayMs: 500 },
       alwaysRetry,
-    )();
-
-    const result = await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     expect(result).toEqual(E.left(error));
     expect(action).toHaveBeenCalledTimes(1);
@@ -104,15 +87,10 @@ describe("retryTaskEither", () => {
       throw new Error("fail");
     });
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      3,
-      100,
-      500,
+    await retryTaskEither(
+      { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 500 },
       alwaysRetry,
-    )();
-
-    await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     expect(delays[0]).toBeGreaterThanOrEqual(100);
     expect(delays[1]).toBeGreaterThanOrEqual(150);
@@ -127,15 +105,10 @@ describe("retryTaskEither", () => {
       throw new Error("fail");
     });
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      4,
-      100,
-      150,
+    await retryTaskEither(
+      { maxRetries: 4, initialDelayMs: 100, maxDelayMs: 150 },
       alwaysRetry,
-    )();
-
-    await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     const measuredDelays = timestamps.slice(1).map((t, i) => t - timestamps[i]);
     expect(measuredDelays[1]).toBeLessThanOrEqual(160);
@@ -155,15 +128,10 @@ describe("retryTaskEither", () => {
 
     const shouldRetry = vi.fn((e: Error) => e === retriableError);
 
-    const resultPromise = retryTaskEither(
-      TE.tryCatch(action, (e) => e as Error),
-      3,
-      100,
-      500,
+    const result = await retryTaskEither(
+      { maxRetries: 3, initialDelayMs: 100, maxDelayMs: 500 },
       shouldRetry,
-    )();
-
-    const result = await resultPromise;
+    )(TE.tryCatch(action, (e) => e as Error))();
 
     expect(result).toEqual(E.left(nonRetriableError));
     expect(action).toHaveBeenCalledTimes(2);

--- a/packages/external-clients/src/utils/retries.ts
+++ b/packages/external-clients/src/utils/retries.ts
@@ -2,48 +2,56 @@ import * as T from "fp-ts/lib/Task";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type RetryOptions = {
+  readonly initialDelayMs: number;
+  readonly maxDelayMs: number;
+  readonly maxRetries: number;
+};
+
 /**
  * Retries a TaskEither action with exponential backoff.
  *
  * @param action - The TaskEither action to execute and potentially retry.
- * @param maxRetries - Maximum number of retry attempts (0 = no retries).
- * @param initialDelayMs - Initial delay in milliseconds before the first retry.
- * @param maxDelayMs - Maximum delay cap in milliseconds.
+ * @param retryOptions - Retry options for retry operation (undefined or 0 maxRetries means no retries).
  * @param shouldRetry - Predicate to determine if the error is retriable.
  */
-export const retryTaskEither = <E, A>(
-  action: TE.TaskEither<E, A>,
-  maxRetries: number,
-  initialDelayMs: number,
-  maxDelayMs: number,
-  shouldRetry: (error: E) => boolean,
-): TE.TaskEither<E, A> => {
-  const attempt = (
-    retriesLeft: number,
-    currentDelay: number,
-    maxDelay: number,
-  ): TE.TaskEither<E, A> =>
-    pipe(
-      action,
-      TE.orElse((error) => {
-        if (retriesLeft > 0 && shouldRetry(error)) {
-          return pipe(
-            T.delay(currentDelay)(T.of(void 0)),
-            TE.fromTask,
-            TE.mapLeft((_) => error),
-            TE.chain(() =>
-              attempt(
-                retriesLeft - 1,
-                // simple backoff coefficient here
-                Math.min(currentDelay * 1.5, maxDelay),
-                maxDelay,
+export const retryTaskEither =
+  <E, A>(
+    retryOptions: RetryOptions,
+    shouldRetry: (error: E) => boolean,
+  ): ((action: TE.TaskEither<E, A>) => TE.TaskEither<E, A>) =>
+  (action) => {
+    const attempt = (
+      retriesLeft: number,
+      currentDelay: number,
+      maxDelay: number,
+    ): TE.TaskEither<E, A> =>
+      pipe(
+        action,
+        TE.orElse((error) => {
+          if (retriesLeft > 0 && shouldRetry(error)) {
+            return pipe(
+              T.delay(currentDelay)(T.of(void 0)),
+              TE.fromTask,
+              TE.mapLeft((_) => error),
+              TE.chain(() =>
+                attempt(
+                  retriesLeft - 1,
+                  // simple backoff coefficient here
+                  Math.min(currentDelay * 1.5, maxDelay),
+                  maxDelay,
+                ),
               ),
-            ),
-          );
-        }
-        return TE.left(error);
-      }),
-    );
+            );
+          }
+          return TE.left(error);
+        }),
+      );
 
-  return attempt(maxRetries, initialDelayMs, maxDelayMs);
-};
+    return attempt(
+      retryOptions.maxRetries,
+      retryOptions.initialDelayMs,
+      retryOptions.maxDelayMs,
+    );
+  };

--- a/packages/external-clients/src/utils/retries.ts
+++ b/packages/external-clients/src/utils/retries.ts
@@ -2,6 +2,15 @@ import * as T from "fp-ts/lib/Task";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
+/**
+ * Retries a TaskEither action with exponential backoff.
+ *
+ * @param action - The TaskEither action to execute and potentially retry.
+ * @param maxRetries - Maximum number of retry attempts (0 = no retries).
+ * @param initialDelayMs - Initial delay in milliseconds before the first retry.
+ * @param maxDelayMs - Maximum delay cap in milliseconds.
+ * @param shouldRetry - Predicate to determine if the error is retriable.
+ */
 export const retryTaskEither = <E, A>(
   action: TE.TaskEither<E, A>,
   maxRetries: number,

--- a/packages/external-clients/src/utils/retries.ts
+++ b/packages/external-clients/src/utils/retries.ts
@@ -13,7 +13,7 @@ export type RetryOptions = {
  * Retries a TaskEither action with exponential backoff.
  *
  * @param action - The TaskEither action to execute and potentially retry.
- * @param retryOptions - Retry options for retry operation (undefined or 0 maxRetries means no retries).
+ * @param retryOptions - Retry options for retry operation (0 maxRetries means no retries).
  * @param shouldRetry - Predicate to determine if the error is retriable.
  */
 export const retryTaskEither =

--- a/packages/external-clients/src/utils/retries.ts
+++ b/packages/external-clients/src/utils/retries.ts
@@ -1,0 +1,40 @@
+import * as T from "fp-ts/lib/Task";
+import * as TE from "fp-ts/lib/TaskEither";
+import { pipe } from "fp-ts/lib/function";
+
+export const retryTaskEither = <E, A>(
+  action: TE.TaskEither<E, A>,
+  maxRetries: number,
+  initialDelayMs: number,
+  maxDelayMs: number,
+  shouldRetry: (error: E) => boolean,
+): TE.TaskEither<E, A> => {
+  const attempt = (
+    retriesLeft: number,
+    currentDelay: number,
+    maxDelay: number,
+  ): TE.TaskEither<E, A> =>
+    pipe(
+      action,
+      TE.orElse((error) => {
+        if (retriesLeft > 0 && shouldRetry(error)) {
+          return pipe(
+            T.delay(currentDelay)(T.of(void 0)),
+            TE.fromTask,
+            TE.mapLeft((_) => error),
+            TE.chain(() =>
+              attempt(
+                retriesLeft - 1,
+                // simple backoff coefficient here
+                Math.min(currentDelay * 1.5, maxDelay),
+                maxDelay,
+              ),
+            ),
+          );
+        }
+        return TE.left(error);
+      }),
+    );
+
+  return attempt(maxRetries, initialDelayMs, maxDelayMs);
+};


### PR DESCRIPTION
Library treats AbortError as non retryable and doesn't trigger a retry with core-rest-pipeline integrated options. This PR swaps retry method with retries enforced (if options are present). This mechanism is only added to the listSecrets utility but can be extended to other use cases in the future