### PR TITLE
Map `suitable_for_minors` on service converters for GetServicePublication and GetServiceHistory

### DIFF
--- a/.changeset/sharp-kangaroos-brake.md
+++ b/.changeset/sharp-kangaroos-brake.md
@@ -1,0 +1,5 @@
+---
+"io-services-cms-webapp": minor
+---
+
+Map suitable_for_minors on service converters for GetServicePublication and GetServiceHistory

--- a/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-common-converters.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-common-converters.test.ts
@@ -1,0 +1,73 @@
+import { ServiceLifecycle } from "@io-services-cms/models";
+import { describe, expect, test } from "vitest";
+
+import { IConfig } from "../../../config";
+import { ScopeEnum } from "../../../generated/api/ServiceBaseMetadata";
+import {
+  ageToSuitableForMinors,
+  toScopeType,
+  withSuitableForMinors,
+} from "../service-common-converters";
+
+type Age = ServiceLifecycle.definitions.Service["data"]["age"];
+
+const buildAge = (age?: { max?: number; min?: number }): Age => age as Age;
+
+describe("ageToSuitableForMinors", () => {
+  test("age.min below 18 should be suitable for minors", () => {
+    expect(ageToSuitableForMinors(buildAge({ min: 14 }))).toBe(true);
+  });
+
+  test("age.min equal to 18 should not be suitable for minors", () => {
+    expect(ageToSuitableForMinors(buildAge({ min: 18 }))).toBe(false);
+  });
+
+  test("age.min above 18 should not be suitable for minors", () => {
+    expect(ageToSuitableForMinors(buildAge({ min: 21 }))).toBe(false);
+  });
+
+  test("undefined age should not be suitable for minors", () => {
+    expect(ageToSuitableForMinors(undefined)).toBe(false);
+  });
+
+  test("age without min should not be suitable for minors", () => {
+    expect(ageToSuitableForMinors(buildAge({ max: 65 }))).toBe(false);
+  });
+});
+
+describe("withSuitableForMinors", () => {
+  const enabledConfig = {
+    FF_SUITABLE_FOR_MINORS_ENABLED: true,
+  } as unknown as IConfig;
+  const disabledConfig = {
+    FF_SUITABLE_FOR_MINORS_ENABLED: false,
+  } as unknown as IConfig;
+
+  test("should expose suitable_for_minors true when flag enabled and age suitable", () => {
+    expect(withSuitableForMinors(enabledConfig)(buildAge({ min: 14 }))).toEqual({
+      suitable_for_minors: true,
+    });
+  });
+
+  test("should expose suitable_for_minors false when flag enabled and age not suitable", () => {
+    expect(withSuitableForMinors(enabledConfig)(buildAge({ min: 18 }))).toEqual({
+      suitable_for_minors: false,
+    });
+  });
+
+  test("should omit suitable_for_minors when flag disabled", () => {
+    expect(withSuitableForMinors(disabledConfig)(buildAge({ min: 14 }))).toEqual(
+      {},
+    );
+  });
+});
+
+describe("toScopeType", () => {
+  test("should map LOCAL scope", () => {
+    expect(toScopeType("LOCAL")).toBe(ScopeEnum.LOCAL);
+  });
+
+  test("should map NATIONAL scope", () => {
+    expect(toScopeType("NATIONAL")).toBe(ScopeEnum.NATIONAL);
+  });
+});

