### PR TITLE
fix unwanted behaviour on app service plang scaling

### DIFF
--- a/infra/resources/_modules/cms_function_app/monitoring.tf
+++ b/infra/resources/_modules/cms_function_app/monitoring.tf
@@ -40,20 +40,6 @@ module "function_profile_autoscale" {
       decrease_by               = 1
       cooldown_decrease         = 5
     }
-    memory = {
-      upper_threshold           = 85
-      statistic_increase        = "Average"
-      time_aggregation_increase = "Average"
-      time_window_increase      = 1
-      increase_by               = 1
-      cooldown_increase         = 5
-      lower_threshold           = 55
-      statistic_decrease        = "Average"
-      time_aggregation_decrease = "Average"
-      time_window_decrease      = 5
-      decrease_by               = 1
-      cooldown_decrease         = 5
-    }
     requests = {
       upper_threshold           = 500
       statistic_increase        = "Max"


### PR DESCRIPTION
Remove memory-based scaling rule to prevent instances getting stuck at max capacity.