### PR TITLE
fix `USE_MANAGED_IDENTITY=false` behaviour

### DIFF
--- a/.changeset/long-zoos-laugh.md
+++ b/.changeset/long-zoos-laugh.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": patch
+---
+
+Fix USE_MANAGED_IDENTITY=false behaviour

--- a/apps/io-services-cms-webapp/src/__tests__/config.test.ts
+++ b/apps/io-services-cms-webapp/src/__tests__/config.test.ts
@@ -141,24 +141,56 @@ describe("RuntimeModeConfiguration", () => {
 
     expect(E.isLeft(result)).toBe(true);
   });
-});
 
-describe("IConfig", () => {
-  it("should allow managed identity mode without fallback connection strings", () => {
-    const result = IConfig.decode({
-      ...sharedSettings,
-      USE_MANAGED_IDENTITY: "true",
-      ...managedIdentitySettings,
+  it("should allow connection string mode when all fallback settings are provided and no managed identity settings are present", () => {
+    const result = RuntimeModeConfiguration.decode({
+      USE_MANAGED_IDENTITY: "false",
+      ...fallbackSettings,
     });
 
     if (E.isLeft(result)) {
       throw new Error(readableReport(result.left));
     }
 
+    expect(result.right.USE_MANAGED_IDENTITY).toBe(false);
+  });
+});
+
+describe("IConfig", () => {
+  it("should allow only managed identity mode without fallback connection strings", () => {
+    const result = IConfig.decode({
+      ...sharedSettings,
+      USE_MANAGED_IDENTITY: "true",
+      ...managedIdentitySettings,
+    });
+
     expect(E.isRight(result)).toBe(true);
   });
 
-  it("should require fallback connection strings when managed identity mode is disabled", () => {
+  it("should require all managed identity settings when managed identity mode is enabled", () => {
+    const { CMS_COSMOSDB__accountEndpoint, ...partialManagedIdentitySettings } =
+      managedIdentitySettings;
+
+    const result = IConfig.decode({
+      ...sharedSettings,
+      USE_MANAGED_IDENTITY: "true",
+      ...partialManagedIdentitySettings,
+    });
+
+    expect(E.isLeft(result)).toBe(true);
+  });
+
+  it("should allow only fallback connection strings when managed identity mode is disabled", () => {
+    const result = IConfig.decode({
+      ...sharedSettings,
+      USE_MANAGED_IDENTITY: "false",
+      ...fallbackSettings,
+    });
+
+    expect(E.isRight(result)).toBe(true);
+  });
+
+  it("should require all fallback connection strings when managed identity mode is disabled", () => {
     const { ACTIVATIONS_EVENT_HUB_CONNECTION_STRING, ...partialFallback } =
       fallbackSettings;
 

--- a/apps/io-services-cms-webapp/src/config.ts
+++ b/apps/io-services-cms-webapp/src/config.ts
@@ -128,8 +128,8 @@ const RuntimeModeConfigurationCodec: t.Type<
           RuntimeModeEnabledSettings.validate(input, context),
           E.map(
             (settings): RuntimeModeEnabledConfiguration => ({
-              USE_MANAGED_IDENTITY: true,
               ...settings,
+              USE_MANAGED_IDENTITY: true,
             }),
           ),
         )
@@ -137,8 +137,8 @@ const RuntimeModeConfigurationCodec: t.Type<
           RuntimeModeDisabledSettings.validate(input, context),
           E.map(
             (settings): RuntimeModeDisabledConfiguration => ({
-              USE_MANAGED_IDENTITY: false,
               ...settings,
+              USE_MANAGED_IDENTITY: false,
             }),
           ),
         );
@@ -589,8 +589,8 @@ const IConfigCodec: t.Type<
           ManagedIdentityAppConfigurationSettings.validate(input, context),
           E.map(
             (settings): ManagedIdentityAppConfiguration => ({
-              USE_MANAGED_IDENTITY: true,
               ...settings,
+              USE_MANAGED_IDENTITY: true,
             }),
           ),
         )
@@ -598,8 +598,8 @@ const IConfigCodec: t.Type<
           FallbackAppConfigurationSettings.validate(input, context),
           E.map(
             (settings): FallbackAppConfiguration => ({
-              USE_MANAGED_IDENTITY: false,
               ...settings,
+              USE_MANAGED_IDENTITY: false,
             }),
           ),
         );


### PR DESCRIPTION
Even when `USE_MANAGED_IDENTITY` was  `false` the managedIdentity configurations were still required otherwise the application wasn't boot.