--- a/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-history-converters.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-history-converters.test.ts
@@ -1,0 +1,227 @@
+import { ServiceHistory as ServiceHistoryCosmosItem } from "@io-services-cms/models";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+import * as TE from "fp-ts/lib/TaskEither";
+import { describe, expect, test, vi } from "vitest";
+
+import { IConfig } from "../../../config";
+import { ScopeEnum } from "../../../generated/api/ServiceBaseMetadata";
+import { ServiceHistoryStatusKindEnum } from "../../../generated/api/ServiceHistoryStatusKind";
+import { ServiceHistoryStatusTypeEnum } from "../../../generated/api/ServiceHistoryStatusType";
+import {
+  buildStatus,
+  itemToResponse,
+  itemsToResponse,
+} from "../service-history-converters";
+
+const { getServiceTopicDao } = vi.hoisted(() => ({
+  getServiceTopicDao: vi.fn(() => ({
+    findById: vi.fn((id: number) =>
+      TE.right(O.some({ id, name: "topic name" })),
+    ),
+  })),
+}));
+
+vi.mock("../../../utils/service-topic-dao", () => ({
+  getDao: getServiceTopicDao,
+}));
+
+const mockConfig = {
+  FF_SUITABLE_FOR_MINORS_ENABLED: true,
+} as unknown as IConfig;
+
+const aBaseItem = {
+  data: {
+    authorized_cidrs: [],
+    authorized_recipients: [],
+    description: "a description",
+    max_allowed_payment_amount: 0,
+    metadata: {
+      scope: "LOCAL",
+      topic_id: 1,
+    },
+    name: "a service",
+    organization: {
+      fiscal_code: "00000000000",
+      name: "org",
+    },
+    require_secure_channel: false,
+  },
+  fsm: { state: "approved" },
+  last_update: "2023-01-01T00:00:00.000Z",
+  serviceId: "aServiceId",
+} as unknown as ServiceHistoryCosmosItem;
+
+const buildItemWithAge = (age?: { max?: number; min?: number }) =>
+  ({
+    ...aBaseItem,
+    data: { ...aBaseItem.data, age },
+  }) as unknown as ServiceHistoryCosmosItem;
+
+// The suitable_for_minors mapping logic is unit-tested in
+// service-common-converters.test.ts; here we only assert the converter wires it
+// up correctly (field exposed/omitted, internal age never leaked, applied per item).
+describe("itemToResponse suitable_for_minors integration", () => {
+  test("should expose suitable_for_minors when the feature flag is enabled", async () => {
+    const result = await itemToResponse(mockConfig)(
+      buildItemWithAge({ min: 14 }),
+    )();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.suitable_for_minors).toBe(true);
+    }
+  });
+
+  test("should omit suitable_for_minors when the feature flag is disabled", async () => {
+    const disabledConfig = {
+      FF_SUITABLE_FOR_MINORS_ENABLED: false,
+    } as unknown as IConfig;
+    const result = await itemToResponse(disabledConfig)(
+      buildItemWithAge({ min: 14 }),
+    )();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect("suitable_for_minors" in result.right).toBe(false);
+    }
+  });
+
+  test("response should not expose the internal age field", async () => {
+    const result = await itemToResponse(mockConfig)(
+      buildItemWithAge({ min: 14 }),
+    )();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect((result.right as Record<string, unknown>).age).toBeUndefined();
+    }
+  });
+});
+
+describe("itemsToResponse suitable_for_minors mapping", () => {
+  test("should map suitable_for_minors on every item", async () => {
+    const result = await itemsToResponse(mockConfig)([
+      buildItemWithAge({ min: 14 }),
+      buildItemWithAge({ min: 18 }),
+    ])();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right).toHaveLength(2);
+      expect(result.right[0].suitable_for_minors).toBe(true);
+      expect(result.right[1].suitable_for_minors).toBe(false);
+    }
+  });
+});
+
+describe("buildStatus", () => {
+  test.each(["approved", "deleted", "draft", "submitted"] as const)(
+    "should map lifecycle state %s",
+    (state) => {
+      expect(buildStatus({ state })).toEqual({
+        kind: ServiceHistoryStatusKindEnum.lifecycle,
+        value: ServiceHistoryStatusTypeEnum[state],
+      });
+    },
+  );
+
+  test("should map rejected state keeping the reason", () => {
+    expect(
+      buildStatus({
+        reason: "a reason",
+        state: "rejected",
+      }),
+    ).toEqual({
+      kind: ServiceHistoryStatusKindEnum.lifecycle,
+      reason: "a reason",
+      value: ServiceHistoryStatusTypeEnum.rejected,
+    });
+  });
+
+  test.each(["published", "unpublished"] as const)(
+    "should map publication state %s",
+    (state) => {
+      expect(buildStatus({ state })).toEqual({
+        kind: ServiceHistoryStatusKindEnum.publication,
+        value: ServiceHistoryStatusTypeEnum[state],
+      });
+    },
+  );
+});
+
+describe("itemToResponse mapping", () => {
+  test("should map id, status and mapped scope", async () => {
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.id).toBe("aServiceId");
+      expect(result.right.status).toEqual({
+        kind: ServiceHistoryStatusKindEnum.lifecycle,
+        value: ServiceHistoryStatusTypeEnum.approved,
+      });
+      expect(result.right.metadata.scope).toBe(ScopeEnum.LOCAL);
+    }
+  });
+
+  test("should resolve the topic when topic_id is set", async () => {
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.metadata.topic).toEqual({
+        id: 1,
+        name: "topic name",
+      });
+    }
+  });
+
+  test("should leave the topic undefined when topic_id is not set", async () => {
+    const itemWithoutTopic = {
+      ...aBaseItem,
+      data: {
+        ...aBaseItem.data,
+        metadata: { scope: "LOCAL" },
+      },
+    } as unknown as ServiceHistoryCosmosItem;
+    const result = await itemToResponse(mockConfig)(itemWithoutTopic)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.metadata.topic).toBeUndefined();
+    }
+  });
+
+  test("should fail when the topic_id cannot be resolved", async () => {
+    getServiceTopicDao.mockReturnValueOnce({
+      findById: vi.fn(() => TE.right(O.none)),
+    });
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isLeft(result)).toBe(true);
+  });
+
+  test("should keep the existing last_update", async () => {
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.last_update).toBe("2023-01-01T00:00:00.000Z");
+    }
+  });
+
+  test("should not expose internal metadata fields", async () => {
+    const itemWithInternalMetadata = {
+      ...aBaseItem,
+      data: {
+        ...aBaseItem.data,
+        metadata: {
+          category: "STANDARD",
+          custom_special_flow: "aFlow",
+          scope: "LOCAL",
+          topic_id: 1,
+        },
+      },
+    } as unknown as ServiceHistoryCosmosItem;
+    const result = await itemToResponse(mockConfig)(itemWithInternalMetadata)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      const metadata = result.right.metadata as Record<string, unknown>;
+      expect(metadata.category).toBeUndefined();
+      expect(metadata.custom_special_flow).toBeUndefined();
+      expect(metadata.topic_id).toBeUndefined();
+    }
+  });
+});

