### PR TITLE
Add permissions for legacy Cosmos DB

### DIFF
--- a/infra/bootstrapper/prod/data.tf
+++ b/infra/bootstrapper/prod/data.tf
@@ -7,3 +7,8 @@ data "azurerm_key_vault_secret" "slack_webhook_url" {
   key_vault_id = data.azurerm_key_vault.svc_kv.id
   name         = "slack-webhook-url-terraform-drift"
 }
+
+data "azurerm_cosmosdb_account" "legacy_api" {
+  name                = local.legacy_cosmosdb.name
+  resource_group_name = local.legacy_cosmosdb.resource_group_name
+}

--- a/infra/bootstrapper/prod/locals.tf
+++ b/infra/bootstrapper/prod/locals.tf
@@ -41,6 +41,11 @@ locals {
     resource_group_name = "io-p-rg-common"
   }
 
+  legacy_cosmosdb = {
+    name                = "${local.prefix}-${local.env_short}-cosmos-api"
+    resource_group_name = "${local.prefix}-${local.env_short}-rg-internal"
+  }
+
   repo_secrets = {
     "SLACK_WEBHOOK_URL" = data.azurerm_key_vault_secret.slack_webhook_url.value
   }

--- a/infra/bootstrapper/prod/rbac.tf
+++ b/infra/bootstrapper/prod/rbac.tf
@@ -10,6 +10,12 @@ resource "azurerm_role_assignment" "storage_blob_tags_contributor_admins" {
   principal_id         = data.azuread_group.admins.object_id
 }
 
+resource "azurerm_role_assignment" "infra_cd_legacy_cosmosdb_account_contributor" {
+  scope                = data.azurerm_cosmosdb_account.legacy_api.id
+  role_definition_name = "DocumentDB Account Contributor"
+  principal_id         = module.repo.identities.infra.cd.principal_id
+}
+
 resource "azurerm_key_vault_access_policy" "infra_cd_kv_common" {
   for_each = toset(local.keyvault_common_ids)
 


### PR DESCRIPTION
Introduce permissions for the legacy Cosmos DB account, including the necessary role assignments and local configurations. This enhances access control for the infrastructure.