### PR TITLE
fix: update pre-commit and module locks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pagopa/dx
-    rev: pre_commit_scripts@0.1.0
+    rev: pre_commit_scripts@0.1.1
     hooks:
       - id: lock_modules
         exclude: ^.*/(_modules|modules|\.terraform)(/.*)?$

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -103,7 +103,7 @@
   },
   "container_apps.services_ca": {
     "hash": "860b4a28c2ed17b0061483d238aab56f8074a6e4fe0db399b36583423cf145be",
-    "version": "6.0.1",
+    "version": "6.1.0",
     "name": "azure_container_app",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-container-app/azurerm/6.1.0"
   },


### PR DESCRIPTION
Update `pre-commit` version, this will support new DX modules which are targeting NX(module.json instead package.json)