--- a/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-lifecycle-converters.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-lifecycle-converters.test.ts
@@ -4,7 +4,7 @@ import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { describe, expect, test, vi } from "vitest";
-import { TopicPostgreSqlConfig } from "../../../config";
+import { IConfig, TopicPostgreSqlConfig } from "../../../config";
 import { FiscalCode } from "../../../generated/api/FiscalCode";
 import { ServicePayload } from "../../../generated/api/ServicePayload";
 import {
@@ -34,7 +34,7 @@ const aSandboxFiscalCode = "AAAAAA00A00A000A";
 
 const mockDbConfig = {
   FF_SUITABLE_FOR_MINORS_ENABLED: true,
-} as unknown as TopicPostgreSqlConfig;
+} as unknown as IConfig;
 
 describe("test service-lifecycle-converters", () => {
   test("test service-lifecycle-converters", () => {
@@ -282,7 +282,7 @@ describe("itemToResponse suitable_for_minors mapping", () => {
   test("suitable_for_minors should be omitted when the feature flag is disabled", async () => {
     const disabledConfig = {
       FF_SUITABLE_FOR_MINORS_ENABLED: false,
-    } as unknown as TopicPostgreSqlConfig;
+    } as unknown as IConfig;
     const result = await itemToResponse(disabledConfig)(
       buildItemWithAge({ min: 14 }),
     )();

--- a/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-publication-converters.test.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/__tests__/service-publication-converters.test.ts
@@ -1,0 +1,198 @@
+import { DateUtils, ServicePublication } from "@io-services-cms/models";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+import * as TE from "fp-ts/lib/TaskEither";
+import { describe, expect, test, vi } from "vitest";
+
+import { IConfig } from "../../../config";
+import { ScopeEnum } from "../../../generated/api/ServiceBaseMetadata";
+import { ServicePublicationStatusTypeEnum } from "../../../generated/api/ServicePublicationStatusType";
+import {
+  itemToResponse,
+  toServiceStatusType,
+} from "../service-publication-converters";
+
+const { getServiceTopicDao } = vi.hoisted(() => ({
+  getServiceTopicDao: vi.fn(() => ({
+    findById: vi.fn((id: number) =>
+      TE.right(O.some({ id, name: "topic name" })),
+    ),
+  })),
+}));
+
+vi.mock("../../../utils/service-topic-dao", () => ({
+  getDao: getServiceTopicDao,
+}));
+
+const mockConfig = {
+  FF_SUITABLE_FOR_MINORS_ENABLED: true,
+} as unknown as IConfig;
+
+const aBaseItem = {
+  data: {
+    authorized_cidrs: [],
+    authorized_recipients: [],
+    description: "a description",
+    max_allowed_payment_amount: 0,
+    metadata: {
+      scope: "LOCAL",
+      topic_id: 1,
+    },
+    name: "a service",
+    organization: {
+      fiscal_code: "00000000000",
+      name: "org",
+    },
+    require_secure_channel: false,
+  },
+  fsm: { state: "published" },
+  id: "aServiceId",
+} as unknown as ServicePublication.ItemType;
+
+const buildItemWithAge = (age?: { max?: number; min?: number }) =>
+  ({
+    ...aBaseItem,
+    data: { ...aBaseItem.data, age },
+  }) as unknown as ServicePublication.ItemType;
+
+// The suitable_for_minors mapping logic is unit-tested in
+// service-common-converters.test.ts; here we only assert the converter wires it
+// up correctly (field exposed/omitted, internal age never leaked).
+describe("itemToResponse suitable_for_minors integration", () => {
+  const enabledConfig = {
+    FF_SUITABLE_FOR_MINORS_ENABLED: true,
+  } as unknown as IConfig;
+
+  test("should expose suitable_for_minors when the feature flag is enabled", async () => {
+    const result = await itemToResponse(enabledConfig)(
+      buildItemWithAge({ min: 14 }),
+    )();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.suitable_for_minors).toBe(true);
+    }
+  });
+
+  test("should omit suitable_for_minors when the feature flag is disabled", async () => {
+    const disabledConfig = {
+      FF_SUITABLE_FOR_MINORS_ENABLED: false,
+    } as unknown as IConfig;
+    const result = await itemToResponse(disabledConfig)(
+      buildItemWithAge({ min: 14 }),
+    )();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect("suitable_for_minors" in result.right).toBe(false);
+    }
+  });
+
+  test("response should not expose the internal age field", async () => {
+    const result = await itemToResponse(enabledConfig)(
+      buildItemWithAge({ min: 14 }),
+    )();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect((result.right as Record<string, unknown>).age).toBeUndefined();
+    }
+  });
+});
+
+describe("toServiceStatusType", () => {
+  test("should map published state", () => {
+    expect(toServiceStatusType("published")).toBe(
+      ServicePublicationStatusTypeEnum.published,
+    );
+  });
+
+  test("should map unpublished state", () => {
+    expect(toServiceStatusType("unpublished")).toBe(
+      ServicePublicationStatusTypeEnum.unpublished,
+    );
+  });
+});
+
+describe("itemToResponse mapping", () => {
+  test("should map id, status and mapped scope", async () => {
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.id).toBe("aServiceId");
+      expect(result.right.status).toBe(
+        ServicePublicationStatusTypeEnum.published,
+      );
+      expect(result.right.metadata.scope).toBe(ScopeEnum.LOCAL);
+    }
+  });
+
+  test("should resolve the topic when topic_id is set", async () => {
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.metadata.topic).toEqual({
+        id: 1,
+        name: "topic name",
+      });
+    }
+  });
+
+  test("should leave the topic undefined when topic_id is not set", async () => {
+    const itemWithoutTopic = {
+      ...aBaseItem,
+      data: {
+        ...aBaseItem.data,
+        metadata: { scope: "LOCAL" },
+      },
+    } as unknown as ServicePublication.ItemType;
+    const result = await itemToResponse(mockConfig)(itemWithoutTopic)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.metadata.topic).toBeUndefined();
+    }
+  });
+
+  test("should fail when the topic_id cannot be resolved", async () => {
+    getServiceTopicDao.mockReturnValueOnce({
+      findById: vi.fn(() => TE.right(O.none)),
+    });
+    const result = await itemToResponse(mockConfig)(aBaseItem)();
+    expect(E.isLeft(result)).toBe(true);
+  });
+
+  test("should derive last_update from modified_at when present", async () => {
+    const modified_at = 1_700_000_000_000;
+    const itemWithModifiedAt = {
+      ...aBaseItem,
+      modified_at,
+    } as unknown as ServicePublication.ItemType;
+    const result = await itemToResponse(mockConfig)(itemWithModifiedAt)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.last_update).toBe(
+        DateUtils.isoStringfromUnixMillis(modified_at),
+      );
+    }
+  });
+
+  test("should not expose internal metadata fields", async () => {
+    const itemWithInternalMetadata = {
+      ...aBaseItem,
+      data: {
+        ...aBaseItem.data,
+        metadata: {
+          category: "STANDARD",
+          custom_special_flow: "aFlow",
+          scope: "LOCAL",
+          topic_id: 1,
+        },
+      },
+    } as unknown as ServicePublication.ItemType;
+    const result = await itemToResponse(mockConfig)(itemWithInternalMetadata)();
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      const metadata = result.right.metadata as Record<string, unknown>;
+      expect(metadata.category).toBeUndefined();
+      expect(metadata.custom_special_flow).toBeUndefined();
+      expect(metadata.topic_id).toBeUndefined();
+    }
+  });
+});

