### PR TITLE
[IOPID-3989] Make `selcGroups` required in `BackOfficeUserPermissions`

### DIFF
--- a/.changeset/five-worms-pump.md
+++ b/.changeset/five-worms-pump.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-backoffice": patch
+---
+
+Make selcGroups required in BackOfficeUserPermissions

--- a/apps/backoffice/src/app/api/services/__tests__/route.test.ts
+++ b/apps/backoffice/src/app/api/services/__tests__/route.test.ts
@@ -328,12 +328,12 @@ describe("Services API", () => {
 
     it.each`
       scenario                                                                         | userRole                  | selcGroups          | group_id      | mockGetGroup
-      ${"user is operator and has no groups and group is not set"}                     | ${SelfcareRoles.operator} | ${undefined}        | ${undefined}  | ${undefined}
+      ${"user is operator and has no groups and group is not set"}                     | ${SelfcareRoles.operator} | ${[]}               | ${undefined}  | ${undefined}
       ${"user is operator and has groups and group is set and included and is active"} | ${SelfcareRoles.operator} | ${aSelcGroupActive} | ${"aGroupId"} | ${undefined}
-      ${"user is admin and has no groups and group is not set"}                        | ${SelfcareRoles.admin}    | ${undefined}        | ${undefined}  | ${undefined}
+      ${"user is admin and has no groups and group is not set"}                        | ${SelfcareRoles.admin}    | ${[]}               | ${undefined}  | ${undefined}
       ${"user is admin and has groups and group is not set"}                           | ${SelfcareRoles.admin}    | ${aSelcGroupActive} | ${undefined}  | ${undefined}
       ${"user is admin and has groups and group is set and valid"}                     | ${SelfcareRoles.admin}    | ${aSelcGroupActive} | ${aGroup.id}  | ${aSelcGroupActive[0]}
-      ${"user is admin and has no groups and group is set and valid"}                  | ${SelfcareRoles.admin}    | ${undefined}        | ${aGroup.id}  | ${aSelcGroupActive[0]}
+      ${"user is admin and has no groups and group is set and valid"}                  | ${SelfcareRoles.admin}    | ${[]}               | ${aGroup.id}  | ${aSelcGroupActive[0]}
     `(
       "should forward request when $scenario",
       async ({ userRole, selcGroups, group_id, mockGetGroup }) => {

--- a/apps/backoffice/src/app/api/services/route.ts
+++ b/apps/backoffice/src/app/api/services/route.ts
@@ -67,10 +67,7 @@ export const POST = withJWTAuthHandler(
               );
             }
           } else {
-            if (
-              backofficeUser.permissions.selcGroups &&
-              backofficeUser.permissions.selcGroups.length > 0
-            ) {
+            if (backofficeUser.permissions.selcGroups.length > 0) {
               return handleBadRequestErrorResponse("group_id is required");
             }
           }

--- a/apps/backoffice/src/components/services/service-create-update/service-create-update.tsx
+++ b/apps/backoffice/src/components/services/service-create-update/service-create-update.tsx
@@ -71,8 +71,7 @@ export const ServiceCreateUpdate = ({
   const handleOperatorWithSingleGroup = () =>
     hasApiKeyGroupsFeatures(GROUP_APIKEY_ENABLED)(session) &&
     isOperator(session) &&
-    session?.user?.permissions.selcGroups !== undefined &&
-    session.user.permissions.selcGroups.length === 1
+    session?.user.permissions.selcGroups.length === 1
       ? session.user.permissions.selcGroups[0]
       : "";
 

--- a/apps/backoffice/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/backoffice/src/lib/auth/__tests__/auth.test.ts
@@ -116,7 +116,7 @@ const getExpectedUser = (
     apimGroups: apimUser.groups
       .filter((group) => group.type === "custom")
       .map((group) => group.name),
-    selcGroups: jwtPayload.organization.groups,
+    selcGroups: jwtPayload.organization.groups ?? [],
   },
   parameters: {
     userId: apimUser.name,

--- a/apps/backoffice/src/lib/auth/auth.ts
+++ b/apps/backoffice/src/lib/auth/auth.ts
@@ -344,7 +344,7 @@ const toUser = ({
       .filter((group) => group.type === "custom")
       .map((group) => group.name),
     selcGroups: getConfiguration().GROUP_AUTHZ_ENABLED
-      ? identityTokenPayload.organization.groups
-      : undefined,
+      ? (identityTokenPayload.organization.groups ?? [])
+      : [],
   },
 });

--- a/apps/backoffice/src/lib/be/__tests__/authz.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/authz.test.ts
@@ -208,10 +208,9 @@ describe("userAuthz", () => {
 
   describe("hasSelcGroups", () => {
     it.each`
-      scenario                                 | expectedResult | selcGroups
-      ${"the user's selcGroup is not defined"} | ${false}       | ${undefined}
-      ${"the user's selcGroup is empty"}       | ${false}       | ${[]}
-      ${"the user's selcGroup is not empty"}   | ${true}        | ${["group1", "group2"]}
+      scenario                               | expectedResult | selcGroups
+      ${"the user's selcGroup is empty"}     | ${false}       | ${[]}
+      ${"the user's selcGroup is not empty"} | ${true}        | ${["group1", "group2"]}
     `(
       "should return $expectedResult with $scenario",
       ({ expectedResult, selcGroups }) => {

--- a/apps/backoffice/src/lib/be/__tests__/services.test.ts
+++ b/apps/backoffice/src/lib/be/__tests__/services.test.ts
@@ -122,6 +122,7 @@ const aBackofficeUser: BackOfficeUser = {
   id: "selcUserId",
   permissions: {
     apimGroups: ["permission1", "permission2"],
+    selcGroups: [],
   },
   parameters: {
     userEmail: "anEmail@email.it",
@@ -239,7 +240,7 @@ describe("Services TEST", () => {
     it.each`
       scenario                                | backofficeUser
       ${"user is admin with groups"}          | ${{ ...aBackofficeUser, permissions: { ...aBackofficeUser.permissions, selcGroups: ["id"] }, institution: { role: "admin" } }}
-      ${"user is not admin and has no group"} | ${{ ...aBackofficeUser, permissions: { ...aBackofficeUser.permissions, selcGroups: undefined }, institution: { role: "operator" } }}
+      ${"user is not admin and has no group"} | ${{ ...aBackofficeUser, permissions: { ...aBackofficeUser.permissions, selcGroups: [] }, institution: { role: "operator" } }}
     `(
       "request without body request and with response body when $scenario",
       async ({ backofficeUser }) => {
@@ -278,7 +279,7 @@ describe("Services TEST", () => {
             "x-user-groups-selc":
               backofficeUser.institution.role === "admin"
                 ? ""
-                : (backofficeUser.permissions.selcGroups?.join(",") ?? ""),
+                : backofficeUser.permissions.selcGroups.join(","),
             "x-channel": "BO",
           }),
         );
@@ -335,7 +336,7 @@ describe("Services TEST", () => {
             "x-subscription-id": aBackofficeUser.parameters.subscriptionId,
             "x-user-groups": aBackofficeUser.permissions.apimGroups.join(","),
             "x-user-groups-selc":
-              aBackofficeUser.permissions.selcGroups?.join(",") ?? "",
+              aBackofficeUser.permissions.selcGroups.join(","),
             "x-channel": "BO",
           }),
         );
@@ -400,7 +401,7 @@ describe("Services TEST", () => {
           "x-subscription-id": aBackofficeUser.parameters.subscriptionId,
           "x-user-groups": aBackofficeUser.permissions.apimGroups.join(","),
           "x-user-groups-selc":
-            aBackofficeUser.permissions.selcGroups?.join(",") ?? "",
+            aBackofficeUser.permissions.selcGroups.join(","),
           "x-channel": "BO",
           body: aBodyPayload,
           serviceId: "test",
@@ -452,7 +453,7 @@ describe("Services TEST", () => {
           "x-subscription-id": aBackofficeUser.parameters.subscriptionId,
           "x-user-groups": aBackofficeUser.permissions.apimGroups.join(","),
           "x-user-groups-selc":
-            aBackofficeUser.permissions.selcGroups?.join(",") ?? "",
+            aBackofficeUser.permissions.selcGroups.join(","),
           "x-channel": "BO",
           body: aBodyPayload,
           serviceId: "test",
@@ -507,7 +508,7 @@ describe("Services TEST", () => {
           "x-subscription-id": aBackofficeUser.parameters.subscriptionId,
           "x-user-groups": aBackofficeUser.permissions.apimGroups.join(","),
           "x-user-groups-selc":
-            aBackofficeUser.permissions.selcGroups?.join(",") ?? "",
+            aBackofficeUser.permissions.selcGroups.join(","),
           "x-channel": "BO",
           body: aBodyPayload,
           serviceId: "test",
@@ -575,7 +576,7 @@ describe("Services TEST", () => {
           "x-subscription-id": aBackofficeUser.parameters.subscriptionId,
           "x-user-groups": aBackofficeUser.permissions.apimGroups.join(","),
           "x-user-groups-selc":
-            aBackofficeUser.permissions.selcGroups?.join(",") ?? "",
+            aBackofficeUser.permissions.selcGroups.join(","),
           "x-channel": "BO",
           body: aBodyPayload,
           serviceId: "test",
@@ -591,7 +592,7 @@ describe("Services TEST", () => {
     it.each`
       scenario                                | backofficeUser
       ${"user is admin with groups"}          | ${{ ...aBackofficeUser, permissions: { ...aBackofficeUser.permissions, selcGroups: ["id"] }, institution: { role: "admin" } }}
-      ${"user is not admin and has no group"} | ${{ ...aBackofficeUser, permissions: { ...aBackofficeUser.permissions, selcGroups: undefined }, institution: { role: "operator" } }}
+      ${"user is not admin and has no group"} | ${{ ...aBackofficeUser, permissions: { ...aBackofficeUser.permissions, selcGroups: [] }, institution: { role: "operator" } }}
     `(
       "should return a list of services with visibility when $scenario",
       async ({ backofficeUser }) => {
@@ -602,8 +603,7 @@ describe("Services TEST", () => {
           backofficeUser.institution.role === "admin",
         );
         hasSelcGroupsMock.mockReturnValueOnce(
-          backofficeUser.permissions.selcGroups &&
-            backofficeUser.permissions.selcGroups.length > 0,
+          backofficeUser.permissions.selcGroups.length > 0,
         );
 
         getSubscriptionsMock.mockReturnValueOnce(
@@ -1111,10 +1111,10 @@ describe("Services TEST", () => {
 
     const getExpectedGetSubscriptionsFilter = (
       authzServiceIds: string[],
-      selcGroups?: string[],
+      selcGroups: string[],
       serviceId?: string,
     ) =>
-      selcGroups && selcGroups.length > 0
+      selcGroups.length > 0
         ? authzServiceIds.length > 0
           ? serviceId
             ? authzServiceIds.includes(serviceId)
@@ -1126,9 +1126,7 @@ describe("Services TEST", () => {
 
     it.each`
       scenario                                                                                          | selcGroups                                                                                                       | serviceId      | authzServiceIds
-      ${"selcGroups is undefined, serviceId is undefined (authzServiceIds doesn't matters)"}            | ${undefined}                                                                                                     | ${undefined}   | ${undefined}
       ${"selcGroups has no elements, serviceId is undefined (authzServiceIds doesn't matters)"}         | ${[]}                                                                                                            | ${undefined}   | ${undefined}
-      ${"selcGroups is undefined, serviceId is defined (authzServiceIds doesn't matters)"}              | ${undefined}                                                                                                     | ${"serviceId"} | ${undefined}
       ${"selcGroups has no elements, serviceId is defined (authzServiceIds doesn't matters)"}           | ${[]}                                                                                                            | ${"serviceId"} | ${undefined}
       ${"selcGroups has at least one element, serviceId is undefined and authzServiceIds is empty"}     | ${[{ id: "g1", name: "group", state: "ACTIVE" }]}                                                                | ${undefined}   | ${[]}
       ${"selcGroups has at least one element, serviceId is undefined and authzServiceIds is empty"}     | ${[{ id: "group_id", name: "group", state: "SUSPENDED" }]}                                                       | ${undefined}   | ${[]}
@@ -1151,7 +1149,7 @@ describe("Services TEST", () => {
             selcGroups,
           },
         };
-        if (selcGroups && selcGroups.length > 0) {
+        if (selcGroups.length > 0) {
           retrieveAuthorizedServiceIdsMock.mockReturnValueOnce(
             TE.right(authzServiceIds),
           );
@@ -1166,7 +1164,7 @@ describe("Services TEST", () => {
         expect(isAdminMock).toHaveBeenCalledOnce();
         expect(isAdminMock).toHaveBeenCalledWith();
 
-        if (selcGroups && selcGroups.length > 0) {
+        if (selcGroups.length > 0) {
           expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledOnce();
           expect(retrieveAuthorizedServiceIdsMock).toHaveBeenCalledWith(
             selcGroups.map((group) => group.id),

--- a/apps/backoffice/src/lib/be/authz.ts
+++ b/apps/backoffice/src/lib/be/authz.ts
@@ -44,10 +44,7 @@ export const userAuthz = (user: BackOfficeUserEnriched) => {
      * Check if the user has at least one group
      * @returns a boolean indicating whether the user has at least one group
      */
-    hasSelcGroups: (): boolean =>
-      !!(
-        user.permissions.selcGroups && user.permissions.selcGroups.length !== 0
-      ),
+    hasSelcGroups: (): boolean => user.permissions.selcGroups.length !== 0,
     /**
      * Check if the user role is admin
      * @returns a boolean indicating whether the user is admin or not
@@ -76,7 +73,7 @@ export const userAuthz = (user: BackOfficeUserEnriched) => {
      */
     isGroupAllowed: (groupId: string, checkActive?: boolean): boolean => {
       const { selcGroups } = user.permissions;
-      if (isAdmin() || !selcGroups || selcGroups.length === 0) {
+      if (isAdmin() || selcGroups.length === 0) {
         return true;
       }
 

--- a/apps/backoffice/src/lib/be/services/business.ts
+++ b/apps/backoffice/src/lib/be/services/business.ts
@@ -74,7 +74,6 @@ const retrieveSubscriptions = (
   serviceId?: string,
 ): TE.TaskEither<Error, SubscriptionCollection> =>
   !userAuthz(backofficeUser).isAdmin() &&
-  backofficeUser.permissions.selcGroups &&
   backofficeUser.permissions.selcGroups.length > 0
     ? pipe(
         backofficeUser.permissions.selcGroups.map((group) => group.id),
@@ -131,7 +130,7 @@ export const retrieveServiceList = async (
                   retrieveInstitutionGroups(backofficeUser.institution.id, "*"),
                 E.toError,
               )
-            : TE.right(backofficeUser.permissions.selcGroups ?? []),
+            : TE.right(backofficeUser.permissions.selcGroups),
         ),
         TE.map(reduceGrops),
       ),
@@ -272,9 +271,9 @@ export async function forwardIoServicesCmsRequest<
       "x-user-groups": backofficeUser.permissions.apimGroups.join(","),
       "x-user-groups-selc": userAuthz(backofficeUser).isAdmin()
         ? ""
-        : (backofficeUser.permissions.selcGroups
-            ?.map((group) => group.id)
-            .join(",") ?? ""),
+        : backofficeUser.permissions.selcGroups
+            .map((group) => group.id)
+            .join(","),
       "x-user-id": backofficeUser.parameters.userId,
     };
 

--- a/apps/backoffice/src/lib/be/wrappers.ts
+++ b/apps/backoffice/src/lib/be/wrappers.ts
@@ -44,10 +44,8 @@ export const withJWTAuthHandler =
       institutionGroups =
         institutionGroups ??
         (await retrieveInstitutionGroups(session.user.institution.id, "*"));
-      selcGroups = institutionGroups.filter(
-        (institutionGroup) =>
-          session.user.permissions.selcGroups?.includes(institutionGroup.id) ??
-          false,
+      selcGroups = institutionGroups.filter((institutionGroup) =>
+        session.user.permissions.selcGroups.includes(institutionGroup.id),
       );
     }
 

--- a/apps/backoffice/src/utils/__tests__/auth-util.test.ts
+++ b/apps/backoffice/src/utils/__tests__/auth-util.test.ts
@@ -160,6 +160,7 @@ describe("[auth utils] hasAtLeastOneGroup", () => {
     user: {
       permissions: {
         apimGroups: ["ApiServiceRead"],
+        selcGroups: [],
       },
       institution: { role: "operator" },
     },
@@ -198,7 +199,7 @@ describe("[auth utils] hasAtLeastOneGroup", () => {
     },
   };
 
-  it("should return false for a session without groups", () => {
+  it("should return false for a session with no groups", () => {
     const result = isAtLeastInOneGroup(aSessionWithoutGroups);
     expect(result).toBe(false);
   });

--- a/apps/backoffice/src/utils/auth-util.ts
+++ b/apps/backoffice/src/utils/auth-util.ts
@@ -42,8 +42,7 @@ export const hasAggregatorFeatures =
 
 /** Check if user is in one or more Selfcare Group  */
 export const isAtLeastInOneGroup = (session: Session | null) =>
-  session?.user?.permissions?.selcGroups !== undefined &&
-  session?.user?.permissions?.selcGroups?.length > 0;
+  (session?.user.permissions.selcGroups.length ?? 0) > 0;
 
 export const isGroupRequired = (
   session: Session | null,

--- a/apps/backoffice/types/next-auth.d.ts
+++ b/apps/backoffice/types/next-auth.d.ts
@@ -14,7 +14,7 @@ export interface Institution {
 
 export interface BackOfficeUserPermissions {
   apimGroups: string[];
-  selcGroups?: string[];
+  selcGroups: string[];
 }
 
 export interface BackOfficeUserParameters {


### PR DESCRIPTION
This PR makes the `selcGroups` in `BackOfficeUserPermissions` a required array (defaulting to `[]` when no groups are present), instead of being possibly `undefined`