### PR TITLE
chore: make PostgreSQL SSL configurable for local testing

### DIFF
--- a/apps/io-services-cms-webapp/src/config.ts
+++ b/apps/io-services-cms-webapp/src/config.ts
@@ -213,6 +213,7 @@ export const PostgreSqlConfig = t.type({
     IntegerFromString,
     "50" as unknown as number,
   ),
+  REVIEWER_DB_SSL: withDefault(t.string, "true").pipe(BooleanFromString),
   REVIEWER_DB_USER: NonEmptyString,
 });
 

--- a/apps/io-services-cms-webapp/src/lib/clients/pg-client.ts
+++ b/apps/io-services-cms-webapp/src/lib/clients/pg-client.ts
@@ -20,7 +20,7 @@ export const getPool = (config: PostgreSqlConfig): Pool => {
       max: 20,
       password: config.REVIEWER_DB_PASSWORD,
       port: config.REVIEWER_DB_PORT,
-      ssl: true,
+      ssl: config.REVIEWER_DB_SSL,
       user: config.REVIEWER_DB_USER,
     });
   }


### PR DESCRIPTION
Introduced the `REVIEWER_DB_SSL` configuration to make SSL optional during the PostgreSQL Pool initialization. 
This allows connecting to local database instances for development and testing. 
The new configuration defaults to true to ensure backward compatibility with existing environments.