--- a/apps/io-services-cms-webapp/src/utils/converters/service-common-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-common-converters.ts
@@ -1,0 +1,49 @@
+import { ServiceLifecycle } from "@io-services-cms/models";
+
+import { IConfig } from "../../config";
+import { ScopeEnum } from "../../generated/api/ServiceBaseMetadata";
+
+const ADULT_AGE = 18;
+
+/**
+ * Service Lifecycle age => API DTO suitable_for_minors mapping
+ * If a service has a min age set ant it's below 18, then suitable_for_minors is true.
+ * Otherwise, it's false.
+ * @param age
+ * @returns
+ */
+export const ageToSuitableForMinors = (
+  age: ServiceLifecycle.definitions.Service["data"]["age"],
+): boolean => (age?.min === undefined ? false : age.min < ADULT_AGE);
+
+/**
+ * Builds the optional `suitable_for_minors` response fragment, gated by the
+ * `FF_SUITABLE_FOR_MINORS_ENABLED` feature flag.
+ * When the flag is disabled the field is omitted to preserve backward
+ * compatibility for external read consumers.
+ *
+ * @param config the app config exposing the feature flag
+ * @returns a function mapping a service age to the response fragment
+ */
+export const withSuitableForMinors =
+  (config: Pick<IConfig, "FF_SUITABLE_FOR_MINORS_ENABLED">) =>
+  (
+    age: ServiceLifecycle.definitions.Service["data"]["age"],
+  ): { suitable_for_minors: boolean } | Record<string, never> =>
+    config.FF_SUITABLE_FOR_MINORS_ENABLED
+      ? { suitable_for_minors: ageToSuitableForMinors(age) }
+      : {};
+
+export const toScopeType = (
+  s: ServiceLifecycle.ItemType["data"]["metadata"]["scope"],
+): ScopeEnum => {
+  switch (s) {
+    case "LOCAL":
+    case "NATIONAL":
+      return ScopeEnum[s];
+    default:
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-case-declarations
+      const _: never = s;
+      return ScopeEnum[s];
+  }
+};

--- a/apps/io-services-cms-webapp/src/utils/converters/service-common-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-common-converters.ts
@@ -7,7 +7,7 @@ const ADULT_AGE = 18;
 
 /**
  * Service Lifecycle age => API DTO suitable_for_minors mapping
- * If a service has a min age set ant it's below 18, then suitable_for_minors is true.
+ * If a service has a min age set and it's below 18, then suitable_for_minors is true.
  * Otherwise, it's false.
  * @param age
  * @returns

--- a/apps/io-services-cms-webapp/src/utils/converters/service-history-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-history-converters.ts
@@ -3,25 +3,29 @@ import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
-import { TopicPostgreSqlConfig } from "../../config";
+import { IConfig, TopicPostgreSqlConfig } from "../../config";
 import { ServiceHistoryItem as ServiceResponsePayload } from "../../generated/api/ServiceHistoryItem";
 import { ServiceHistoryItemStatus } from "../../generated/api/ServiceHistoryItemStatus";
 import { ServiceHistoryStatusKindEnum } from "../../generated/api/ServiceHistoryStatusKind";
 import { ServiceHistoryStatusTypeEnum } from "../../generated/api/ServiceHistoryStatusType";
 import { getDao as getServiceTopicDao } from "../service-topic-dao";
-import { toScopeType } from "./service-lifecycle-converters";
+import {
+  toScopeType,
+  withSuitableForMinors,
+} from "./service-common-converters";
 
 export const itemsToResponse =
-  (dbConfig: TopicPostgreSqlConfig) =>
+  (dbConfig: IConfig) =>
   (
     items: readonly ServiceHistoryCosmosItem[],
   ): TE.TaskEither<Error, readonly ServiceResponsePayload[]> =>
     pipe(items, TE.traverseArray(itemToResponse(dbConfig)));
 
 export const itemToResponse =
-  (dbConfig: TopicPostgreSqlConfig) =>
+  (dbConfig: IConfig) =>
   ({
     data: {
+      age,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       metadata: { category, custom_special_flow, scope, topic_id, ...metadata },
       ...data
@@ -36,6 +40,7 @@ export const itemToResponse =
         id: serviceId,
         last_update: last_update ?? new Date().toISOString(),
         status: buildStatus(fsm),
+        ...withSuitableForMinors(dbConfig)(age),
         ...data,
         metadata: {
           ...metadata,

--- a/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-lifecycle-converters.ts
@@ -9,12 +9,18 @@ import { pipe } from "fp-ts/lib/function";
 import { IConfig, TopicPostgreSqlConfig } from "../../config";
 import { Cidr } from "../../generated/api/Cidr";
 import { FiscalCode } from "../../generated/api/FiscalCode";
-import { ScopeEnum } from "../../generated/api/ServiceBaseMetadata";
 import { ServiceLifecycle as ServiceResponsePayload } from "../../generated/api/ServiceLifecycle";
 import { ServiceLifecycleStatus } from "../../generated/api/ServiceLifecycleStatus";
 import { ServiceLifecycleStatusTypeEnum } from "../../generated/api/ServiceLifecycleStatusType";
 import { ServicePayload as ServiceRequestPayload } from "../../generated/api/ServicePayload";
 import { getDao as getServiceTopicDao } from "../service-topic-dao";
+import {
+  toScopeType,
+  withSuitableForMinors,
+} from "./service-common-converters";
+
+// Min age for a service is 14 years old
+const SUITABLE_FOR_MINORS_MIN_AGE = 14;
 
 export const payloadToItem = (
   id: ServiceLifecycle.definitions.Service["id"],
@@ -54,10 +60,6 @@ const calculateItemAuthorizedRecipients = (
     ? [...authorizedRecipients]
     : [...authorizedRecipients, sandboxFiscalCode];
 
-// Min age for a service is 14 years old
-const SUITABLE_FOR_MINORS_MIN_AGE = 14;
-const ADULT_AGE = 18;
-
 /**
  * API DTO => Service Lifecycle age mapping
  * If a service is suitable, the min age is set to 14.
@@ -76,17 +78,6 @@ const suitableForMinorsToAge = (
         >,
       }
     : undefined;
-
-/**
- * Service Lifecycle age => API DTO suitable_for_minors mapping
- * If a service has a min age set ant it's below 18, then suitable_for_minors is true.
- * Otherwise, it's false.
- * @param age
- * @returns
- */
-const ageToSuitableForMinors = (
-  age: ServiceLifecycle.definitions.Service["data"]["age"],
-): boolean => (age?.min !== undefined ? age.min < ADULT_AGE : false);
 
 export const itemToResponse =
   (
@@ -117,9 +108,7 @@ export const itemToResponse =
             ? DateUtils.isoStringfromUnixMillis(modified_at)
             : new Date().toISOString(),
           status: toServiceStatus(fsm),
-          ...(config.FF_SUITABLE_FOR_MINORS_ENABLED
-            ? { suitable_for_minors: ageToSuitableForMinors(age) }
-            : {}),
+          ...withSuitableForMinors(config)(age),
           ...data,
           metadata: {
             ...metadata,
@@ -170,19 +159,5 @@ export const toServiceStatus = (
       // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-case-declarations
       const _: never = fsm;
       return ServiceLifecycleStatusTypeEnum[fsm];
-  }
-};
-
-export const toScopeType = (
-  s: ServiceLifecycle.ItemType["data"]["metadata"]["scope"],
-): ScopeEnum => {
-  switch (s) {
-    case "LOCAL":
-    case "NATIONAL":
-      return ScopeEnum[s];
-    default:
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-case-declarations
-      const _: never = s;
-      return ScopeEnum[s];
   }
 };

--- a/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
+++ b/apps/io-services-cms-webapp/src/utils/converters/service-publication-converters.ts
@@ -6,19 +6,23 @@ import {
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
-import { TopicPostgreSqlConfig } from "../../config";
+import { IConfig, TopicPostgreSqlConfig } from "../../config";
 import { ServicePublication as ServiceResponsePayload } from "../../generated/api/ServicePublication";
 import {
   ServicePublicationStatusType,
   ServicePublicationStatusTypeEnum,
 } from "../../generated/api/ServicePublicationStatusType";
 import { getDao as getServiceTopicDao } from "../service-topic-dao";
-import { toScopeType } from "./service-lifecycle-converters";
+import {
+  toScopeType,
+  withSuitableForMinors,
+} from "./service-common-converters";
 
 export const itemToResponse =
-  (dbConfig: TopicPostgreSqlConfig) =>
+  (config: IConfig) =>
   ({
     data: {
+      age,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       metadata: { category, custom_special_flow, scope, topic_id, ...metadata },
       ...data
@@ -31,7 +35,7 @@ export const itemToResponse =
     ServiceResponsePayload
   > =>
     pipe(
-      toServiceTopic(dbConfig)(id, topic_id),
+      toServiceTopic(config)(id, topic_id),
       TE.bimap(
         (err) => ResponseErrorInternal(err.message),
         (topic) => ({
@@ -40,6 +44,7 @@ export const itemToResponse =
             ? DateUtils.isoStringfromUnixMillis(modified_at)
             : new Date().toISOString(),
           status: toServiceStatusType(state),
+          ...withSuitableForMinors(config)(age),
           ...data,
           metadata: {
             ...metadata,


### PR DESCRIPTION
Closes IOCOM-3249

# Refactor: centralize `suitable_for_minors` mapping in service converters

## Context
The mapping logic between `age` (internal model) and `suitable_for_minors` (API DTO) lived only in the Lifecycle converter, whereas the field is part of the shared `ServiceData` type and must be exposed consistently on Publication and History as well.

## Changes
- New `service-common-converters.ts` module containing the shared logic:
  - `ageToSuitableForMinors` — maps `age` → `suitable_for_minors`
  - `withSuitableForMinors` — helper that exposes/omits the field based on the `FF_SUITABLE_FOR_MINORS_ENABLED` feature flag
  - `toScopeType` — moved here (previously imported from Lifecycle)
- `suitableForMinorsToAge` (used only in `payloadToItem`) remains in the Lifecycle converter.
- Publication and History converters now expose `suitable_for_minors`, gated by the feature flag.
- Removed the direct Publication/History → Lifecycle dependency (both now import from the `common` module).
- Removed `toServiceTopic`/constants duplication and aligned converter signatures (`IConfig`).

## Tests
- New `service-common-converters.test.ts`: unit tests for age thresholds, feature flag, and scope.
- New `service-publication-converters.test.ts` and `service-history-converters.test.ts`: integration smoke tests (`suitable_for_minors` exposed/omitted, internal `age` never exposed) + coverage for status, scope, topic resolution, and metadata cleanup.
